### PR TITLE
updated cooling & elliptical initial conditions

### DIFF
--- a/docs/fork.rst
+++ b/docs/fork.rst
@@ -1,6 +1,12 @@
 Forking Phantom
 ===============
 
+Warning
+-------
+
+This instructions on this page are out of date.
+
+
 Why fork?
 ---------
 

--- a/docs/gitinfo.rst
+++ b/docs/gitinfo.rst
@@ -1,19 +1,21 @@
 Working with Phantom and git
 ============================
 
-Make sure you have the git version control system installed. See also :doc:`how to work on a fork <fork>`.
+Make sure you have the git version control system installed.
 
 Getting your first copy
 -----------------------
 
-Once you have a bitbucket account, use:
+Once you have a GitHub account, you must create your own :doc:'fork <fork>`.
+This is done using the “fork” button (the big button on top right of the
+repo page).  You can then clone your fork to your computer:
 
 ::
 
-   git clone https://USERNAME@bitbucket.org/danielprice/phantom
+   git clone https://github.com/USERNAME/phantom.git
 
-this gets a copy of the entire phantom repository. Obviously replacing
-USERNAME with your bitbucket username.
+This gets a copy of the entire phantom repository. Obviously replace
+USERNAME with your GitHub username.
 
 Setting your username and email address
 ---------------------------------------
@@ -30,10 +32,10 @@ address are set, as follows:
 Please use your full name in the format above, as this is what appears
 in the commit logs (and in the AUTHORS file)
 
-Receiving updates
------------------
+Receiving updates from your fork
+--------------------------------
 
-Procedure is: stash your changes, pull the updates, replay your changes
+Procedure is: stash your changes, pull the updates, reapply your changes
 
 ::
 
@@ -41,8 +43,32 @@ Procedure is: stash your changes, pull the updates, replay your changes
    git pull
    git stash pop
 
-Committing changes
-------------------
+Receiving updates from the master branch
+----------------------------------------
+
+Before you can receive updates from the master branch, you must first link
+your fork to the master branch:
+
+::
+
+   git remote add upstream https://github.com/danieljprice/phantom.git
+
+This only needs to be done once.
+
+To update, the procedure is: stash your changes, pull the updates,
+reapply your changes
+
+::
+
+   git stash
+   git fetch upstream
+   git merge upstream/master
+   git stash pop
+
+This will update your fork on your local machine only.
+
+Committing changes to your fork
+-------------------------------
 
 Submit changes to Phantom carefully! The first thing is to pull any
 upstream changes as described above. Once you have done this, first
@@ -60,9 +86,7 @@ file(s) with a message:
    git commit -m 'changed units in dim file for problem x' src/main/dim_myprob.f90
 
 and so on, for all the files that you want to commit. Then, when you’re
-ready to push the changeset back to the global repository (i.e. :doc:`HAVING
-MADE SURE YOUR CHANGES WILL NOT BREAK ANYONE ELSE’S STUFF <testing>`),
-use
+ready to push the changeset back to your fork use
 
 ::
 
@@ -71,10 +95,27 @@ use
 Note that you will only be allowed to push changes if you have already
 updated your copy to the latest version.
 
-At the moment, everyone in the developer group has permission to push
-back changes to the Phantom repositories. This may change in the future
-if I think it is a bad idea, in which case I’ll start pulling in changes
-explicitly. Compilation failures are automatically checked by the
-buildbot, which runs every night there have been commits made to the
+If you have just updated your code from the master repo, simply update
+your fork via
+
+::
+   git commit
+   git push
+
+This will push all the remote changes to your forked version of Phantom.
+
+Committing changes to the master branch
+---------------------------------------
+
+This is done through a “pull request” which I must approve.  To do this,
+you can click the big “pull request” button on the GitHub page to request
+that your changes be pulled into the master copy of Phantom. Please do
+this frequently. Many small pull requests are much better than one giant
+pull request!
+
+Before making a pull request, :doc:`ENSURE THAT YOUR CHANGES WILL NOT
+BREAK ANYONE ELSE’S STUFF <testing>`).  Automated tests will be performed
+on all pull requests.  Compilation failures are automatically checked by
+the buildbot, which runs every night there have been commits made to the
 code and checks for any compilation failures and/or new compiler
 warnings and **emails those responsible**.

--- a/src/main/checksetup.F90
+++ b/src/main/checksetup.F90
@@ -440,9 +440,9 @@ subroutine check_setup(nerror,nwarn,restart)
  if (id==master) &
     write(*,"(a,2(es10.3,', '),es10.3,a)") ' Centre of mass is at (x,y,z) = (',xcom,')'
 
- if (.not.h2chemistry .and. maxvxyzu >= 4 .and. icooling >= 1 .and. iexternalforce/=iext_corotate) then
+ if (.not.h2chemistry .and. maxvxyzu >= 4 .and. icooling == 3 .and. iexternalforce/=iext_corotate) then
     if (dot_product(xcom,xcom) >  1.e-2) then
-       print*,'Error in setup: Gammie (2001) cooling (icooling=1) assumes Omega = 1./r^1.5'
+       print*,'Error in setup: Gammie (2001) cooling (icooling=3) assumes Omega = 1./r^1.5'
        print*,'                but the centre of mass is not at the origin!'
        nerror = nerror + 1
     endif

--- a/src/main/cooling.F90
+++ b/src/main/cooling.F90
@@ -110,6 +110,8 @@ subroutine init_cooling_type(h2chemistry,ierr)
  integer, intent(out) :: ierr
  logical, intent(in)  :: h2chemistry
 
+ cooling_implicit = .false.
+ cooling_explicit = .false.
  if (h2chemistry) then
     if (icooling > 0) cooling_implicit = .true.    ! cooling is calculated implicitly in step
  elseif (icooling > 0) then

--- a/src/main/cooling.F90
+++ b/src/main/cooling.F90
@@ -358,7 +358,7 @@ end subroutine cooling_KoyamaInutuska
 
 !-----------------------------------------------------------------------
 !
-!   explicit cooling cooling
+!   explicit cooling
 !
 !-----------------------------------------------------------------------
 subroutine explicit_cooling (ui, dudt, rho, dt, Trad, mu_in, K2, kappa)

--- a/src/main/cooling.F90
+++ b/src/main/cooling.F90
@@ -346,8 +346,8 @@ end subroutine cooling_Gammie
 !   typos corrected as per Vazquez-Semadeni+ (2007)
 !+
 !-----------------------------------------------------------------------
-subroutine cooling_KoyamaInutuska(xi,yi,zi,rhoi,Tgas,dudti)
- real, intent(in)    :: xi,yi,zi,rhoi,Tgas
+subroutine cooling_KoyamaInutuska(rhoi,Tgas,dudti)
+ real, intent(in)    :: rhoi,Tgas
  real, intent(inout) :: dudti
  real                :: crate
 
@@ -456,7 +456,7 @@ subroutine energ_cooling(xi,yi,zi,ui,dudt,rho,dt,Trad,mu_in,K2,kappa,Tgas)
     call exact_cooling_table(ui,rho,dt,dudt)
  case (5)
     if (present(Tgas)) then
-       call cooling_KoyamaInutuska(xi,yi,zi,rho,Tgas,dudt)
+       call cooling_KoyamaInutuska(rho,Tgas,dudt)
     else
        call fatal('energ_cooling','Koyama & Inutuska cooling requires gas temperature')
     endif

--- a/src/main/dens.F90
+++ b/src/main/dens.F90
@@ -896,7 +896,6 @@ pure subroutine calculate_divcurlv_from_sums(rhosum,termnorm,divcurlvi,ndivcurlv
  real :: ddenom,gradvxdxi,gradvxdyi,gradvxdzi
  real :: gradvydxi,gradvydyi,gradvydzi,gradvzdxi,gradvzdyi,gradvzdzi
  real :: dvxdxi,dvxdyi,dvxdzi,dvydxi,dvydyi,dvydzi,dvzdxi,dvzdyi,dvzdzi
- real :: fac,traceS,txy,txz,tyz,txx,tyy,tzz!,Ri
  logical, parameter :: use_exact_linear = .true.
 
  !--divergence of the velocity field
@@ -1489,14 +1488,12 @@ subroutine store_results(icall,cell,getdv,getdb,realviscosity,stressmax,xyzh,&
                          dustfrac,rhomax,nneightry,nneighact,maxneightry,&
                          maxneighact,np,ncalc,radprop)
  use part,        only:hrho,get_partinfo,iamgas,&
-                       maxphase,massoftype,igas,n_R,n_electronT,&
-                       eta_nimhd,iambi,ndustlarge,ndustsmall,xyzh_soa,&
-                       maxgradh,idust,&
-                       ifluxx,ifluxz,ithick
+                       maxphase,massoftype,igas,ndustlarge,ndustsmall,xyzh_soa,&
+                       maxgradh,idust,ifluxx,ifluxz,ithick
  use io,          only:fatal,real4
  use dim,         only:maxp,ndivcurlv,ndivcurlB,nalpha,use_dust,&
                        do_radiation
- use options,     only:ieos,alpha,alphamax,use_dustfrac
+ use options,     only:use_dustfrac
  use viscosity,   only:bulkvisc,shearparam
  use linklist,    only:set_hmaxcell
  use kernel,      only:radkern
@@ -1527,7 +1524,7 @@ subroutine store_results(icall,cell,getdv,getdb,realviscosity,stressmax,xyzh,&
 
  real         :: rhosum(maxrhosum)
 
- integer      :: iamtypei,i,lli,ierr,l
+ integer      :: iamtypei,i,lli,l
  logical      :: iactivei,iamgasi,iamdusti
  logical      :: igotrmatrix
  real         :: hi,hi1,hi21,hi31,hi41

--- a/src/main/eos.F90
+++ b/src/main/eos.F90
@@ -11,6 +11,7 @@ module eos
 !     1 = isothermal eos
 !     2 = adiabatic/polytropic eos
 !     3 = eos for a locally isothermal disc as in Lodato & Pringle (2007)
+!     4 = GR isothermal
 !     6 = eos for a locally isothermal disc as in Lodato & Pringle (2007),
 !         centered on a sink particle
 !     7 = z-dependent locally isothermal eos
@@ -20,6 +21,9 @@ module eos
 !    11 = isothermal eos with zero pressure
 !    12 = ideal gas with radiation pressure
 !    14 = locally isothermal prescription from Farris et al. (2014) for binary system
+!    15 = Helmholtz free energy eos
+!    16 = Shen eos
+!    19 = Variable gamma (requires KROME)
 !
 ! :References: None
 !
@@ -357,19 +361,6 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
        spsoundi = 0.
        call fatal('eos','tried to call Helmholtz free energy eos without passing temperature')
     endif
-!
-!--variable gamma
-!
- case(19)
-
-    if (present(gamma_local)) then
-       ponrhoi  = (gamma_local-1.)*eni
-       spsoundi = sqrt(gamma_local*ponrhoi)
-    else
-       call fatal('eos','invoking KROME to calculate local gamma but variable '&
-                        'not passed in equationofstate (bad value for eos?)')
-    endif
-    if (present(tempi)) tempi = temperature_coef*gmw*ponrhoi
 
  case(16)
 !
@@ -386,6 +377,19 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
 !    else
 !       call fatal('eos','tried to call NL3 eos without passing temperature')
 !    endif
+
+ case(19)
+!
+!--variable gamma
+!
+    if (present(gamma_local)) then
+       ponrhoi  = (gamma_local-1.)*eni
+       spsoundi = sqrt(gamma_local*ponrhoi)
+       if (present(tempi)) tempi = temperature_coef*gmw*ponrhoi
+    else
+       call fatal('eos','invoking KROME to calculate local gamma but variable '&
+                        'not passed in equationofstate (bad value for eos?)')
+    endif
 
  case default
     spsoundi = 0. ! avoids compiler warnings

--- a/src/main/externalforces.F90
+++ b/src/main/externalforces.F90
@@ -577,7 +577,8 @@ end subroutine update_externalforce
 !-----------------------------------------------------------------------
 subroutine accrete_particles(iexternalforce,xi,yi,zi,hi,mi,ti,accreted,i)
  use extern_binary, only:binary_accreted,accradius1
- use part,          only:set_particle_type,iboundary,maxphase,maxp,igas,npartoftype
+ use part,          only:set_particle_type,iboundary,maxphase,maxp,igas
+ !use part,          only:npartoftype
  integer, intent(in)    :: iexternalforce
  real,    intent(in)    :: xi,yi,zi,mi,ti
  real,    intent(inout) :: hi

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -854,9 +854,6 @@ subroutine compute_forces(i,iamgasi,iamdusti,xpartveci,hi,hi1,hi21,hi41,gradhi,g
 #ifdef IND_TIMESTEPS
  use part,        only:ibin_old,iamboundary
 #endif
-#ifdef KROME
- use part,        only:gamma_chem
-#endif
  use timestep,    only:bignumber
  use options,     only:overcleanfac,use_dustfrac
  use units,       only:get_c_code
@@ -951,21 +948,18 @@ subroutine compute_forces(i,iamgasi,iamdusti,xpartveci,hi,hi1,hi21,hi41,gradhi,g
  logical :: usej
  integer :: iamtypei
  real    :: radFi(3),radFj(3),radRj,radDFWi,radDFWj,c_code,radkappai,radkappaj,&
-            radDi,radDj,radeni,radenj,radlambdai,radlambdaj,radPi
+            radDi,radDj,radeni,radenj,radlambdai,radlambdaj
  real    :: xi,yi,zi,densi,eni,metrici(0:3,0:3,2)
  real    :: vxi,vyi,vzi,vxj,vyj,vzj
  real    :: qrho2i,qrho2j
  integer :: ii,ia,ib,ic
-
-
- real    :: projbigvi,projbigvj,lorentzi_star,lorentzj_star,dlorentzv
- real    :: enthi,enthj
  real    :: densj
- real    :: lorentzi,lorentzj
- real    :: bigvi(1:3),bigvj(1:3),bigv2i,bigv2j,alphagri,alphagrj
- real    :: veli(3),velj(3),vij,metricj(0:3,0:3,2)
- real    :: enthdensav
-
+ real    :: bigvi(1:3),bigv2i,alphagri,lorentzi
+ real    :: veli(3),vij
+#ifdef GR
+ real    :: bigv2j,alphagrj,enthdensav,enthi,enthj,dlorentzv,lorentzj,lorentzi_star,lorentzj_star,projbigvi,projbigvj
+ real    :: bigvj(1:3),velj(3),metricj(0:3,0:3,2)
+#endif
  real    :: radPj
 
  ! unpack
@@ -1913,9 +1907,9 @@ subroutine get_stress(pri,spsoundi,rhoi,rho1i,xi,yi,zi, &
  real,    intent(in)    :: dvdx(9)
  real,    intent(in)    :: radPi
 
- real :: Bro2i,Brhoxi,Brhoyi,Brhozi,rhogasi,gasfrac
+ real :: Bro2i,Brhoxi,Brhoyi,Brhozi
  real :: stressiso,term,graddivvcoeff,del2vcoeff,strain(6)
- real :: shearvisc,etavisc,valfven2i,p_on_rhogas
+ real :: shearvisc,etavisc,valfven2i
 
  sxxi = 0.
  sxyi = 0.
@@ -2456,7 +2450,9 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
 #ifdef LIGHTCURVE
  use part,           only:luminosity
 #endif
+#ifdef KROME
  use part,           only:gamma_chem
+#endif
  use metric_tools,   only:unpack_metric
  use utils_gr,       only:get_u0
  use io,             only:error

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -216,8 +216,8 @@ subroutine startrun(infile,logfile,evfile,dumpfile)
  use eos,              only:ieos,init_eos
  use part,             only:h2chemistry
  use checksetup,       only:check_setup
- use h2cooling,        only:init_h2cooling
- use cooling,          only:init_cooling
+ use h2cooling,        only:init_h2cooling,energ_h2cooling
+ use cooling,          only:init_cooling,init_cooling_type
  use chem,             only:init_chem
  use cpuinfo,          only:print_cpuinfo
  use units,            only:udist,unit_density
@@ -338,6 +338,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile)
     call init_cooling(ierr)
     if (ierr /= 0) call fatal('initial','error initialising cooling')
  endif
+ call init_cooling_type(h2chemistry,ierr)
 
  if (idamp > 0 .and. any(abs(vxyzu(1:3,:)) > tiny(0.)) .and. abs(time) < tiny(time)) then
     call error('setup','damping on: setting non-zero velocities to zero')

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -1254,12 +1254,12 @@ end function count_dead_particles
 !  uses the routines above for efficiency
 !+
 !-----------------------------------------------------------------------
-subroutine delete_dead_or_accreted_particles(npart,npartoftype)
- integer, intent(inout) :: npart,npartoftype(:)
+subroutine delete_dead_or_accreted_particles(npart,npoftype)
+ integer, intent(inout) :: npart,npoftype(:)
  integer :: i
 
  do i=1,npart
-    if (isdead_or_accreted(xyzh(4,i))) call kill_particle(i,npartoftype)
+    if (isdead_or_accreted(xyzh(4,i))) call kill_particle(i,npoftype)
  enddo
  call shuffle_part(npart)
 
@@ -1610,9 +1610,9 @@ end subroutine delete_dead_particles_inside_radius
 !  Delete particles within radius
 !+
 !----------------------------------------------------------------
-subroutine delete_particles_inside_radius(center,radius,npart,npartoftype)
+subroutine delete_particles_inside_radius(center,radius,npart,npoftype)
  real, intent(in) :: center(3), radius
- integer, intent(inout) :: npart,npartoftype(:)
+ integer, intent(inout) :: npart,npoftype(:)
  integer :: i
  real :: x,y,z,r
 
@@ -1621,7 +1621,7 @@ subroutine delete_particles_inside_radius(center,radius,npart,npartoftype)
     y = xyzh(2,i)
     z = xyzh(3,i)
     r=sqrt((x-center(1))**2+(y-center(2))**2+(z-center(3))**2)
-    if (r < radius) call kill_particle(i,npartoftype)
+    if (r < radius) call kill_particle(i,npoftype)
  enddo
  call shuffle_part(npart)
 

--- a/src/main/readwrite_dumps_fortran.F90
+++ b/src/main/readwrite_dumps_fortran.F90
@@ -253,7 +253,7 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
  integer, parameter :: isteps_sphNG = 0, iphase0 = 0
  integer(kind=8)    :: ilen(4)
  integer            :: nums(ndatatypes,4)
- integer            :: ipass,k,l,i
+ integer            :: ipass,k,l
  integer            :: ierr,ierrs(28)
  integer            :: nblocks,nblockarrays,narraylengths
  integer(kind=8)    :: nparttot,npartoftypetot(maxtypes)

--- a/src/main/readwrite_infile.F90
+++ b/src/main/readwrite_infile.F90
@@ -320,7 +320,10 @@ subroutine read_infile(infile,logfile,evfile,dumpfile)
  use part,            only:mhd,nptmass
  use cooling,         only:read_options_cooling
  use ptmass,          only:read_options_ptmass
- use ptmass_radiation,only:read_options_ptmass_radiation,isink_radiation,alpha_rad
+ use ptmass_radiation,only:read_options_ptmass_radiation
+#ifdef WIND
+ use ptmass_radiation,only:isink_radiation,alpha_rad
+#endif
  use damping,         only:read_options_damping
  character(len=*), parameter   :: label = 'read_infile'
  character(len=*), intent(in)  :: infile

--- a/src/main/step_leapfrog.F90
+++ b/src/main/step_leapfrog.F90
@@ -1021,7 +1021,7 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
                           idxmsi,idymsi,idzmsi,idmsi,idspinxsi,idspinysi,idspinzsi, &
                           idvxmsi,idvymsi,idvzmsi,idfxmsi,idfymsi,idfzmsi, &
                           ndptmass,update_ptmass
- use options,        only:iexternalforce,idamp,icooling
+ use options,        only:iexternalforce,idamp
  use part,           only:maxphase,abundance,nabundances,h2chemistry,eos_vars,epot_sinksink,&
                           isdead_or_accreted,iamboundary,igas,iphase,iamtype,massoftype,rhoh,divcurlv, &
                           fxyz_ptmass_sinksink,dust_temp
@@ -1034,7 +1034,7 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
  use mpiutils,       only:bcast_mpi,reduce_in_place_mpi,reduceall_mpi
  use damping,        only:calc_damp,apply_damp
  use ptmass_radiation,only:get_rad_accel_from_ptmass,isink_radiation
- use cooling,        only:energ_cooling
+ use cooling,        only:energ_cooling,cooling_implicit
 #ifdef NUCLEATION
  use part,           only:nucleation
  use dust_formation, only:evolve_dust
@@ -1143,7 +1143,7 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
     !$omp shared(maxp,maxphase) &
     !$omp shared(npart,xyzh,vxyzu,fext,abundance,iphase,ntypes,massoftype) &
     !$omp shared(eos_vars,dust_temp) &
-    !$omp shared(dt,hdt,timei,iexternalforce,extf_is_velocity_dependent,icooling) &
+    !$omp shared(dt,hdt,timei,iexternalforce,extf_is_velocity_dependent,cooling_implicit) &
     !$omp shared(xyzmh_ptmass,vxyz_ptmass,idamp,damp_fac) &
     !$omp shared(nptmass,f_acc,nsubsteps,C_force,C_cool,divcurlv,dphotflag,dphot0) &
     !$omp shared(abundc,abundo,abundsi,abunde) &
@@ -1262,7 +1262,7 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
              !
              ! COOLING
              !
-             if (icooling > 0) then
+             if (cooling_implicit) then
                 if (h2chemistry) then
                    !
                    ! Call cooling routine, requiring total density, some distance measure and
@@ -1287,7 +1287,7 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
              endif
 #endif
              ! update internal energy & cooling timestep
-             if (icooling > 0 .or. use_krome) then
+             if (cooling_implicit .or. use_krome) then
                 vxyzu(4,i) = vxyzu(4,i) + dt * dudtcool
                 if (abs(dudtcool) > 0.) dtextforcenew = min(dtextforcenew, C_cool*abs(vxyzu(4,i)/dudtcool))
              endif

--- a/src/main/step_leapfrog.F90
+++ b/src/main/step_leapfrog.F90
@@ -1130,7 +1130,6 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
        endif
        call bcast_mpi(xyzmh_ptmass(:,1:nptmass))
        call bcast_mpi(vxyz_ptmass(:,1:nptmass))
-       call bcast_mpi(fxyz_ptmass(:,1:nptmass))  !JHW: Added... was its exclusion intentional?
        call bcast_mpi(epot_sinksink)
        call bcast_mpi(dtf)
        dtextforcenew = min(dtextforcenew,C_force*dtf)

--- a/src/main/step_leapfrog.F90
+++ b/src/main/step_leapfrog.F90
@@ -709,8 +709,7 @@ subroutine step_extern_gr(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,pxyzu,dens,me
  use externalforces, only:externalforce,accrete_particles,update_externalforce
  use options,        only:iexternalforce,idamp
  use part,           only:maxphase,isdead_or_accreted,iamboundary,igas,iphase,iamtype,massoftype,rhoh
- use io_summary,     only:summary_variable,iosumextsr,iosumextst,iosumexter,iosumextet,iosumextr,iosumextt, &
-                          summary_accrete,summary_accrete_fail
+ use io_summary,     only:summary_variable,iosumextr,iosumextt,summary_accrete,summary_accrete_fail
  use timestep,       only:bignumber,C_force,xtol,ptol
  use eos,            only:equationofstate,ieos,gamma
  use cons2primsolver,only:conservative2primitive,ien_entropy
@@ -1027,8 +1026,7 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
                           fxyz_ptmass_sinksink,dust_temp
  use chem,           only:update_abundances,get_dphot
  use h2cooling,      only:dphot0,energ_h2cooling,dphotflag,abundsi,abundo,abunde,abundc,nabn
- use io_summary,     only:summary_variable,iosumextsr,iosumextst,iosumexter,iosumextet,iosumextr,iosumextt, &
-                          summary_accrete,summary_accrete_fail
+ use io_summary,     only:summary_variable,iosumextr,iosumextt,summary_accrete,summary_accrete_fail
  use timestep,       only:bignumber,C_force,C_cool
  use timestep_sts,   only:sts_it_n
  use mpiutils,       only:bcast_mpi,reduce_in_place_mpi,reduceall_mpi
@@ -1450,17 +1448,8 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
        write(iprint,"(a,i6,a,f8.2,a,es10.3,a,es10.3)") &
            ' using ',nsubsteps,' substeps (dthydro/dtextf = ',dtsph/dtextforce_min,'), dt = ',dtextforce_min,' dtsph = ',dtsph
     endif
-    ! It is no longer reasonable to distinguish between these since they are no longer mutually exclusive
-    if (nptmass >  0 .and. iexternalforce <= 0) then
-       call summary_variable('ext',iosumextsr,nsubsteps,dtsph/dtextforce_min)
-       call summary_variable('ext',iosumextst,nsubsteps,dtextforce_min,1.0/dtextforce_min)
-    elseif (nptmass <= 0 .and. iexternalforce >  0) then
-       call summary_variable('ext',iosumexter,nsubsteps,dtsph/dtextforce_min)
-       call summary_variable('ext',iosumextet,nsubsteps,dtextforce_min,1.0/dtextforce_min)
-    else
-       call summary_variable('ext',iosumextr ,nsubsteps,dtsph/dtextforce_min)
-       call summary_variable('ext',iosumextt ,nsubsteps,dtextforce_min,1.0/dtextforce_min)
-    endif
+    call summary_variable('ext',iosumextr ,nsubsteps,dtsph/dtextforce_min)
+    call summary_variable('ext',iosumextt ,nsubsteps,dtextforce_min,1.0/dtextforce_min)
  endif
 
 end subroutine step_extern

--- a/src/main/utils_summary.F90
+++ b/src/main/utils_summary.F90
@@ -53,15 +53,11 @@ module io_summary
  integer, parameter :: iosumstsns = iosumdgr + 13   ! number of particles using Nsupersteps=Nreal for small Nreal
  integer, parameter :: iosumstsnl = iosumdgr + 14   ! number of particles using Nsupersteps=Nreal for large Nreal
  !  Substeps for dtextf < dthydro
- integer, parameter :: iosumextr  = iosumstsnl + 1  ! ratio due to external force .or. sink-sink
- integer, parameter :: iosumextt  = iosumstsnl + 2  ! dtmin due to external force .or. sink-sink
- integer, parameter :: iosumexter = iosumstsnl + 3  ! ratio due to external force
- integer, parameter :: iosumextet = iosumstsnl + 4  ! dtmin due to external force
- integer, parameter :: iosumextsr = iosumstsnl + 5  ! ratio due to sink-sink
- integer, parameter :: iosumextst = iosumstsnl + 6  ! dtmin due to sink-sink
+ integer, parameter :: iosumextr  = iosumstsnl + 1  ! ratio due to sub-stepping
+ integer, parameter :: iosumextt  = iosumstsnl + 2  ! dtmin due to sub-stepping
  !  restricted h jump
- integer, parameter :: iosumhup   = iosumextst + 1  ! jump up
- integer, parameter :: iosumhdn   = iosumextst + 2  ! jump down
+ integer, parameter :: iosumhup   = iosumextt + 1   ! jump up
+ integer, parameter :: iosumhdn   = iosumextt + 2   ! jump down
  !  velocity-dependent force iterations
  integer, parameter :: iosumtvi   = iosumhdn + 1    ! number of iterations
  integer, parameter :: iosumtve   = iosumhdn + 2    ! errmax
@@ -508,14 +504,6 @@ subroutine summary_printout(iprint,nptmass)
      '|         |',iosum_nstep(iosumextr ),'|',iosum_rpart(iosumextr ),'|' &
                                               ,iosum_ave(iosumextr   ),'|',    iosum_max(iosumextr ) ,'|' &
                                               ,iosum_ave(iosumextt   ),'|',1.0/iosum_max(iosumextt ) ,'|'
-    if (iosum_nstep(iosumexter)/=0) write(iprint,90) &
-     '|external |',iosum_nstep(iosumexter),'|',iosum_rpart(iosumexter),'|' &
-                                              ,iosum_ave(iosumexter),'|',    iosum_max(iosumexter) ,'|' &
-                                              ,iosum_ave(iosumextet),'|',1.0/iosum_max(iosumextet) ,'|'
-    if (iosum_nstep(iosumextsr)/=0) write(iprint,90) &
-     '|sink     |',iosum_nstep(iosumextsr),'|',iosum_rpart(iosumextsr),'|' &
-                                              ,iosum_ave(iosumextsr),'|',    iosum_max(iosumextsr) ,'|' &
-                                              ,iosum_ave(iosumextst),'|',1.0/iosum_max(iosumextst) ,'|'
     write(iprint,'(a)') '------------------------------------------------------------------------------'
  endif
 90 format(a,i6,a,f8.2,1x,a,f8.2,1x,a,f8.2,1x,a,Es13.3,1x,a,Es13.3,1x,a)

--- a/src/main/utils_summary.F90
+++ b/src/main/utils_summary.F90
@@ -17,8 +17,8 @@ module io_summary
 ! :Dependencies: None
 !
  implicit none
- integer, parameter :: maxrhomx = 32         ! Number of maximum possible rhomax' per set
- integer, parameter :: maxisink =  5         ! Maximum number of sink particles's accretion details to track
+ integer, parameter :: maxrhomx = 32                ! Number of maximum possible rhomax' per set
+ integer, parameter :: maxisink =  5                ! Maximum number of sink particles's accretion details to track
  !--Array indicies for various parameters
  !  Timesteps
  integer, parameter :: iosumdtf   =  1              ! dtforce (gas particles)
@@ -75,15 +75,15 @@ module io_summary
  integer, parameter :: maxiosum = iosum_nsts        ! Number of values to summarise
  !
  !  Reason sink particle was not created
- integer, parameter :: inosink_notgas = 1  ! not gas particles
- integer, parameter :: inosink_divv   = 2  ! div v > 0
- integer, parameter :: inosink_h      = 3  ! 2h > h_acc
- integer, parameter :: inosink_active = 4  ! not all particles are active
- integer, parameter :: inosink_therm  = 5  ! E_therm/E_grav > 0.5
- integer, parameter :: inosink_grav   = 6  ! a_grav+b_grav > 1
- integer, parameter :: inosink_Etot   = 7  ! E_tot > 0
- integer, parameter :: inosink_poten  = 8  ! Not minimum potential
- integer, parameter :: inosink_max    = 8  ! Number of failure reasons
+ integer, parameter :: inosink_notgas = 1           ! not gas particles
+ integer, parameter :: inosink_divv   = 2           ! div v > 0
+ integer, parameter :: inosink_h      = 3           ! 2h > h_acc
+ integer, parameter :: inosink_active = 4           ! not all particles are active
+ integer, parameter :: inosink_therm  = 5           ! E_therm/E_grav > 0.5
+ integer, parameter :: inosink_grav   = 6           ! a_grav+b_grav > 1
+ integer, parameter :: inosink_Etot   = 7           ! E_tot > 0
+ integer, parameter :: inosink_poten  = 8           ! Not minimum potential
+ integer, parameter :: inosink_max    = 8           ! Number of failure reasons
  !
  !  Frequency of output based number of steps; 0 to turn off; if < 0 then every 2**{-iosum_nprint} steps
  integer,         parameter :: iosum_nprint  = 0

--- a/src/main/writeheader.F90
+++ b/src/main/writeheader.F90
@@ -83,6 +83,7 @@ subroutine write_header(icall,infile,evfile,logfile,dumpfile,ntot)
                             gravity,h2chemistry,periodic,npartoftype,massoftype,&
                             labeltype,maxtypes
  use eos,              only:eosinfo
+ use cooling,          only:cooling_implicit,cooling_explicit
  use readwrite_infile, only:write_infile
  use physcon,          only:pi
  use kernel,           only:kernelname,radkern
@@ -162,18 +163,19 @@ subroutine write_header(icall,infile,evfile,logfile,dumpfile,ntot)
     write(iprint,50) hfact, massoftype(1), tolh, Nneigh
 50  format(6x,' h = ',f5.2,'*[',es9.2,'/rho]^(1/3); htol = ',es9.2,/ &
            6x,' Number of neighbours = ',i4)
-!
-!--MHD compile time options
-!
-    if (mhd) then
-       write(iprint,60) 'B/rho with cleaning'
-60     format(/,' Magnetic fields are ON, evolving ',a)
-    endif
-    if (gravity)     write(iprint,"(1x,a)") 'Self-gravity is ON'
-    if (h2chemistry) write(iprint,"(1x,a)") 'H2 Chemistry is ON'
-    if (use_dustfrac) write(iprint,"(1x,a)") 'One-fluid dust is ON'
-    if (use_dustgrowth) write(iprint,"(1x,a)") 'Dust growth is ON'
 
+    if (mhd)              write(iprint,"(1x,a)") 'Magnetic fields are ON, evolving B/rho with cleaning'
+    if (gravity)          write(iprint,"(1x,a)") 'Self-gravity is ON'
+    if (h2chemistry)      write(iprint,"(1x,a)") 'H2 Chemistry is ON'
+    if (use_dustfrac)     write(iprint,"(1x,a)") 'One-fluid dust is ON'
+    if (use_dustgrowth)   write(iprint,"(1x,a)") 'Dust growth is ON'
+    if (cooling_explicit) write(iprint,"(1x,a)") 'Cooling is explicitly calculated in force'
+    if (cooling_implicit) then
+       write(iprint,"(1x,a)") 'Cooling is implicitly calculated in step'
+       write(iprint,"(1x,a)") 'WARNING!  Implicit cooling timestep has not been properly initialised!!!'
+       ! The initial cooling timestep is an explicit timestep that neglects heating; all subsequent (non-restart)
+       ! cooling timesteps are correct.  JHW
+    endif
     call eosinfo(ieos,iprint)
 
     if (maxalpha==maxp) then

--- a/src/setup/set_sphere.f90
+++ b/src/setup/set_sphere.f90
@@ -18,16 +18,16 @@ module spherical
 ! :Dependencies: random, stretchmap, unifdis
 !
  use unifdis, only:set_unifdis,mask_prototype,mask_true
+ use physcon, only:pi
  implicit none
 
- public  :: set_sphere
-
- real, parameter :: pi = 4.*atan(1.)
+ public  :: set_sphere,set_ellipse
 
  integer, parameter :: &
    ierr_notinrange    = 1, &
    ierr_not_converged = 2, &
-   ierr_unknown       = 3
+   ierr_unknown       = 3, &
+   ierr_notashape     = 4
 
  private
 
@@ -95,12 +95,11 @@ subroutine set_sphere(lattice,id,master,rmin,rmax,delta,hfact,np,xyzh, &
  !--Create a sphere of uniform density
  !
  if (lattice=='random' .and. present(np_requested)) then
-    call set_sphere_mc(id,master,rmin,rmax,hfact,np_requested,np,xyzh,ierr,&
-                       nptot,my_mask)
+    call set_sphere_mc(id,master,rmin,rmax,hfact,np_requested,np,xyzh,ierr,nptot,my_mask)
  elseif ( use_sphereN ) then
     vol_sphere = 4.0/3.0*pi*rmax**3
     call set_unifdis_sphereN(lattice,id,master,xmin,xmax,ymin,ymax,zmin,zmax,delta,&
-                             hfact,np,np_requested,xyzh,rmax,vol_sphere,nptot,my_mask,ierr)
+                             hfact,np,np_requested,xyzh,vol_sphere,nptot,my_mask,ierr,r_sphere=rmax)
  else
     call set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
                      zmin,zmax,delta,hfact,np,xyzh,.false.,&
@@ -221,20 +220,19 @@ end subroutine set_sphere_mc
 
 !-----------------------------------------------------------------------
 !+
-!  If setting up a uniform sphere, this will iterate to get
+!  If setting up a uniform sphere or ellipse, this will iterate to get
 !  approximately the desired number of particles
-!  Note: Since this is only for a sphere, the call to this is the
-!        same as if a sphere were being created by set_unifdis
 !+
 !-----------------------------------------------------------------------
 subroutine set_unifdis_sphereN(lattice,id,master,xmin,xmax,ymin,ymax,zmin,zmax,psep,&
-                    hfact,npart,nps_requested,xyzh,r_sphere,v_sphere,npart_total,mask,ierr)
+                    hfact,npart,nps_requested,xyzh,v_sphere,npart_total,mask,ierr,r_sphere,r_ellipsoid,in_ellipsoid)
  character(len=*), intent(in)    :: lattice
  integer,          intent(in)    :: id,master
  integer,          intent(inout) :: npart
  integer,          intent(in)    :: nps_requested
- real,             intent(in)    :: xmin,xmax,ymin,ymax,zmin,zmax,hfact,r_sphere,v_sphere
+ real,             intent(in)    :: xmin,xmax,ymin,ymax,zmin,zmax,hfact,v_sphere
  real,             intent(out)   :: psep,xyzh(:,:)
+ real,   optional, intent(in)    :: r_sphere,r_ellipsoid(3)
  integer(kind=8),  intent(inout) :: npart_total
  integer,          intent(out)   :: ierr
  integer,          parameter     :: itermax = 100
@@ -243,7 +241,9 @@ subroutine set_unifdis_sphereN(lattice,id,master,xmin,xmax,ymin,ymax,zmin,zmax,p
  integer                         :: iter,test_region,nps_lo,nps_hi,npr_lo,npr_hi,nps_hi_nx
  integer                         :: npin,npmax,npart0,nx,np,dn
  integer                         :: nold(4)
- logical                         :: iterate_to_get_nps
+ logical                         :: iterate_to_get_nps,is_sphere
+ logical,          optional      :: in_ellipsoid
+ character(len=9)                :: c_shape
  !
  !--Initialise values
  !
@@ -262,9 +262,20 @@ subroutine set_unifdis_sphereN(lattice,id,master,xmin,xmax,ymin,ymax,zmin,zmax,p
  npart0        = 0
  nold          = 0
  nps_hi_nx     = 0
+ is_sphere     = .true.
  iterate_to_get_nps = .true.
+ if (present(r_sphere)) then
+    c_shape   = 'sphere'
+ elseif (present(r_ellipsoid) .and. present(in_ellipsoid)) then
+    is_sphere = .false.
+    c_shape   = 'ellipsoid'
+ else
+    ierr = ierr_notashape
+    print "(a)",' ERROR: set_sphere: This must either be a sphere or ellipsoid.'
+    return
+ endif
 
- print*, ' set_sphere: Iterating to form sphere with approx ',nps_requested,' particles'
+ print*, ' set_sphere: Iterating to form ',c_shape,' with approx ',nps_requested,' particles'
  !
  !--Perform the iterations
  !
@@ -275,8 +286,15 @@ subroutine set_unifdis_sphereN(lattice,id,master,xmin,xmax,ymin,ymax,zmin,zmax,p
     if (lattice=='closepacked') psep = psep*sqrt(2.)**(1./3.)         ! adjust psep for close-packed lattice
     npart       = npin
     npart_total = npart_local
-    call set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax,zmin,zmax,psep,&
-                    hfact,npart,xyzh,.false.,rmax=r_sphere,nptot=npart_total,verbose=.false.,mask=mask)
+    if (is_sphere) then
+       call set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax,zmin,zmax,psep,&
+                        hfact,npart,xyzh,.false.,rmax=r_sphere,nptot=npart_total,verbose=.false.,mask=mask)
+    else
+       call set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax,zmin,zmax,psep,&
+                        hfact,npart,xyzh,.false.,rellipsoid=r_ellipsoid,in_ellipsoid=in_ellipsoid,&
+                        nptot=npart_total,verbose=.false.,mask=mask)
+    endif
+    !print*, "iteration, npart: ", iter,np,nps_lo,nps_hi,npin,npart,npart0,nps_requested,psep
     if (nold(1)==np .and. nold(2)==npart0 .and. nold(3)==nps_lo .and. nold(4)==nps_hi) iterate_to_get_nps = .false.
     if (nps_lo > 0 .and. nps_hi < npmax) then
        nold(1) = np
@@ -287,6 +305,7 @@ subroutine set_unifdis_sphereN(lattice,id,master,xmin,xmax,ymin,ymax,zmin,zmax,p
     npart0 = npart - npin
     if (npart0==nps_requested) then
        iterate_to_get_nps = .false.
+       nps_hi_nx          = nx
     elseif (npart0 < nps_requested .and. nps_hi==npmax) then
        ! initialising for the case where npart0 is too small
        nps_lo = npart0
@@ -346,20 +365,63 @@ subroutine set_unifdis_sphereN(lattice,id,master,xmin,xmax,ymin,ymax,zmin,zmax,p
     npart       = npin
     psep        = (v_sphere)**(1./3.)/real(nps_hi_nx)                 ! particle separation in sphere
     if (lattice=='closepacked') psep = psep*sqrt(2.)**(1./3.)         ! adjust psep for close-packed lattice
-    call set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax,zmin,zmax,psep,&
-                    hfact,npart,xyzh,.false.,rmax=r_sphere,nptot=npart_total,verbose=.true.,mask=mask)
-    if (nps_requested - nps_lo < nps_hi - nps_requested) then
-       write(*,'(a,I8,a,F5.2,a)') " set_sphere: The closest number of particles to the requested number is " &
-                    ,nps_lo,", which is ",float(nps_requested-nps_lo)/float(nps_requested)*100.0 &
-                    ,"% than less requested."
-       write(*,'(a)') " set_sphere: We will not use fewer than the requested number of particles."
+    if (is_sphere) then
+       call set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax,zmin,zmax,psep,&
+                        hfact,npart,xyzh,.false.,rmax=r_sphere,nptot=npart_total,verbose=.false.,mask=mask)
+    else
+       call set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax,zmin,zmax,psep,&
+                        hfact,npart,xyzh,.false.,rellipsoid=r_ellipsoid,in_ellipsoid=in_ellipsoid,&
+                        nptot=npart_total,verbose=.false.,mask=mask)
     endif
-    write(*,'(a,I8,a,F5.2,a)') " set_sphere: Using " &
-              , npart," particles, which is ",float(npart - nps_requested)/float(nps_requested)*100.0 &
-              ,"% more than requested."
+    npart0 = npart - npin
+    if (npart0 == nps_requested) then
+       write(*,'(a,I8)') " set_sphere: Iterated to exactly the requested number of ",nps_requested
+    else
+       if (nps_requested - nps_lo < npart0 - nps_requested) then
+          write(*,'(a,I8,a,F5.2,a)') " set_sphere: The closest number of particles to the requested number is " &
+                       ,nps_lo,", which is ",float(nps_requested-nps_lo)/float(nps_requested)*100.0 &
+                       ,"% than less requested."
+          write(*,'(a)') " set_sphere: We will not use fewer than the requested number of particles."
+       endif
+       write(*,'(a,I8,a,F5.2,a)') " set_sphere: Using " &
+                 , npart0," particles, which is ",float(npart0- nps_requested)/float(nps_requested)*100.0 &
+                 ,"% more than requested."
+    endif
  endif
- write(*,'(a,I10,a)') ' set_sphere: Iterations complete: added ',npart,' particles in sphere'
+ write(*,'(a,I10,2a)') ' set_sphere: Iterations complete: added ',npart0,' particles in the ',trim(c_shape)
 
 end subroutine set_unifdis_sphereN
+!-----------------------------------------------------------------------
+!+
+!  Wrapper to set an ellipse
+!+
+!-----------------------------------------------------------------------
+subroutine set_ellipse(lattice,id,master,r_ellipsoid,delta,hfact,xyzh,np,nptot,np_requested,mask)
+ character(len=*), intent(in)    :: lattice
+ integer,          intent(in)    :: id,master,np_requested
+ integer,          intent(inout) :: np
+ real,             intent(in)    :: r_ellipsoid(3),hfact
+ real,             intent(out)   :: xyzh(:,:)
+ real,             intent(inout) :: delta
+ integer(kind=8),  intent(inout) :: nptot
+ procedure(mask_prototype), optional :: mask
+ procedure(mask_prototype), pointer  :: my_mask
+ integer                         :: ierr
+ real                            :: xi,yi,zi,vol_ellipse
 
+ if (present(mask)) then
+    my_mask => mask
+ else
+    my_mask => mask_true
+ endif
+
+ xi = 1.5*r_ellipsoid(1)
+ yi = 1.5*r_ellipsoid(2)
+ zi = 1.5*r_ellipsoid(3)
+ vol_ellipse = 4.0*pi/3.0*r_ellipsoid(1)*r_ellipsoid(2)*r_ellipsoid(3)
+ call set_unifdis_sphereN(lattice,id,master,-xi,xi,-yi,yi,-zi,zi,delta,hfact,np,np_requested,xyzh, &
+                          vol_ellipse,nptot,my_mask,ierr,r_ellipsoid=r_ellipsoid,in_ellipsoid=.true.)
+
+end subroutine set_ellipse
+!-----------------------------------------------------------------------
 end module spherical

--- a/src/setup/set_unifdis.f90
+++ b/src/setup/set_unifdis.f90
@@ -38,10 +38,15 @@ contains
 !+
 !  This subroutine positions particles on a uniform lattice
 !  in three dimensions, either cubic or close packed.
+!  Optional inputs permit the creation of
+!  -spheres, cylinders & ellipses
+!  -spherical & cylindrical shells
+!  -spherical, cylindrical & elliptical voids
 !+
 !-------------------------------------------------------------
 subroutine set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
-                       zmin,zmax,delta,hfact,np,xyzh,periodic,rmin,rmax,rcylmin,rcylmax,&
+                       zmin,zmax,delta,hfact,np,xyzh,periodic, &
+                       rmin,rmax,rcylmin,rcylmax,rellipsoid,in_ellipsoid, &
                        nptot,npy,npz,rhofunc,inputiseed,verbose,centre,dir,geom,mask,err)
  use random,     only:ran2
  use stretchmap, only:set_density_profile
@@ -55,11 +60,12 @@ subroutine set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
 
  real,             intent(in),    optional :: rmin,rmax
  real,             intent(in),    optional :: rcylmin,rcylmax
+ real,             intent(in),    optional :: rellipsoid(3)
  integer(kind=8),  intent(inout), optional :: nptot
  integer,          intent(in),    optional :: npy,npz,dir,geom
  real, external,                  optional :: rhofunc
  integer,          intent(in),    optional :: inputiseed
- logical,          intent(in),    optional :: verbose,centre
+ logical,          intent(in),    optional :: verbose,centre,in_ellipsoid
  integer,          intent(out),   optional :: err
  procedure(mask_prototype), optional :: mask
  procedure(mask_prototype), pointer  :: i_belong
@@ -71,7 +77,7 @@ subroutine set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
  real               :: deltax,deltay,deltaz,dxbound,dybound,dzbound
  real               :: xstart,ystart,zstart,xi,yi,zi,rcyl2,rr2
  real               :: xcentre,ycentre,zcentre
- real               :: rmin2,rmax2,rcylmin2,rcylmax2
+ real               :: rmin2,rmax2,rcylmin2,rcylmax2,rellipsoid21(3),rellmin,rellmax,rell2
  real               :: xpartmin,ypartmin,zpartmin
  real               :: xpartmax,ypartmax,zpartmax,xmins,xmaxs
  logical            :: is_verbose,centre_lattice
@@ -117,6 +123,20 @@ subroutine set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
     rcylmax2 = rcylmax*rcylmax
  else
     rcylmax2 = huge(0.)
+ endif
+ if (present(rellipsoid) .and. present(in_ellipsoid) ) then
+    rellipsoid21 = 1.0/(rellipsoid*rellipsoid)
+    if (in_ellipsoid) then
+       rellmin = 0.
+       rellmax = 1.
+    else
+       rellmin = 1.
+       rellmax = huge(0.)
+    endif
+ else
+    rellipsoid21 = 0.
+    rellmin      = 0.
+    rellmax      = huge(0.)
  endif
  if (present(nptot)) then
     iparttot = nptot
@@ -174,7 +194,8 @@ subroutine set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
 
              rcyl2 = xi*xi + yi*yi
              rr2   = rcyl2 + zi*zi
-             if (in_range(rr2,rmin2,rmax2) .and. in_range(rcyl2,rcylmin2,rcylmax2)) then
+             rell2 = xi*xi*rellipsoid21(1) + yi*yi*rellipsoid21(2) + zi*zi*rellipsoid21(3)
+             if (in_range(rr2,rmin2,rmax2) .and. in_range(rcyl2,rcylmin2,rcylmax2) .and. in_range(rell2,rellmin,rellmax)) then
                 iparttot = iparttot + 1
                 if (i_belong(iparttot)) then
                    ipart = ipart + 1
@@ -285,7 +306,8 @@ subroutine set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
        !
        rcyl2 = xi*xi + yi*yi
        rr2   = rcyl2 + zi*zi
-       if (in_range(rr2,rmin2,rmax2) .and. in_range(rcyl2,rcylmin2,rcylmax2)) then
+       rell2 = xi*xi*rellipsoid21(1) + yi*yi*rellipsoid21(2) + zi*zi*rellipsoid21(3)
+       if (in_range(rr2,rmin2,rmax2) .and. in_range(rcyl2,rcylmin2,rcylmax2) .and. in_range(rell2,rellmin,rellmax)) then
           iparttot = iparttot + 1
           if (i_belong(iparttot)) then
              ipart = ipart + 1
@@ -450,7 +472,8 @@ subroutine set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
        !
        rcyl2 = xi*xi + yi*yi
        rr2   = rcyl2 + zi*zi
-       if (in_range(rr2,rmin2,rmax2) .and. in_range(rcyl2,rcylmin2,rcylmax2)) then
+       rell2 = xi*xi*rellipsoid21(1) + yi*yi*rellipsoid21(2) + zi*zi*rellipsoid21(3)
+       if (in_range(rr2,rmin2,rmax2) .and. in_range(rcyl2,rcylmin2,rcylmax2) .and. in_range(rell2,rellmin,rellmax)) then
           iparttot = iparttot + 1
           if (i_belong(iparttot)) then
              ipart = ipart + 1
@@ -504,7 +527,8 @@ subroutine set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
 !--do not use if not within radial cuts
        rcyl2 = xi*xi + yi*yi
        rr2   = rcyl2 + zi*zi
-       if (in_range(rr2,rmin2,rmax2) .and. in_range(rcyl2,rcylmin2,rcylmax2)) then
+       rell2 = xi*xi*rellipsoid21(1) + yi*yi*rellipsoid21(2) + zi*zi*rellipsoid21(3)
+       if (in_range(rr2,rmin2,rmax2) .and. in_range(rcyl2,rcylmin2,rcylmax2) .and. in_range(rell2,rellmin,rellmax)) then
           iparttot = iparttot + 1
           if (i_belong(iparttot)) then
              ipart = ipart + 1
@@ -572,7 +596,7 @@ end subroutine set_unifdis
 pure logical function in_range(x,xmin,xmax)
  real, intent(in) :: x,xmin,xmax
 
- in_range = (x >= xmin .and. x <= xmax)
+ in_range = (xmin <= x .and. x <= xmax)
 
 end function in_range
 


### PR DESCRIPTION
1) Cooling:
Added Koyama & Inutuska (2002); this and Gammie cooling are solved explicitly in force; the remaining cooling options are still implicitly calculated in step.  I am not confident that the implicit cooling is fully and correctly operational.  I have corrected a few bugs and added a few fail-safes.  Concern 1 is that the cooling timestep was never initialised nor calculated in step (the latter has been corrected).  Concern 2 is that the new default cooling requires a pre-processor flag and optional arguments, which is very dangerous; default cooling should not require pre-processor flags or optional arguments (so I suggest returning the default to Gammie).  

2) Initial conditions:
Added option to initialise an ellipse or an elliptical void; at the moment, we cannot initialise an elliptical shell.

3) Miscellaneous:
There are several small changes, including updating the documentation to reflect GitHub and not BitBucket