### PR TITLE
Tracking particle IDs

### DIFF
--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -44,14 +44,15 @@ module part
 !--basic storage needed for read/write of particle data
 !
 
- real, allocatable :: xyzh(:,:)
- real, allocatable :: xyzh_soa(:,:)
- real, allocatable :: vxyzu(:,:)
+ real,         allocatable :: xyzh(:,:)
+ real,         allocatable :: xyzh_soa(:,:)
+ real,         allocatable :: vxyzu(:,:)
  real(kind=4), allocatable :: alphaind(:,:)
  real(kind=4), allocatable :: divcurlv(:,:)
  real(kind=4), allocatable :: divcurlB(:,:)
- real, allocatable :: Bevol(:,:)
- real, allocatable :: Bxyz(:,:)
+ real,         allocatable :: Bevol(:,:)
+ real,         allocatable :: Bxyz(:,:)
+ integer,      allocatable :: iorig(:)
  character(len=*), parameter :: xyzh_label(4) = (/'x','y','z','h'/)
  character(len=*), parameter :: vxyzu_label(4) = (/'vx','vy','vz','u '/)
  character(len=*), parameter :: Bxyz_label(3) = (/'Bx','By','Bz'/)
@@ -113,7 +114,6 @@ module part
  character(len=*), parameter :: abundance_label(5) = &
    (/'h2ratio','abHIq  ','abhpq  ','abeq   ','abco   '/)
 #endif
-
 !
 !--eos_variables
 !
@@ -125,8 +125,6 @@ module part
                        maxeosvars = 4
  character(len=*), parameter :: eos_vars_label(maxeosvars) = &
     (/'pressure   ','sound speed', 'temperature', 'mu         '/)
-
-!
 !
 !--one-fluid dust (small grains)
 !
@@ -145,7 +143,6 @@ module part
  real, allocatable :: dens(:) !dens(maxgr)
  real, allocatable :: metrics(:,:,:,:) !metrics(0:3,0:3,2,maxgr)
  real, allocatable :: metricderivs(:,:,:,:) !metricderivs(0:3,0:3,3,maxgr)
-
 !
 !--sink particles
 !
@@ -271,18 +268,15 @@ module part
 !
  integer, allocatable :: ll(:)
  real    :: dxi(ndim) ! to track the extent of the particles
-
 !
 !--particle belong
 !
  integer, allocatable :: ibelong(:)
-
 !
 !--super time stepping
 !
  integer(kind=1), allocatable :: istsactive(:)
  integer(kind=1), allocatable :: ibin_sts(:)
-
 !
 !--size of the buffer required for transferring particle <<<< FIX THIS FOR GR MPI
 !  information between MPI threads
@@ -406,6 +400,7 @@ subroutine allocate_part
  call allocate_array('divcurlB', divcurlB, ndivcurlB, maxp)
  call allocate_array('Bevol', Bevol, maxBevol, maxmhd)
  call allocate_array('Bxyz', Bxyz, 3, maxmhd)
+ call allocate_array('iorig', iorig, maxp)
  call allocate_array('dustprop', dustprop, 2, maxp_growth)
  call allocate_array('dustgasprop', dustgasprop, 4, maxp_growth)
  call allocate_array('VrelVf', VrelVf, maxp_growth)
@@ -484,6 +479,7 @@ subroutine deallocate_part
  if (allocated(divcurlB)) deallocate(divcurlB)
  if (allocated(Bevol))    deallocate(Bevol)
  if (allocated(Bxyz))     deallocate(Bxyz)
+ if (allocated(iorig))    deallocate(iorig)
  if (allocated(dustprop)) deallocate(dustprop)
  if (allocated(dustgasprop))  deallocate(dustgasprop)
  if (allocated(VrelVf))       deallocate(VrelVf)
@@ -550,6 +546,7 @@ end subroutine deallocate_part
 !+
 !----------------------------------------------------------------
 subroutine init_part
+ integer :: i
 
  npart = 0
  nptmass = 0
@@ -608,6 +605,16 @@ subroutine init_part
 #endif
 
  ideadhead = 0
+!
+!--Initialise particle id's
+!
+!$omp parallel do default(none) &
+!$omp shared(iorig) &
+!$omp private(i)
+ do i = 1,maxp
+    iorig(i) = i
+ enddo
+!$omp end parallel do
 
 end subroutine init_part
 
@@ -1032,8 +1039,9 @@ end function strain_from_dvdx
 ! (prior to a derivs evaluation - so no derivs required)
 !+
 !----------------------------------------------------------------
-subroutine copy_particle(src, dst)
+subroutine copy_particle(src,dst,new_part)
  integer, intent(in) :: src, dst
+ logical, intent(in) :: new_part
 
  xyzh(:,dst)  = xyzh(:,src)
  vxyzu(:,dst) = vxyzu(:,src)
@@ -1067,6 +1075,12 @@ subroutine copy_particle(src, dst)
  eos_vars(:,dst) = eos_vars(:,src)
  if (store_dust_temperature) dust_temp(dst) = dust_temp(src)
 
+ if (new_part) then
+    iorig(dst) = dst        ! we are creating a new particle; give it the new ID
+ else
+    iorig(dst) = iorig(src) ! we are moving the particle within the list; maintain ID
+ endif
+
  return
 end subroutine copy_particle
 
@@ -1079,8 +1093,9 @@ end subroutine copy_particle
 ! must be rebuilt after a copy operation.
 !+
 !----------------------------------------------------------------
-subroutine copy_particle_all(src,dst)
+subroutine copy_particle_all(src,dst,new_part)
  integer, intent(in) :: src,dst
+ logical, intent(in) :: new_part
 
  xyzh(:,dst)  = xyzh(:,src)
  xyzh_soa(dst,:)  = xyzh_soa(src,:)
@@ -1164,6 +1179,12 @@ subroutine copy_particle_all(src,dst)
     ibin_sts(dst) = ibin_sts(src)
  endif
 
+ if (new_part) then
+    iorig(dst) = dst        ! we are creating a new particle; give it the new ID
+ else
+    iorig(dst) = iorig(src) ! we are moving the particle within the list; maintain ID
+ endif
+
  return
 end subroutine copy_particle_all
 
@@ -1219,7 +1240,7 @@ subroutine shuffle_part(np)
     if (newpart <= np) then
        if (.not.isdead(np)) then
           ! move particle to new position
-          call copy_particle_all(np,newpart)
+          call copy_particle_all(np,newpart,.false.)
           ! move ibelong to new position
 #ifdef MPI
           ibelong(newpart) = ibelong(np)

--- a/src/main/partinject.F90
+++ b/src/main/partinject.F90
@@ -149,6 +149,7 @@ subroutine update_injected_particles(npartold,npart,istepfrac,nbinmax,time,dtmax
  use timestep_ind, only:get_newbin,change_nbinmax,get_dt
  use part,         only:twas,ibin
 #endif
+ use part,         only:iorig
 #ifdef GR
  use part,         only:xyzh,vxyzu,pxyzu,dens,metrics,metricderivs,fext
  use cons2prim,    only:prim2consall
@@ -193,6 +194,11 @@ subroutine update_injected_particles(npartold,npart,istepfrac,nbinmax,time,dtmax
     twas(i) = time + 0.5*get_dt(dtmax,ibin(i))
  enddo
 #endif
+
+ ! add particle ID
+ do i=npartold+1,npart
+    iorig(i) = i
+ enddo
 
 end subroutine update_injected_particles
 

--- a/src/main/partinject.F90
+++ b/src/main/partinject.F90
@@ -162,12 +162,12 @@ subroutine update_injected_particles(npartold,npart,istepfrac,nbinmax,time,dtmax
  integer(kind=1), intent(inout) :: nbinmax
  real,            intent(inout) :: dt
  real,            intent(in)    :: time,dtmax,dtinject
+ integer                        :: i
 #ifdef IND_TIMESTEPS
- integer(kind=1) :: nbinmaxprev
- integer :: i
+ integer(kind=1)                :: nbinmaxprev
 #endif
 #ifdef GR
- real :: dtext_dum
+ real                           :: dtext_dum
 #endif
 
  if (npartold==npart) return

--- a/src/main/readwrite_dumps_common.F90
+++ b/src/main/readwrite_dumps_common.F90
@@ -122,8 +122,8 @@ subroutine check_arrays(i1,i2,npartoftype,npartread,nptmass,nsinkproperties,mass
                         alphafile,tfile,phantomdump,got_iphase,got_xyzh,got_vxyzu,got_alpha, &
                         got_krome_mols,got_krome_gamma,got_krome_mu,got_krome_T, &
                         got_abund,got_dustfrac,got_sink_data,got_sink_vels,got_Bxyz,got_psi,got_dustprop,got_pxyzu,got_VrelVf, &
-                        got_dustgasprop,got_temp,got_raden,got_kappa,got_Tdust,iphase,&
-                        xyzh,vxyzu,pxyzu,alphaind,xyzmh_ptmass,Bevol,iprint,ierr)
+                        got_dustgasprop,got_temp,got_raden,got_kappa,got_Tdust,got_iorig,iphase,&
+                        xyzh,vxyzu,pxyzu,alphaind,xyzmh_ptmass,Bevol,iorig,iprint,ierr)
  use dim,  only:maxp,maxvxyzu,maxalpha,maxBevol,mhd,h2chemistry,store_temperature,&
                 use_dustgrowth,gr,do_radiation,store_dust_temperature
  use eos,  only:polyk,gamma
@@ -138,8 +138,9 @@ subroutine check_arrays(i1,i2,npartoftype,npartread,nptmass,nsinkproperties,mass
  logical,         intent(in)    :: got_VrelVf,got_dustgasprop(:)
  logical,         intent(in)    :: got_abund(:),got_dustfrac(:),got_sink_data(:),got_sink_vels(:),got_Bxyz(:)
  logical,         intent(in)    :: got_krome_mols(:),got_krome_gamma,got_krome_mu,got_krome_T
- logical,         intent(in)    :: got_psi,got_temp,got_Tdust,got_pxyzu(:),got_raden(:),got_kappa
+ logical,         intent(in)    :: got_psi,got_temp,got_Tdust,got_pxyzu(:),got_raden(:),got_kappa,got_iorig
  integer(kind=1), intent(inout) :: iphase(:)
+ integer,         intent(inout) :: iorig(:)
  real,            intent(inout) :: vxyzu(:,:),Bevol(:,:),pxyzu(:,:)
  real(kind=4),    intent(inout) :: alphaind(:,:)
  real,            intent(inout) :: xyzh(:,:),xyzmh_ptmass(:,:)
@@ -362,6 +363,16 @@ subroutine check_arrays(i1,i2,npartoftype,npartread,nptmass,nsinkproperties,mass
        write(*,*) 'WARNING: GR but momentum arrays not found in Phantom dump file'
        pxyzu(:,i1:i2) = 0.
     endif
+ endif
+
+!
+! Particle IDs
+!
+ if (.not.got_iorig) then
+    do i=i1,i2
+       iorig(i) = i
+    enddo
+    if (id==master .and. i1==1) write(*,*) 'WARNING: Particle IDs not in dump; resetting IDs'
  endif
 
 end subroutine check_arrays

--- a/src/main/readwrite_dumps_fortran.F90
+++ b/src/main/readwrite_dumps_fortran.F90
@@ -218,7 +218,7 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
                  divcurlv,divcurlv_label,divcurlB,divcurlB_label,poten,dustfrac,deltav,deltav_label,tstop,&
                  dustfrac_label,tstop_label,dustprop,dustprop_label,eos_vars,eos_vars_label,ndusttypes,ndustsmall,VrelVf,&
                  VrelVf_label,dustgasprop,dustgasprop_label,dust_temp,pxyzu,pxyzu_label,dens,& !,dvdx,dvdx_label
-                 rad,rad_label,radprop,radprop_label,do_radiation,maxirad,maxradprop,itemp,igasP
+                 rad,rad_label,radprop,radprop_label,do_radiation,maxirad,maxradprop,itemp,igasP,iorig
  use options,    only:use_dustfrac
  use dump_utils, only:tag,open_dumpfile_w,allocate_header,&
                  free_header,write_header,write_array,write_block_header
@@ -254,7 +254,7 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
  integer(kind=8)    :: ilen(4)
  integer            :: nums(ndatatypes,4)
  integer            :: ipass,k,l
- integer            :: ierr,ierrs(28)
+ integer            :: ierr,ierrs(29)
  integer            :: nblocks,nblockarrays,narraylengths
  integer(kind=8)    :: nparttot,npartoftypetot(maxtypes)
  logical            :: sphNGdump,write_itype,use_gas
@@ -397,6 +397,8 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
        temparr(1:npart) = dtmax/2**ibin(1:npart)
        call write_array(1,temparr,'dt',npart,k,ipass,idump,nums,ierrs(18),use_kind=4)
 #endif
+       call write_array(1,iorig,'iorig',npart,k,ipass,idump,nums,ierrs(29))
+
 #ifdef PRDRAG
        if (k==i_real) then
           if (.not.allocated(temparr)) allocate(temparr(npart))
@@ -1097,7 +1099,7 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
                       Bevol,Bxyz,Bxyz_label,nabundances,iphase,idust,dustfrac_label, &
                       eos_vars,eos_vars_label,dustprop,dustprop_label,divcurlv,divcurlv_label,&
                       VrelVf,VrelVf_label,dustgasprop,dustgasprop_label,pxyzu,pxyzu_label,dust_temp, &
-                      rad,rad_label,radprop,radprop_label,do_radiation,maxirad,maxradprop,ikappa,ithick,itemp
+                      rad,rad_label,radprop,radprop_label,do_radiation,maxirad,maxradprop,ikappa,ithick,itemp,iorig
 #ifdef IND_TIMESTEPS
  use part,       only:dt_in
 #endif
@@ -1126,7 +1128,7 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
  logical               :: got_krome_mols(krome_nmols),got_krome_T,got_krome_gamma,got_krome_mu
  logical               :: got_nucleation(n_nucleation)
  logical               :: got_psi,got_temp,got_Tdust,got_dustprop(2),got_VrelVf,got_dustgasprop(4), &
-                          got_divcurlv(4),got_raden(maxirad),got_kappa,got_pxyzu(4)
+                          got_divcurlv(4),got_raden(maxirad),got_kappa,got_pxyzu(4),got_iorig
  character(len=lentag) :: tag,tagarr(64)
  integer :: k,i,iarr,ik,ndustfraci
 
@@ -1158,6 +1160,7 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
  got_raden       = .false.
  got_kappa       = .false.
  got_pxyzu       = .false.
+ got_iorig       = .false.
 
  ndustfraci = 0
  over_arraylengths: do iarr=1,narraylengths
@@ -1225,6 +1228,9 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
              !
              call read_array(dt_in,'dt',dt_read_in_fortran,ik,i1,i2,noffset,idisk1,tag,match,ierr)
 #endif
+             ! read particle ID's
+             call read_array(iorig,'iorig',got_iorig,ik,i1,i2,noffset,idisk1,tag,match,ierr)
+
              if (do_radiation) then
                 call read_array(rad,rad_label,got_raden,ik,i1,i2,noffset,idisk1,tag,match,ierr)
                 call read_array(radprop(ikappa,:),radprop_label(ikappa),got_kappa,ik,i1,i2,noffset,idisk1,tag,match,ierr)
@@ -1252,8 +1258,8 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
                    alphafile,tfile,phantomdump,got_iphase,got_xyzh,got_vxyzu,got_alpha, &
                    got_krome_mols,got_krome_gamma,got_krome_mu,got_krome_T, &
                    got_abund,got_dustfrac,got_sink_data,got_sink_vels,got_Bxyz,got_psi,got_dustprop,got_pxyzu,got_VrelVf, &
-                   got_dustgasprop,got_temp,got_raden,got_kappa,got_Tdust,iphase,&
-                   xyzh,vxyzu,pxyzu,alphaind,xyzmh_ptmass,Bevol,iprint,ierr)
+                   got_dustgasprop,got_temp,got_raden,got_kappa,got_Tdust,got_iorig,iphase,&
+                   xyzh,vxyzu,pxyzu,alphaind,xyzmh_ptmass,Bevol,iorig,iprint,ierr)
 
  return
 100 continue

--- a/src/main/readwrite_dumps_hdf5.F90
+++ b/src/main/readwrite_dumps_hdf5.F90
@@ -109,7 +109,7 @@ subroutine write_dump_hdf5(t,dumpfile,fulldump,ntotal,dtind)
                           Bextz,ndustlarge,idust,idustbound,grainsize,         &
                           graindens,h2chemistry,lightcurve,ndivcurlB,          &
                           ndivcurlv,pxyzu,dens,gamma_chem,mu_chem,T_chem,      &
-                          dust_temp,rad,radprop,itemp,igasP,eos_vars
+                          dust_temp,rad,radprop,itemp,igasP,eos_vars,iorig
 #ifdef NUCLEATION
  use part,           only:nucleation
 #endif
@@ -359,6 +359,7 @@ subroutine write_dump_hdf5(t,dumpfile,fulldump,ntotal,dtind)
                            divcurlB,     & !
                            divBsymm,     & !
                            eta_nimhd,    & !
+                           iorig,        & !
                            dustfrac,     & !
                            tstop,        & !
                            deltav,       & !
@@ -490,7 +491,7 @@ subroutine read_any_dump_hdf5(                                                  
                           alphaind,poten,Bxyz,Bevol,dustfrac,deltav,dustprop,  &
                           dustgasprop,VrelVf,eos_vars,abundance,               &
                           periodic,ndusttypes,pxyzu,gamma_chem,mu_chem,T_chem, &
-                          dust_temp,rad,radprop,igasP,itemp
+                          dust_temp,rad,radprop,igasP,itemp,iorig
 #ifdef IND_TIMESTEPS
  use part,           only:dt_in
 #endif
@@ -681,6 +682,7 @@ subroutine read_any_dump_hdf5(                                                  
                        poten,         &
                        Bxyz,          &
                        Bevol,         &
+                       iorig,         &
                        dustfrac,      &
                        deltav,        &
                        dustprop,      &
@@ -735,6 +737,7 @@ subroutine read_any_dump_hdf5(                                                  
                       got_arrays%got_raden,       &
                       got_arrays%got_kappa,       &
                       got_arrays%got_Tdust,       &
+                      got_arrays%got_iorig,       &
                       iphase,                     &
                       xyzh,                       &
                       vxyzu,                      &
@@ -742,6 +745,7 @@ subroutine read_any_dump_hdf5(                                                  
                       alphaind,                   &
                       xyzmh_ptmass,               &
                       Bevol,                      &
+                      iorig,                      &
                       iprint,                     &
                       ierr)
  endif

--- a/src/main/utils_allocate.f90
+++ b/src/main/utils_allocate.f90
@@ -35,6 +35,7 @@ module allocutils
       allocate_array_real4_2d, &
       allocate_array_real4_3d, &
       allocate_array_real4_4d, &
+      allocate_array_integer8_1d, &
       allocate_array_integer4_1d, &
       allocate_array_integer4_2d, &
       allocate_array_integer4_3d, &
@@ -144,6 +145,17 @@ subroutine allocate_array_real4_4d(name, x, n1, n2, n3, n4)
  call print_allocation_stats(name, (/n1, n2, n3, n4/), 'real(4)')
 
 end subroutine allocate_array_real4_4d
+
+subroutine allocate_array_integer8_1d(name, x, n1)
+ character(len=*),               intent(in)     :: name
+ integer(kind=8), allocatable,   intent(inout)  :: x(:)
+ integer,                        intent(in)     :: n1
+ integer                                        :: allocstat
+
+ allocate(x(n1), stat = allocstat)
+ call check_allocate(name, allocstat)
+ call print_allocation_stats(name, (/n1/), 'integer(8)')
+end subroutine allocate_array_integer8_1d
 
 subroutine allocate_array_integer4_1d(name, x, n1)
  character(len=*),               intent(in)     :: name
@@ -265,6 +277,8 @@ subroutine print_allocation_stats(name, xdim, type)
     databytes = 8
  elseif (type == 'real(4)') then
     databytes = 4
+ elseif (type == 'integer(8)') then
+    databytes = 8
  elseif (type == 'integer(4)') then
     databytes = 4
  elseif (type == 'integer(1)') then

--- a/src/main/utils_dumpfiles.f90
+++ b/src/main/utils_dumpfiles.f90
@@ -138,6 +138,7 @@ module dump_utils
  ! generic interface for writing arrays to file
  interface write_array
   module procedure write_array_int1, &
+   write_array_int4,  write_array_int8, &
    write_array_real4, write_array_real4arr, &
    write_array_real8, write_array_real8arr
  end interface write_array
@@ -145,6 +146,7 @@ module dump_utils
  ! generic interface for writing arrays to file
  interface read_array
   module procedure read_array_int1, &
+   read_array_int4, read_array_int8, &
    read_array_real4, read_array_real4arr, &
    read_array_real8, read_array_real8arr
  end interface read_array
@@ -1594,6 +1596,82 @@ end subroutine write_array_int1
 
 !---------------------------------------------------------------------
 !+
+!  Write int*4 array to block header (ipass=1) or to file (ipass=2)
+!+
+!---------------------------------------------------------------------
+subroutine write_array_int4(ib,iarr,my_tag,len,ikind,ipass,iunit,nums,ierr,func)
+ integer(kind=4),  intent(in) :: iarr(:)
+ character(len=*), intent(in) :: my_tag
+ integer, intent(in)    :: ib,len,ikind,ipass,iunit
+ integer, intent(inout) :: nums(:,:)
+ integer, intent(out)   :: ierr
+ !procedure(integer(kind=1)), pointer, optional :: func
+ interface
+  integer(kind=4) pure function func(x)
+   integer(kind=4), intent(in) :: x
+  end function func
+ end interface
+ optional :: func
+ !integer(kind=1), optional :: func
+ integer :: i
+
+ ierr = 0
+ ! check if kind matches
+ if (ikind==i_int4) then
+    if (ipass==1) then
+       nums(i_int4,ib) = nums(i_int4,ib) + 1
+    elseif (ipass==2) then
+       write(iunit, iostat=ierr) tag(my_tag)
+       if (present(func)) then
+          write(iunit, iostat=ierr) (func(iarr(i)),i=1,len)
+       else
+          write(iunit, iostat=ierr) iarr(1:len)
+       endif
+    endif
+ endif
+
+end subroutine write_array_int4
+
+!---------------------------------------------------------------------
+!+
+!  Write int*4 array to block header (ipass=1) or to file (ipass=2)
+!+
+!---------------------------------------------------------------------
+subroutine write_array_int8(ib,iarr,my_tag,len,ikind,ipass,iunit,nums,ierr,func)
+ integer(kind=8),  intent(in) :: iarr(:)
+ character(len=*), intent(in) :: my_tag
+ integer, intent(in)    :: ib,len,ikind,ipass,iunit
+ integer, intent(inout) :: nums(:,:)
+ integer, intent(out)   :: ierr
+ !procedure(integer(kind=1)), pointer, optional :: func
+ interface
+  integer(kind=8) pure function func(x)
+   integer(kind=8), intent(in) :: x
+  end function func
+ end interface
+ optional :: func
+ !integer(kind=1), optional :: func
+ integer :: i
+
+ ierr = 0
+ ! check if kind matches
+ if (ikind==i_int8) then
+    if (ipass==1) then
+       nums(i_int8,ib) = nums(i_int8,ib) + 1
+    elseif (ipass==2) then
+       write(iunit, iostat=ierr) tag(my_tag)
+       if (present(func)) then
+          write(iunit, iostat=ierr) (func(iarr(i)),i=1,len)
+       else
+          write(iunit, iostat=ierr) iarr(1:len)
+       endif
+    endif
+ endif
+
+end subroutine write_array_int8
+
+!---------------------------------------------------------------------
+!+
 !  Write real*4 array to block header (ipass=1) or to file (ipass=2)
 !+
 !---------------------------------------------------------------------
@@ -1864,12 +1942,76 @@ subroutine read_array_int1(iarr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag,ma
        got_arr = .true.
        read(iunit,iostat=ierr) (dum,i=1,noffset),iarr(i1:i2)
     else
-       print*,'ERROR: wrong datatype for '//trim(tag)
+       print*,'ERROR: wrong datatype for '//trim(tag)//' (is not int1)'
        read(iunit,iostat=ierr)
     endif
  endif
 
 end subroutine read_array_int1
+
+!--------------------------------------------------------------------
+!+
+!  Routine for extracting int*4 array from main block in dump files
+!+
+!--------------------------------------------------------------------
+subroutine read_array_int4(iarr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag,matched,ierr)
+ integer(kind=4),  intent(inout) :: iarr(:)
+ character(len=*), intent(in)    :: arr_tag,tag
+ logical,          intent(inout) :: got_arr
+ integer,          intent(in)    :: ikind,i1,i2,noffset,iunit
+ logical,          intent(inout) :: matched
+ integer,          intent(out)   :: ierr
+ integer      :: i
+ real(kind=4) :: dum
+ logical      :: match_datatype
+
+ if (matched) return
+ match_datatype = (ikind==i_int4)
+
+ if (match_tag(tag,arr_tag) .and. .not.matched) then
+    matched    = .true.
+    if (match_datatype) then
+       got_arr = .true.
+       read(iunit,iostat=ierr) (dum,i=1,noffset),iarr(i1:i2)
+    else
+       print*,'ERROR: wrong datatype for '//trim(tag)//' (is not int4)'
+       read(iunit,iostat=ierr)
+    endif
+ endif
+
+end subroutine read_array_int4
+
+!--------------------------------------------------------------------
+!+
+!  Routine for extracting int*8 array from main block in dump files
+!+
+!--------------------------------------------------------------------
+subroutine read_array_int8(iarr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag,matched,ierr)
+ integer(kind=8),  intent(inout) :: iarr(:)
+ character(len=*), intent(in)    :: arr_tag,tag
+ logical,          intent(inout) :: got_arr
+ integer,          intent(in)    :: ikind,i1,i2,noffset,iunit
+ logical,          intent(inout) :: matched
+ integer,          intent(out)   :: ierr
+ integer      :: i
+ real(kind=4) :: dum
+ logical      :: match_datatype
+
+ if (matched) return
+ match_datatype = (ikind==i_int8)
+
+ if (match_tag(tag,arr_tag) .and. .not.matched) then
+    matched    = .true.
+    if (match_datatype) then
+       got_arr = .true.
+       read(iunit,iostat=ierr) (dum,i=1,noffset),iarr(i1:i2)
+    else
+       print*,'ERROR: wrong datatype for '//trim(tag)//' (is not int8)'
+       read(iunit,iostat=ierr)
+    endif
+ endif
+
+end subroutine read_array_int8
 
 !--------------------------------------------------------------------
 !+
@@ -1896,7 +2038,7 @@ subroutine read_array_real4(arr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag,ma
        got_arr = .true.
        read(iunit,iostat=ierr) (dum,i=1,noffset),arr(i1:i2)
     else
-       print*,'ERROR: wrong datatype for '//trim(tag)
+       print*,'ERROR: wrong datatype for '//trim(tag)//' (is not real4)'
        read(iunit,iostat=ierr)
     endif
  endif
@@ -1940,7 +2082,7 @@ subroutine read_array_real4arr(arr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag
           arr(j,i1:i2) = real(dummyr8(:),kind=4)
           deallocate(dummyr8)
        else
-          print*,'ERROR: wrong datatype for '//trim(tag)
+          print*,'ERROR: wrong datatype for '//trim(tag)//' (is not real4arr)'
           read(iunit,iostat=ierr)
        endif
     endif
@@ -1983,7 +2125,7 @@ subroutine read_array_real8(arr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag,ma
        arr(i1:i2) = real(dummyr4(1:nread),kind=8)
        deallocate(dummyr4)
     else
-       print*,'ERROR: wrong datatype for '//trim(tag)
+       print*,'ERROR: wrong datatype for '//trim(tag)//' (is not real8)'
        read(iunit,iostat=ierr)
     endif
  endif
@@ -2033,7 +2175,7 @@ subroutine read_array_real8arr(arr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag
           arr(j,i1:i2) = real(dummyr4(:),kind=8)
           deallocate(dummyr4)
        else
-          print*,'ERROR: wrong datatype for '//trim(tag)
+          print*,'ERROR: wrong datatype for '//trim(tag)//' (is not real8arr)'
           read(iunit,iostat=ierr)
        endif
     endif

--- a/src/main/utils_dumpfiles_hdf5.f90
+++ b/src/main/utils_dumpfiles_hdf5.f90
@@ -144,6 +144,7 @@ module utils_dumpfiles_hdf5
                got_raden(maxirad),                   &
                got_kappa,                            &
                got_Tdust,                            &
+               got_iorig,                            &
                got_krome_mols(max_krome_nmols_hdf5), &
                got_krome_gamma,                      &
                got_krome_mu,                         &
@@ -315,6 +316,7 @@ subroutine write_hdf5_arrays( &
    divcurlB,                  &
    divBsymm,                  &
    eta_nimhd,                 &
+   iorig,                     &
    dustfrac,                  &
    tstop,                     &
    deltav,                    &
@@ -373,6 +375,7 @@ subroutine write_hdf5_arrays( &
                                 divcurlv(:,:),     &
                                 divcurlB(:,:)
  integer(kind=1), intent(in) :: iphase(:)
+ integer,         intent(in) :: iorig(:)
  type (arrays_options_hdf5), intent(in) :: array_options
 
  integer(HID_T) :: group_id
@@ -511,6 +514,9 @@ subroutine write_hdf5_arrays( &
        call write_to_hdf5(divcurlv(2:4,1:npart), 'curlvxyz', group_id, error)
     endif
  endif
+
+ ! Particle IDs
+ call write_to_hdf5(iorig(1:npart), 'iorig', group_id, error)
 
  ! Close the particles group
  call close_hdf5group(group_id, error)
@@ -770,6 +776,7 @@ subroutine read_hdf5_arrays( &
    poten,                    &
    Bxyz,                     &
    Bevol,                    &
+   iorig,                    &
    dustfrac,                 &
    deltav,                   &
    dustprop,                 &
@@ -792,6 +799,7 @@ subroutine read_hdf5_arrays( &
  type (arrays_options_hdf5), intent(in)  :: array_options
  type (got_arrays_hdf5),     intent(out) :: got_arrays
  integer(kind=1), intent(out) :: iphase(:)
+ integer,         intent(out) :: iorig(:)
  real,            intent(out) :: xyzh(:,:),         &
                                  vxyzu(:,:),        &
                                  xyzmh_ptmass(:,:), &
@@ -847,6 +855,7 @@ subroutine read_hdf5_arrays( &
  got_arrays%got_raden       = .false.
  got_arrays%got_kappa       = .false.
  got_arrays%got_Tdust       = .false.
+ got_arrays%got_iorig       = .false.
  got_arrays%got_krome_mols  = .false.
  got_arrays%got_krome_gamma = .false.
  got_arrays%got_krome_mu    = .false.
@@ -961,6 +970,9 @@ subroutine read_hdf5_arrays( &
     call read_from_hdf5(radprop(6,1:npart), 'radiation_numph', group_id, got, error)
     call read_from_hdf5(radprop(7,1:npart), 'radiation_vorcl', group_id, got, error)
  endif
+
+ call read_from_hdf5(iorig, 'iorig', group_id, got, error)
+ if (got) got_arrays%got_orig = .true
 
  ! Close the particles group
  call close_hdf5group(group_id, error)

--- a/src/tests/test_rwdump.F90
+++ b/src/tests/test_rwdump.F90
@@ -35,7 +35,8 @@ subroutine test_rwdump(ntests,npass)
                            maxp,poten,gravity,use_dust,dustfrac,xyzmh_ptmass,&
                            nptmass,nsinkproperties,xyzh_label,xyzmh_ptmass_label,&
                            dustfrac_label,vxyz_ptmass,vxyz_ptmass_label,&
-                           vxyzu_label,set_particle_type,iphase,ndustsmall,ndustlarge,ndusttypes
+                           vxyzu_label,set_particle_type,iphase,ndustsmall,ndustlarge,ndusttypes,&
+                           iorig,copy_particle_all
  use dim,             only:maxp,maxdustsmall
  use memory,          only:allocate_memory,deallocate_memory
  use testutils,       only:checkval,update_test_scores
@@ -50,7 +51,7 @@ subroutine test_rwdump(ntests,npass)
  use timing,          only:getused,printused
  use options,         only:use_dustfrac
  integer, intent(inout) :: ntests,npass
- integer :: nfailed(64)
+ integer :: nfailed(67)
  integer :: i,j,ierr,itest,ngas,ndust,ntot,maxp_old,iu
  real    :: tfile,hfactfile,time,tol,toldp
  real    :: alphawas,Bextxwas,Bextywas,Bextzwas,polykwas
@@ -92,6 +93,7 @@ subroutine test_rwdump(ntests,npass)
     alphawas = real(0.23_4)
     iu = 4
     do i=1,npart
+       iorig(i) = i
        xyzh(1,i) = 1.
        xyzh(2,i) = 2.
        xyzh(3,i) = 3.
@@ -151,6 +153,8 @@ subroutine test_rwdump(ntests,npass)
     endif
     polykwas = polyk
     call set_units(dist=au,mass=solarm,G=1.d0)
+    call copy_particle_all(ngas,2,.false.)   ! Move i=npart to i=2
+    call copy_particle_all(1,ngas,.true.)    ! Create new i=ngas based upon i=1
 !
 !--write to file
 !
@@ -238,6 +242,12 @@ subroutine test_rwdump(ntests,npass)
        call checkval(Bexty,Bextywas,tiny(Bexty),nfailed(19),'Bexty')
        call checkval(Bextz,Bextzwas,tiny(Bextz),nfailed(20),'Bextz')
     endif
+    if (itest==1) then  ! iorig is not dumped to small dumps
+       call checkval(iorig(2),    ngas, 0,nfailed(65),'iorig(2)')
+       call checkval(iorig(ngas), ngas, 0,nfailed(66),'iorig(ngas)')
+       call checkval(iorig(npart),npart,0,nfailed(67),'iorig(N)')
+    endif
+
     call update_test_scores(ntests,nfailed,npass)
 
     call barrier_mpi()

--- a/src/utils/moddump_binarystar.f90
+++ b/src/utils/moddump_binarystar.f90
@@ -238,7 +238,7 @@ subroutine duplicate_star(npart,npartoftype,xyzh,vxyzu,Nstar1,Nstar2)
  ! duplicate relaxed star
  do i = npart+1, 2*npart
     ! copy all particle properties
-    call copy_particle(i-npart,i)
+    call copy_particle(i-npart,i,.true.)
     ! place star a distance rad away
     xyzh(1,i) = xyzh(1,i-npart) + sep
     xyzh(2,i) = xyzh(2,i-npart)

--- a/src/utils/splitpart.f90
+++ b/src/utils/splitpart.f90
@@ -140,7 +140,7 @@ subroutine merge_all_particles(npart,npartoftype,massoftype,xyzh,vxyzu, &
     !-- quick stochastic merging
     do i = 1,npart,nchild
        iparent = iparent + 1
-       call copy_particle(i,npart+iparent)
+       call copy_particle(i,npart+iparent,.true.)
        xyzh(4,npart+iparent) = xyzh(4,i) * (nchild)**(1./3.)
     enddo
  else
@@ -224,7 +224,7 @@ subroutine merge_all_particles(npart,npartoftype,massoftype,xyzh,vxyzu, &
 
  !-- move the new parents
  do i = 1,nparent
-    call copy_particle(npart+i,i)
+    call copy_particle(npart+i,i,.true.)
  enddo
 
  !-- kill all the useless children

--- a/src/utils/utils_splitmerge.f90
+++ b/src/utils/utils_splitmerge.f90
@@ -49,7 +49,7 @@ subroutine split_a_particle(nchild,iparent,xyzh,vxyzu, &
  do j=0,nchild-2
     ichild = ichild + 1
     ! copy properties
-    call copy_particle(iparent,ichildren+ichild)
+    call copy_particle(iparent,ichildren+ichild,.true.)
 
     ! adjust the position
     if (lattice_type == 0) then
@@ -150,7 +150,7 @@ subroutine fancy_merge_into_a_particle(nchild,ichildren,mchild,npart, &
  real    :: qij,rij,wchild,grkernchild,rho_parent
 
  !-- copy properties from first child
- call copy_particle(ichildren(1),iparent)
+ call copy_particle(ichildren(1),iparent,.true.)
 
  !-- positions and velocities from centre of mass
  xyzh(1:3,iparent) = 0.
@@ -206,7 +206,7 @@ subroutine fast_merge_into_a_particle(nchild,ichildren,mchild,npart, &
  integer :: i
 
  ! use first child to be parent
- call copy_particle(ichildren(1),iparent)
+ call copy_particle(ichildren(1),iparent,.true.)
  xyzh(4,iparent) = xyzh(4,ichildren(1)) * (nchild)**(1./3.)
 
  ! discard the rest


### PR DESCRIPTION
Particle IDs are now tracked.  This is required for MPI and when particles are added/killed between dumps.  In analysis files, to always perform calculations on the same particle, use
do = 1,npart
   j = iorig(i)
  xi = xyzh(1,j)
  ...
enddo

This should solve issue #27 , although some debugging for MPI and hdf5 dumps may be required.
