### PR TITLE
(particle ID) bug fix to prevent reusing IDs

### DIFF
--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -52,10 +52,14 @@ module part
  real(kind=4), allocatable :: divcurlB(:,:)
  real,         allocatable :: Bevol(:,:)
  real,         allocatable :: Bxyz(:,:)
- integer,      allocatable :: iorig(:)
  character(len=*), parameter :: xyzh_label(4) = (/'x','y','z','h'/)
  character(len=*), parameter :: vxyzu_label(4) = (/'vx','vy','vz','u '/)
  character(len=*), parameter :: Bxyz_label(3) = (/'Bx','By','Bz'/)
+!
+!--tracking particle IDs
+!
+ integer              :: norig
+ integer, allocatable :: iorig(:)
 !
 !--storage of dust properties
 !
@@ -615,6 +619,7 @@ subroutine init_part
     iorig(i) = i
  enddo
 !$omp end parallel do
+ norig = maxp
 
 end subroutine init_part
 
@@ -1076,7 +1081,8 @@ subroutine copy_particle(src,dst,new_part)
  if (store_dust_temperature) dust_temp(dst) = dust_temp(src)
 
  if (new_part) then
-    iorig(dst) = dst        ! we are creating a new particle; give it the new ID
+    norig      = norig + 1
+    iorig(dst) = norig      ! we are creating a new particle; give it the new ID
  else
     iorig(dst) = iorig(src) ! we are moving the particle within the list; maintain ID
  endif
@@ -1180,7 +1186,8 @@ subroutine copy_particle_all(src,dst,new_part)
  endif
 
  if (new_part) then
-    iorig(dst) = dst        ! we are creating a new particle; give it the new ID
+    norig      = norig + 1
+    iorig(dst) = norig      ! we are creating a new particle; give it the new ID
  else
     iorig(dst) = iorig(src) ! we are moving the particle within the list; maintain ID
  endif

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -613,7 +613,7 @@ subroutine init_part
 !--Initialise particle id's
 !
 !$omp parallel do default(none) &
-!$omp shared(iorig) &
+!$omp shared(iorig,maxp) &
 !$omp private(i)
  do i = 1,maxp
     iorig(i) = i

--- a/src/main/partinject.F90
+++ b/src/main/partinject.F90
@@ -149,7 +149,7 @@ subroutine update_injected_particles(npartold,npart,istepfrac,nbinmax,time,dtmax
  use timestep_ind, only:get_newbin,change_nbinmax,get_dt
  use part,         only:twas,ibin
 #endif
- use part,         only:iorig
+ use part,         only:norig,iorig
 #ifdef GR
  use part,         only:xyzh,vxyzu,pxyzu,dens,metrics,metricderivs,fext
  use cons2prim,    only:prim2consall
@@ -197,7 +197,8 @@ subroutine update_injected_particles(npartold,npart,istepfrac,nbinmax,time,dtmax
 
  ! add particle ID
  do i=npartold+1,npart
-    iorig(i) = i
+    norig = norig + 1
+    iorig(i) = norig
  enddo
 
 end subroutine update_injected_particles

--- a/src/main/partinject.F90
+++ b/src/main/partinject.F90
@@ -197,7 +197,7 @@ subroutine update_injected_particles(npartold,npart,istepfrac,nbinmax,time,dtmax
 
  ! add particle ID
  do i=npartold+1,npart
-    norig = norig + 1
+    norig    = norig + 1
     iorig(i) = norig
  enddo
 

--- a/src/main/readwrite_dumps_common.F90
+++ b/src/main/readwrite_dumps_common.F90
@@ -128,7 +128,7 @@ subroutine check_arrays(i1,i2,npartoftype,npartread,nptmass,nsinkproperties,mass
                 use_dustgrowth,gr,do_radiation,store_dust_temperature
  use eos,  only:polyk,gamma
  use part, only:maxphase,isetphase,set_particle_type,igas,ihacc,ihsoft,imacc,&
-                xyzmh_ptmass_label,vxyz_ptmass_label,get_pmass,rhoh,dustfrac,ndusttypes
+                xyzmh_ptmass_label,vxyz_ptmass_label,get_pmass,rhoh,dustfrac,ndusttypes,norig
  use io,   only:warning,id,master
  use options,    only:alpha,use_dustfrac
  use sphNGutils, only:itype_from_sphNG_iphase,isphNG_accreted
@@ -372,7 +372,13 @@ subroutine check_arrays(i1,i2,npartoftype,npartread,nptmass,nsinkproperties,mass
     do i=i1,i2
        iorig(i) = i
     enddo
+    norig = i2
     if (id==master .and. i1==1) write(*,*) 'WARNING: Particle IDs not in dump; resetting IDs'
+ else
+    norig = 0
+    do i=i1,i2
+       norig = max(norig,iorig(i))
+    enddo
  endif
 
 end subroutine check_arrays

--- a/src/tests/test_rwdump.F90
+++ b/src/tests/test_rwdump.F90
@@ -36,7 +36,7 @@ subroutine test_rwdump(ntests,npass)
                            nptmass,nsinkproperties,xyzh_label,xyzmh_ptmass_label,&
                            dustfrac_label,vxyz_ptmass,vxyz_ptmass_label,&
                            vxyzu_label,set_particle_type,iphase,ndustsmall,ndustlarge,ndusttypes,&
-                           iorig,copy_particle_all
+                           iorig,copy_particle_all,norig
  use dim,             only:maxp,maxdustsmall
  use memory,          only:allocate_memory,deallocate_memory
  use testutils,       only:checkval,update_test_scores
@@ -122,6 +122,7 @@ subroutine test_rwdump(ntests,npass)
           dustfrac(:,i) = 0.16_4
        endif
     enddo
+    norig   = npart
     nptmass = 10
     do i=1,nptmass
        do j=1,nsinkproperties
@@ -153,7 +154,7 @@ subroutine test_rwdump(ntests,npass)
     endif
     polykwas = polyk
     call set_units(dist=au,mass=solarm,G=1.d0)
-    call copy_particle_all(ngas,2,.false.)   ! Move i=npart to i=2
+    call copy_particle_all(ngas,2,.false.)   ! Move i=ngas to i=2 (assumes i=2 was killed)
     call copy_particle_all(1,ngas,.true.)    ! Create new i=ngas based upon i=1
 !
 !--write to file
@@ -243,9 +244,9 @@ subroutine test_rwdump(ntests,npass)
        call checkval(Bextz,Bextzwas,tiny(Bextz),nfailed(20),'Bextz')
     endif
     if (itest==1) then  ! iorig is not dumped to small dumps
-       call checkval(iorig(2),    ngas, 0,nfailed(65),'iorig(2)')
-       call checkval(iorig(ngas), ngas, 0,nfailed(66),'iorig(ngas)')
-       call checkval(iorig(npart),npart,0,nfailed(67),'iorig(N)')
+       call checkval(iorig(2),    ngas,    0,nfailed(65),'iorig(2)')
+       call checkval(iorig(ngas), npart+1, 0,nfailed(66),'iorig(ngas)')
+       call checkval(iorig(npart),npart,   0,nfailed(67),'iorig(N)')
     endif
 
     call update_test_scores(ntests,nfailed,npass)


### PR DESCRIPTION
We now properly track the maximum particle ID and use this as the reference point for all future IDs.  This prevents duplicating IDs when particles are deleted prior to new particles being added to the list.
