### PR TITLE
Star cleanup

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -1881,8 +1881,8 @@ SRCSETUP= utils_omp.F90 utils_sort.f90 utils_timing.f90 utils_summary.F90 utils_
           mpi_balance.F90 set_dust_options.f90 \
           utils_indtimesteps.F90 partinject.F90 stack.F90 mpi_dens.F90 mpi_force.F90 mpi_derivs.F90 \
           ${SRCTURB} ${SRCNIMHD} ${SRCCHEM} \
-          ptmass.F90 energies.F90 density_profiles.f90 \
-          set_slab.f90 set_disc.F90 relax_star.f90 set_softened_core.f90 set_fixedentropycore.f90\
+          ptmass.F90 energies.F90 density_profiles.f90 set_slab.f90 set_disc.F90 relax_star.f90 \
+	  set_cubic_core.f90 set_fixedentropycore.f90 set_softened_core.f90 \
           set_vfield.f90 sort_particles.F90 dust_formation.F90 ptmass_radiation.F90 ${SRCINJECT} \
           ${SETUPFILE} checksetup.F90 \
           set_Bfield.f90 damping.f90 readwrite_infile.f90 ${SRCKROME}

--- a/src/main/utils_filenames.f90
+++ b/src/main/utils_filenames.f90
@@ -21,7 +21,7 @@ module fileutils
  implicit none
  public :: getnextfilename,numfromfile,basename,get_ncolumns,skip_header
  public :: strip_extension,is_digit,files_are_sequential
- public :: ucase,lcase,make_tags_unique
+ public :: ucase,lcase,make_tags_unique,get_nlines,string_delete
 
  private
 
@@ -197,6 +197,27 @@ function basename(string)
 
 end function basename
 
+!---------------------------------------------------------------------------
+!
+! function to count number of lines in a file
+!
+!---------------------------------------------------------------------------
+function get_nlines(string) result(n)
+ character(len=*), intent(in) :: string
+ integer :: n,iunit,ierr
+
+ open(newunit=iunit, file=string,status='old',iostat=ierr)
+ !--first reading
+ n = 0
+ do while (ierr==0)
+    n = n + 1
+    read(iunit,*,iostat=ierr)
+    if (ierr /= 0) n = n - 1
+ enddo
+ close(iunit)
+    
+end function get_nlines
+  
 !---------------------------------------------------------------------------
 !
 ! routine to strip extension from a filename
@@ -408,5 +429,18 @@ subroutine make_tags_unique(ntags,tags)
  enddo
 
 end subroutine make_tags_unique
+
+pure subroutine string_delete(string,skey)
+ character(len=*), intent(inout) :: string
+ character(len=*), intent(in)    :: skey
+ integer :: ipos,lensub
+
+ ipos = index(string,skey)
+ lensub = len(skey)
+ do while(ipos > 0)
+    string = string(1:ipos-1)//string(ipos+lensub:len_trim(string))
+    ipos = index(trim(string),skey)
+ enddo
+end subroutine string_delete
 
 end module fileutils

--- a/src/main/utils_filenames.f90
+++ b/src/main/utils_filenames.f90
@@ -430,6 +430,9 @@ subroutine make_tags_unique(ntags,tags)
 
 end subroutine make_tags_unique
 
+!----------------------------------------------------------------------
+! Delete a symbol from a string
+!----------------------------------------------------------------------
 pure subroutine string_delete(string,skey)
  character(len=*), intent(inout) :: string
  character(len=*), intent(in)    :: skey

--- a/src/setup/density_profiles.f90
+++ b/src/setup/density_profiles.f90
@@ -528,9 +528,9 @@ subroutine read_mesa(filepath,rho,r,pres,m,ene,temp,Xfrac,Yfrac,Mstar,ierr,cgsun
        pres = dat(1:lines,i)
     case('temperature')
        temp = dat(1:lines,i)
-    case('x_mass_fraction_H')
+    case('x_mass_fraction_h')
        Xfrac = dat(1:lines,i)
-    case('y_mass_fraction_He')
+    case('y_mass_fraction_he')
        Yfrac = dat(1:lines,i)
     end select
  enddo

--- a/src/setup/set_cubic_core.f90
+++ b/src/setup/set_cubic_core.f90
@@ -1,0 +1,289 @@
+!--------------------------------------------------------------------------!
+! The Phantom Smoothed Particle Hydrodynamics code, by Daniel Price et al. !
+! Copyright (c) 2007-2020 The Authors (see AUTHORS)                        !
+! See LICENCE file for usage and distribution conditions                   !
+! http://phantomsph.bitbucket.io/                                          !
+!--------------------------------------------------------------------------!
+module setcubiccore
+!
+! This module softens the core of a MESA stellar profile with a cubic
+!   density profile, given a core radius core mass, in preparation
+!   for adding a sink particle core.
+!
+! :References: For cubic spline softening of sink gravity, see Price &
+!              Monaghan (2007)
+!
+! :Owner: Mike Lau
+!
+! :Runtime parameters: None
+!
+! :Dependencies: eos, io, kernel, physcon, table_utils
+!
+ use physcon,          only:pi,gg,solarm,solarr,kb_on_mh
+ use table_utils,      only:interpolator,diff
+
+ implicit none
+ real    :: rcore,msoft,mcore
+ integer :: icore
+
+ ! rcore: Radius below which we replace the original profile with a
+ !        softened profile.
+ ! mcore: Mass of core particle
+ ! msoft: Softened mass (mass at softening length minus mass of core
+ !        particle)
+ ! hsoft: Softening length for the point particle potential, defined in
+ !        Price & Monaghan (2007). Set to be 0.5*rcore.
+
+contains
+
+!-----------------------------------------------------------------------
+!+
+!  Main subroutine that calculates the cubic core profile
+!+
+!-----------------------------------------------------------------------
+subroutine set_cubic_core(mcore,rcore,rho,r,pres,m,ene,temp,ierr)
+ use eos,         only:calc_temp_and_ene
+ use table_utils, only:flip_array
+ use io,          only:fatal
+ real, intent(inout)        :: r(:),rho(:),m(:),pres(:),ene(:),temp(:)
+ real, allocatable          :: phi(:)
+ real, intent(in)           :: mcore,rcore
+ integer, intent(out)       :: ierr
+ real                       :: mc,rc,hsoft_cm,eneguess
+ logical                    :: isort_decreasing,iexclude_core_mass
+ integer                    :: i
+
+ ! Output data to be sorted from stellar surface to interior?
+ isort_decreasing = .true.     ! Needs to be true if to be read by Phantom
+ !
+ ! Exclude core mass in output mass coordinate?
+ iexclude_core_mass = .true.   ! Needs to be true if to be read by Phantom
+
+ rc       = rcore * solarr      ! Convert to cm
+ hsoft_cm = 0.5*rc             ! Convert to cm
+ mc       = mcore * solarm      ! Convert to g
+ call interpolator(r,rc,icore)   ! Find index in r closest to rc
+ msoft = m(icore) - mc
+
+ call calc_rho_and_m(rho, m, r, mc, rc)
+ call calc_phi(r, mc, m-mc, hsoft_cm, phi)
+ call calc_pres(r, rho, phi, pres)
+
+ call calc_temp_and_ene(rho(1),pres(1),ene(1),temp(1),ierr)
+ if (ierr /= 0) call fatal('set_cubic_core','EoS not one of: adiabatic, ideal gas plus radiation, MESA in set_softened_core')
+ do i = 2,size(rho)-1
+    eneguess = ene(i-1)
+    call calc_temp_and_ene(rho(i),pres(i),ene(i),temp(i),ierr,eneguess)
+ enddo
+ ene(size(rho))  = 0. ! Zero surface internal energy
+ temp(size(rho)) = 0. ! Zero surface temperature
+
+ ! Reverse arrays so that data is sorted from stellar surface to stellar centre.
+ if (isort_decreasing) then
+    call flip_array(m)
+    call flip_array(pres)
+    call flip_array(temp)
+    call flip_array(r)
+    call flip_array(rho)
+    call flip_array(ene)
+ endif
+
+ if (iexclude_core_mass) then
+    m = m - mc
+ endif
+
+end subroutine set_cubic_core
+
+
+!----------------------------------------------------------------
+!+
+!  Iteratively look for a value of mcore for given rcore that
+!  produces a nice softened density profile
+!+
+!----------------------------------------------------------------
+subroutine find_mcore_given_rcore(rcore,r,rho0,m0,mcore,ierr)
+ real,    intent(in)  :: r(:),rho0(:),m0(:),rcore
+ real,    intent(out) :: mcore
+ integer, intent(out) :: ierr
+ real,    allocatable :: rho(:),drho(:),m(:)
+ real                 :: rc,mc,tolerance
+ integer              :: icore,counter=0
+
+ rc = rcore * solarr ! Convert to cm
+ call interpolator(r, rc, icore) ! Find index in r closest to rcore
+ mc = 0.7*m0(icore) ! Initialise profile to have very large softened mass
+ tolerance = 1.3 ! How much we allow the softened density to exceed the original profile by
+ ierr = 0
+
+ allocate(rho(size(rho0)))
+ allocate(m(size(m0)))
+ allocate(drho(size(rho0)-1))
+ do
+    rho = rho0   ! Reset density
+    m   = m0     ! Reset mass
+    call calc_rho_and_m(rho, m, r, mc, rc)
+    call diff(rho,drho)
+    if (all(rho/rho0 < tolerance) .and. all(drho(1:icore) < 0)) exit
+    if (mc > 0.98*m0(icore)) then
+       ierr = 1
+       exit
+    endif
+    mc = mc + 0.01*m0(icore) ! Increase mcore/m(rc) by 1 percent
+    counter = counter+1
+ enddo
+ ! Output mcore in solar masses
+ mcore = mc / solarm
+end subroutine find_mcore_given_rcore
+
+!----------------------------------------------------------------
+!+
+!  Iteratively look for a value of rcore for given mcore that
+!  produces a nice softened density profile
+!+
+!----------------------------------------------------------------
+subroutine find_rcore_given_mcore(mcore,r,rho0,m0,rcore,ierr)
+ real,    intent(in)  :: r(:),rho0(:),m0(:),mcore
+ real,    intent(out) :: rcore
+ integer, intent(out) :: ierr
+ real,    allocatable :: rho(:),drho(:),m(:)
+ real                 :: rc,mc,mh,tolerance
+ integer              :: icore
+
+ mc = mcore * solarm ! Convert to g
+ mh = mc / 0.7 ! Initialise rcore such that m(rcore) to be much larger than mcore
+ tolerance = 1.3 ! How much we allow the softened density to exceed the original profile by
+ ierr = 0
+ allocate(rho(size(rho0)))
+ allocate(m(size(m0)))
+ allocate(drho(size(rho0)-1))
+ do
+    call interpolator(m0, mh, icore)
+    rc   = r(icore)
+    rho = rho0   ! Reset density
+    m   = m0     ! Reset mass
+    call calc_rho_and_m(rho, m, r, mc, rc)
+    call diff(rho,drho)
+    if (all(rho/rho0 < tolerance) .and. all(drho(1:icore) < 0)) exit
+    if (mc > 0.98*m0(icore)) then
+       ierr = 1
+       exit
+    endif
+    call interpolator(m0, 1.3*mc, icore)
+    mh = 1./(1./mh + 0.01/mc) ! Increase mcore/m(h) by 1 percent
+ enddo
+ ! Write out hsoft in solar radii
+ rcore = rc / solarr
+end subroutine find_rcore_given_mcore
+
+!----------------------------------------------------------------
+!+
+!  Check for sensible values of rcore and mcore
+!+
+!----------------------------------------------------------------
+subroutine check_rcore_and_mcore(rcore,mcore,r,rho0,m0,ierr)
+ real,    intent(in)  :: r(:),rho0(:),m0(:),mcore,rcore
+ integer, intent(out) :: ierr
+ real,    allocatable :: rho(:),drho(:),m(:)
+ real                 :: rc,mc,msoft,tolerance
+ integer              :: icore
+ ierr = 0
+ tolerance = 1.5 ! How much we allow the softened density to exceed the original profile by
+ rc = rcore * solarr ! Convert to cm
+ mc = mcore * solarm ! Convert to g
+ call interpolator(r,rc,icore) ! Find index in r closest to h
+ msoft = m0(icore) - mc
+
+ if (msoft < 0.) ierr = 1
+
+ allocate(rho(size(rho0)))
+ allocate(m(size(m0)))
+ allocate(drho(size(rho0)-1))
+ rho = rho0
+ m = m0
+ call calc_rho_and_m(rho, m, r, mc, rc)
+ if (any(rho/rho0 > tolerance)) ierr = 2
+
+ call diff(rho, drho)
+ if (any(drho(1:icore) > 0)) ierr = 3
+end subroutine check_rcore_and_mcore
+
+
+subroutine calc_rho_and_m(rho,m,r,mc,rc)
+ real, intent(in)    :: r(:)
+ real, intent(inout) :: rho(:),m(:)
+ real, intent(in)    :: mc,rc
+ real                :: a,b,d,msoft,drhodr_h
+ integer             :: icore
+
+ call interpolator(r,rc,icore) ! Find index in r closest to rc
+ msoft    = m(icore) - mc
+ drhodr_h = (rho(icore+1) - rho(icore)) / (r(icore+1) - r(icore)) ! drho/dr at r = rc
+
+ ! a, b, d: Coefficients of cubic density profile defined by rho(r) = ar**3 + br**2 + d
+ a = 2./rc**2 * drhodr_h - 10./rc**3 * rho(icore) + 7.5/pi/rc**6 * msoft
+ b = 0.5*drhodr_h/rc - 1.5*a*rc
+ d = rho(icore) - 0.5*rc*drhodr_h + 0.5*a*rc**3
+
+ rho(1:icore) = a*r(1:icore)**3 + b*r(1:icore)**2 + d
+
+ ! Mass is then given by m(r) = mcore + 4*pi (1/6 a r^6 + 1/5 b r^5 + 1/3 d r^3)
+ m(1:icore) = mc + 4.*pi * (1./6. * a * r(1:icore)**6 + 0.2 * b * r(1:icore)**5 + &
+                           1./3. * d * r(1:icore)**3)
+end subroutine calc_rho_and_m
+
+
+subroutine calc_phi(r,mc,mgas,hsoft,phi)
+ use kernel, only:kernel_softening
+ real, intent(in)               :: r(:),mgas(:),mc,hsoft
+ real, allocatable              :: q(:),q2(:),phi_core(:),phi_gas(:)
+ real, allocatable, intent(out) :: phi(:)
+ real                           :: dum
+ integer                        :: i
+
+ ! The gravitational potential is needed to integrate the pressure profile using the
+ ! equation of hydrostatic equilibrium. First calculate gravitational potential due
+ ! to point mass core, using softening kernel selected in Phantom. Then calculate the
+ ! gravitational potential due to the softened gas.
+
+ ! Gravitational potential due to primary core
+ allocate(phi(size(r)), phi_core(size(r)), phi_gas(size(r)), q(size(r)), q2(size(r)))
+ q  = r / hsoft
+ q2 = q**2
+ do i = 1,size(r)
+    call kernel_softening(q2(i),q(i),phi_core(i),dum)
+ enddo
+ deallocate(q,q2)
+ phi_core = gg * phi_core * mc / hsoft
+
+ ! Gravitational potential due to softened gas
+ phi_gas(size(r)) = - gg * mgas(size(r)) / r(size(r)) ! Surface boundary condition for phi
+ do i = 1,size(r)-1
+    phi_gas(size(r)-i) = phi_gas(size(r)-i+1) - gg * mgas(size(r)-i) / r(size(r)-i)**2. &
+                                               * (r(size(r)-i+1) - r(size(r)-i))
+ enddo
+
+ phi = phi_gas + phi_core
+
+end subroutine calc_phi
+
+!----------------------------------------------------------------
+!+
+!  Calculate pressure by integrating the equation of hydrostatic
+!  equilibrium given the gravitational potential and the density
+!  profile
+!+
+!----------------------------------------------------------------
+subroutine calc_pres(r,rho,phi,pres)
+ real, intent(in)  :: rho(:),phi(:),r(:)
+ real, intent(out) :: pres(:)
+ integer           :: i
+
+ pres(size(r)) = 0 ! Set boundary condition of zero pressure at stellar surface
+ do i = 1,size(r)-1
+    ! Reverse Euler
+    pres(size(r)-i) = pres(size(r)-i+1) + rho(size(r)-i+1) * (phi(size(r)-i+1) - phi(size(r)-i))
+ enddo
+
+end subroutine calc_pres
+
+end module setcubiccore

--- a/src/setup/set_fixedentropycore.f90
+++ b/src/setup/set_fixedentropycore.f90
@@ -7,7 +7,7 @@
 module setfixedentropycore
 !
 ! This module softens the core of a MESA stellar profile with a constant
-!   entropy profile, given a softening length and core mass, in preparation
+!   entropy profile, given a core radius and mass, in preparation
 !   for adding a sink particle core.
 !
 ! :References:
@@ -28,29 +28,28 @@ contains
 !  Main subroutine that calculates the constant entropy softened profile
 !+
 !-----------------------------------------------------------------------
-subroutine set_fixedS_softened_core(mcore,hsoft,hphi,rho,r,pres,m,ene,temp,ierr)
+subroutine set_fixedS_softened_core(mcore,rcore,rho,r,pres,m,ene,temp,ierr)
  use eos,         only:calc_temp_and_ene,ieos
  use physcon,     only:pi,gg,solarm,solarr,kb_on_mh
  use table_utils, only:interpolator,flip_array
  use io,          only:fatal
  real, intent(inout)        :: r(:),rho(:),m(:),pres(:),ene(:),temp(:),mcore
  real, allocatable          :: r_alloc(:),rho_alloc(:),pres_alloc(:)
- real, intent(in)           :: hsoft,hphi
+ real, intent(in)           :: rcore
  integer, intent(out)       :: ierr
- real                       :: mc,msoft,h,hphi_cm,eneguess
+ real                       :: mc,msoft,rc,eneguess
  logical                    :: isort_decreasing,iexclude_core_mass
- integer                    :: i,hidx,iSerr
+ integer                    :: i,icore
 
  ! Output data to be sorted from stellar surface to interior?
  isort_decreasing = .true.     ! Needs to be true if to be read by Phantom
  ! Exclude core mass in output mass coordinate?
  iexclude_core_mass = .true.   ! Needs to be true if to be read by Phantom
 
- h       = hsoft * solarr      ! Convert to cm
- hphi_cm = hphi  * solarr      ! Convert to cm
- mc      = mcore * solarm      ! Convert to g
- call interpolator(r,h,hidx)   ! Find index in r closest to h
- msoft = m(hidx) - mc
+ rc = rcore * solarr     ! Convert to cm
+ mc = mcore * solarm     ! Convert to g
+ call interpolator(r,rc,icore)   ! Find index in r closest to rc
+ msoft = m(icore) - mc
 
  select case(ieos)
  case(2)
@@ -64,25 +63,22 @@ subroutine set_fixedS_softened_core(mcore,hsoft,hphi,rho,r,pres,m,ene,temp,ierr)
  end select
 
  ! Make allocatable copies, see instructions of calc_rho_and_pres
- allocate(r_alloc(0:hidx+1))
+ allocate(r_alloc(0:icore+1))
  r_alloc(0) = 0.
- r_alloc(1:hidx+1) = r(1:hidx+1)
- allocate(rho_alloc(0:hidx))
- rho_alloc(hidx) = rho(hidx)
- allocate(pres_alloc(0:hidx+1))
- pres_alloc(hidx:hidx+1) = pres(hidx:hidx+1)
- call calc_rho_and_pres(r_alloc,mc,m(hidx),rho_alloc,pres_alloc,iSerr)
- if (iSerr == 1) then
-    call fatal('setfixedentropycore','Choice of fixed entropy exceeds outer entropy. Try choosing a smaller core mass.')
- endif
+ r_alloc(1:icore+1) = r(1:icore+1)
+ allocate(rho_alloc(0:icore))
+ rho_alloc(icore) = rho(icore)
+ allocate(pres_alloc(0:icore+1))
+ pres_alloc(icore:icore+1) = pres(icore:icore+1)
+ call calc_rho_and_pres(r_alloc,mc,m(icore),rho_alloc,pres_alloc)
  mcore = mc / solarm
  write(*,'(1x,a,f12.5,a)') 'Obtained core mass of ',mcore,' Msun'
- write(*,'(1x,a,f12.5,a)') 'Softened mass is ',m(hidx)/solarm-mcore,' Msun'
- rho(1:hidx)  = rho_alloc(1:hidx)
- pres(1:hidx) = pres_alloc(1:hidx)
+ write(*,'(1x,a,f12.5,a)') 'Softened mass is ',m(icore)/solarm-mcore,' Msun'
+ rho(1:icore)  = rho_alloc(1:icore)
+ pres(1:icore) = pres_alloc(1:icore)
 
- call calc_mass_from_rho(r(1:hidx),rho(1:hidx),m(1:hidx))
- m(1:hidx) = m(1:hidx) + mc
+ call calc_mass_from_rho(r(1:icore),rho(1:icore),m(1:icore))
+ m(1:icore) = m(1:icore) + mc
 
  call calc_temp_and_ene(rho(1),pres(1),ene(1),temp(1),ierr)
  if (ierr /= 0) call fatal('setfixedentropycore','EoS not one of: adiabatic, ideal gas plus radiation, MESA in set_softened_core')
@@ -115,38 +111,32 @@ end subroutine set_fixedS_softened_core
 !  Returns softened core profile with fixed entropy
 !+
 !-----------------------------------------------------------------------
-subroutine calc_rho_and_pres(r,mcore,mh,rho,pres,ierr)
+subroutine calc_rho_and_pres(r,mcore,mh,rho,pres)
  use eos, only:entropy
  real, allocatable, dimension(:), intent(in)    :: r
  real, intent(in)                               :: mh
  real, intent(inout)                            :: mcore
  real, allocatable, dimension(:), intent(inout) :: rho,pres
- integer, intent(out)                           :: ierr
  integer                                        :: Nmax
- real                                           :: Sc,mass,mold,msoft,fac,Sedge
+ real                                           :: Sc,mass,mold,msoft,fac
 
-! Instructions
+! INSTRUCTIONS
 
-! input variables should be given in the following format
+! Input variables should be given in the following format:
 
-! r(0:Nmax+1): Array of radial grid to be softened, satisfying r(0)=0 and r(Nmax)=hsoft
+! r(0:Nmax+1): Array of radial grid to be softened, satisfying r(0)=0 and r(Nmax)=rcore
 ! mcore:       Core particle mass, need to provide initial guess
-! mh:          Mass coordinate at hsoft, m(r=h)
-! rho(0:Nmax): Give rho(Nmax)=(rho at hsoft) as input. Outputs density profile.
+! mh:          Mass coordinate at rcore, m(r=rcore)
+! rho(0:Nmax): Give rho(Nmax)=(rho at rcore) as input. Outputs density profile.
 ! p(0:Nmax+1): Give p(Nmax:Nmax+1)=(p at r(Nmax:Nmax+1)) as input. Outputs pressure profile.
 
-! ierr: Is set to 1 when the fixed entropy value exceeds the outer entropy.
-!       Should choose a smaller core mass if this happens.
-
- ierr  = 0
  msoft = mh - mcore
  Nmax  = size(rho)-1 ! Index corresponding to r = h
- Sedge = entropy(rho(Nmax),pres(Nmax),ientropy)
+ Sc = entropy(rho(Nmax),pres(Nmax),ientropy)
 
  ! Start shooting method
  fac  = 0.05
  mass = msoft
- Sc   = Sedge
 
  do
     mold = mass
@@ -167,7 +157,6 @@ subroutine calc_rho_and_pres(r,mcore,mh,rho,pres,ierr)
     endif
  enddo
 
- if (Sedge < Sc) ierr = 1
  return
 
 end subroutine calc_rho_and_pres
@@ -179,13 +168,13 @@ end subroutine calc_rho_and_pres
 !+
 !-----------------------------------------------------------------------
 subroutine one_shot(Sc,r,mcore,msoft,rho,pres,mass)
- use physcon, only: gg,pi
+ use physcon, only:gg,pi
  real, intent(in)                               :: Sc,mcore,msoft
  real, allocatable, dimension(:), intent(in)    :: r
  real, allocatable, dimension(:), intent(inout) :: rho,pres
  real, intent(out)                              :: mass
  integer                                        :: i,Nmax
- real                                           :: hsoft
+ real                                           :: rcore,rhoguess
  real, allocatable, dimension(:)                :: dr,dvol
 
  Nmax = size(rho)-1
@@ -196,22 +185,28 @@ subroutine one_shot(Sc,r,mcore,msoft,rho,pres,mass)
     dvol(i) = 4.*pi/3. * (r(i)**3 - r(i-1)**3)
  enddo
 
- hsoft = r(Nmax)
+ rcore = r(Nmax)
  mass  = msoft
 
  do i = Nmax, 1, -1
     pres(i-1) = ( dr(i) * dr(i+1) * sum(dr(i:i+1)) &
-                * rho(i) * gg * (mass/r(i)**2 + mcore * gcore(r(i),hsoft)) &
+                * rho(i) * gg * (mass/r(i)**2 + mcore * gcore(r(i),rcore)) &
                 + dr(i)**2 * pres(i+1) &
                 + ( dr(i+1)**2 - dr(i)**2) * pres(i) ) / dr(i+1)**2
+    if (i == Nmax) then
+       rhoguess = 1.e8
+    else 
+       rhoguess = rho(i)
+    endif
     call get_rho_from_p_s(pres(i-1),Sc,rho(i-1))
     mass = mass - 0.5*(rho(i)+rho(i-1)) * dvol(i)
-    if (mass < 0.) return ! m(r) < 0 encountered, exit and increase Sc
+    if (mass < 0.) return ! m(r) < 0 encountered, exit and decrease mcore
  enddo
 
  return
 
 end subroutine one_shot
+
 
 !-----------------------------------------------------------------------
 !+
@@ -248,16 +243,16 @@ end subroutine get_rho_from_p_s
 !  Acceleration from softened potential of stellar core
 !+
 !-----------------------------------------------------------------------
-function gcore(r,hsoft)
+function gcore(r,rcore)
  use kernel, only:kernel_softening
- real, intent(in) :: r,hsoft
+ real, intent(in) :: r,rcore
  real             :: gcore,dum
- real             :: hphi,q
+ real             :: hsoft,q
 
- hphi = 0.5 * hsoft
- q = r / hphi
+ hsoft = 0.5 * rcore
+ q = r / hsoft
  call kernel_softening(q**2,q,dum,gcore)
- gcore = gcore / hphi**2 ! Note: gcore is not multiplied by G or mcore yet.
+ gcore = gcore / hsoft**2 ! Note: gcore is not multiplied by G or mcore yet.
 
 end function gcore
 

--- a/src/setup/set_softened_core.f90
+++ b/src/setup/set_softened_core.f90
@@ -18,7 +18,7 @@ module setsoftenedcore
 ! :Dependencies: eos, io, setcubiccore, setfixedentropycore, table_utils, physcon
 !
  implicit none
- real    :: rcore,mcore,hsoft
+ real :: rcore,mcore
 
  ! rcore: Radius below which we replace the original profile with a
  !        softened profile.
@@ -31,13 +31,13 @@ contains
 !  Main subroutine that sets a softened core profile
 !+
 !-----------------------------------------------------------------------
-subroutine set_softened_core(isoftcore,isofteningopt,r,den,pres,m,ene,temp,X,Y,ierr)
+subroutine set_softened_core(isoftcore,isofteningopt,r,den,pres,m,ene,temp,X,Y,rcore,mcore,ierr)
  use eos,         only:ieos,X_in,Z_in,gmw,init_eos
  use io,          only:fatal
- use setcubiccore,only:set_cubic_core,find_mcore_given_hsoft,find_hsoft_given_mcore,check_hsoft_and_mcore
+ use setcubiccore,only:set_cubic_core,find_mcore_given_rcore,find_rcore_given_mcore,check_rcore_and_mcore
  use setfixedentropycore,only:set_fixedS_softened_core
  integer, intent(in)        :: isoftcore,isofteningopt
- real, intent(inout)        :: r(:),den(:),m(:),pres(:),ene(:),temp(:),X(:),Y(:)
+ real, intent(inout)        :: r(:),den(:),m(:),pres(:),ene(:),temp(:),X(:),Y(:),rcore,mcore
  integer                    :: ierr
 
  ! set mu, X, Z mass fractions to be their values at R/2
@@ -51,28 +51,25 @@ subroutine set_softened_core(isoftcore,isofteningopt,r,den,pres,m,ene,temp,X,Y,i
  ! get values of rcore and mcore
  select case (isofteningopt)
  case(1)
-    call find_mcore_given_hsoft(rcore,r,den,m,mcore,ierr)
+    call find_mcore_given_rcore(rcore,r,den,m,mcore,ierr)
     if (ierr==1) call fatal('setup','Cannot find mcore that produces nice profile (mcore/m(h) > 0.98 reached)')
  case(2)
-    call find_hsoft_given_mcore(mcore,r,den,m,rcore,ierr)
+    call find_rcore_given_mcore(mcore,r,den,m,rcore,ierr)
     if (ierr==1) call fatal('setup','Cannot find softening length that produces nice profile (h/r(mcore) < 1.02 reached)')
  case(3) ! Both rcore and mcore are specified, check if values are sensible
-    call check_hsoft_and_mcore(rcore,mcore,r,den,m,ierr)
+    call check_rcore_and_mcore(rcore,mcore,r,den,m,ierr)
     if (ierr==1) call fatal('setup','mcore cannot exceed m(r=h)')
     if (ierr==2) call fatal('setup','softenedrho/rho > tolerance')
     if (ierr==3) call fatal('setup','drho/dr > 0 found in softened profile')
  end select
- hsoft = 0.5*rcore ! this is set by default so that we have the original unsoftened profile for r > hsoft
 
  ! call core-softening subroutines
  select case(isoftcore) ! choose type of core-softneing
  case(1)
-    call set_cubic_core(mcore,rcore,hsoft,den,r,pres,m,ene,temp,ierr)
+    call set_cubic_core(mcore,rcore,den,r,pres,m,ene,temp,ierr)
     if (ierr /= 0) call fatal('setup','could not set softened core')
  case(2)
-    call set_fixedS_softened_core(mcore,rcore,hsoft,den,r,pres,m,ene,temp,ierr)
-    !call set_fixedS_surface(mcore,mtab,den,r,pres,en,temp,ierr)
-    !call set_fixedS_star(mcore,rcore,mtab,den,r,pres,en,temp,ierr)
+    call set_fixedS_softened_core(mcore,rcore,den,r,pres,m,ene,temp,ierr)
     if (ierr /= 0) call fatal('setup','could not set fixed entropy softened core')
  end select
 

--- a/src/setup/set_softened_core.f90
+++ b/src/setup/set_softened_core.f90
@@ -6,289 +6,100 @@
 !--------------------------------------------------------------------------!
 module setsoftenedcore
 !
-! This module softens the core of a MESA stellar profile with a cubic
-!   density profile, given a softening length and core mass, in preparation
-!   for adding a sink particle core.
+! This module softens the core of a MESA stellar profile given a softening
+! radius
 !
-! :References: For cubic spline softening of sink gravity, see Price &
-!              Monaghan (2007)
+! :References:
 !
 ! :Owner: Mike Lau
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: eos, io, kernel, physcon, table_utils
+! :Dependencies: eos, io, setcubiccore, setfixedentropycore, table_utils, physcon
 !
- use physcon,          only:pi,gg,solarm,solarr,kb_on_mh
- use table_utils,      only:interpolator,diff
-
  implicit none
- real    :: hsoft,msoft,mcore
- integer :: hidx
+ real    :: rcore,mcore,hsoft
 
- ! hsoft: Radius below which we replace the original profile with a
- !        softened profile. Note: This is called 'hdens' in
- !        setup_star.f90
+ ! rcore: Radius below which we replace the original profile with a
+ !        softened profile.
  ! mcore: Mass of core particle
- ! msoft: Softened mass (mass at softening length minus mass of core
- !        particle)
- ! hphi:  Softening length for the point particle potential, defined in
- !        Price & Monaghan (2007). Set to be 0.5*hsoft. Note: This is
- !        called 'hsoft' in setup_star.f90
 
 contains
 
 !-----------------------------------------------------------------------
 !+
-!  Main subroutine that calculates the cubic core profile
+!  Main subroutine that sets a softened core profile
 !+
 !-----------------------------------------------------------------------
-subroutine set_softened_core(mcore,hsoft,hphi,rho,r,pres,m,ene,temp,ierr)
- use eos,         only:calc_temp_and_ene
- use table_utils, only:flip_array
+subroutine set_softened_core(isoftcore,isofteningopt,r,den,pres,m,ene,temp,X,Y,ierr)
+ use eos,         only:ieos,X_in,Z_in,gmw,init_eos
  use io,          only:fatal
- real, intent(inout)        :: r(:),rho(:),m(:),pres(:),ene(:),temp(:)
- real, allocatable          :: phi(:)
- real, intent(in)           :: mcore,hsoft,hphi
- integer, intent(out)       :: ierr
- real                       :: mc,h,hphi_cm,eneguess
- logical                    :: isort_decreasing,iexclude_core_mass
- integer                    :: i
+ use setcubiccore,only:set_cubic_core,find_mcore_given_hsoft,find_hsoft_given_mcore,check_hsoft_and_mcore
+ use setfixedentropycore,only:set_fixedS_softened_core
+ integer, intent(in)        :: isoftcore,isofteningopt
+ real, intent(inout)        :: r(:),den(:),m(:),pres(:),ene(:),temp(:),X(:),Y(:)
+ integer                    :: ierr
 
- ! Output data to be sorted from stellar surface to interior?
- isort_decreasing = .true.     ! Needs to be true if to be read by Phantom
- !
- ! Exclude core mass in output mass coordinate?
- iexclude_core_mass = .true.   ! Needs to be true if to be read by Phantom
-
- h       = hsoft * solarr      ! Convert to cm
- hphi_cm = hphi  * solarr      ! Convert to cm
- mc      = mcore * solarm      ! Convert to g
- call interpolator(r,h,hidx)   ! Find index in r closest to h
- msoft = m(hidx) - mc
-
- call calc_rho_and_m(rho, m, r, mc, h)
- call calc_phi(r, mc, m-mc, hphi_cm, phi)
- call calc_pres(r, rho, phi, pres)
-
- call calc_temp_and_ene(rho(1),pres(1),ene(1),temp(1),ierr)
- if (ierr /= 0) call fatal('set_softened_core','EoS not one of: adiabatic, ideal gas plus radiation, MESA in set_softened_core')
- do i = 2,size(rho)-1
-    eneguess = ene(i-1)
-    call calc_temp_and_ene(rho(i),pres(i),ene(i),temp(i),ierr,eneguess)
- enddo
- ene(size(rho))  = 0. ! Zero surface internal energy
- temp(size(rho)) = 0. ! Zero surface temperature
-
- ! Reverse arrays so that data is sorted from stellar surface to stellar centre.
- if (isort_decreasing) then
-    call flip_array(m)
-    call flip_array(pres)
-    call flip_array(temp)
-    call flip_array(r)
-    call flip_array(rho)
-    call flip_array(ene)
+ ! set mu, X, Z mass fractions to be their values at R/2
+ if ((ieos == 10) .or. (ieos == 12)) then
+    call get_composition(r,den,pres,temp,X,Y,X_in,Z_in,gmw)
+    write(*,'(1x,a,f7.5,a,f7.5,a,f7.5)') 'Using composition at R/2: X = ',X_in,', Z = ',Z_in,', mu = ',gmw
  endif
+ call init_eos(ieos,ierr)
+ if (ierr /= 0) call fatal('set_softened_core','could not initialise equation of state')
 
- if (iexclude_core_mass) then
-    m = m - mc
- endif
+ ! get values of rcore and mcore
+ select case (isofteningopt)
+ case(1)
+    call find_mcore_given_hsoft(rcore,r,den,m,mcore,ierr)
+    if (ierr==1) call fatal('setup','Cannot find mcore that produces nice profile (mcore/m(h) > 0.98 reached)')
+ case(2)
+    call find_hsoft_given_mcore(mcore,r,den,m,rcore,ierr)
+    if (ierr==1) call fatal('setup','Cannot find softening length that produces nice profile (h/r(mcore) < 1.02 reached)')
+ case(3) ! Both rcore and mcore are specified, check if values are sensible
+    call check_hsoft_and_mcore(rcore,mcore,r,den,m,ierr)
+    if (ierr==1) call fatal('setup','mcore cannot exceed m(r=h)')
+    if (ierr==2) call fatal('setup','softenedrho/rho > tolerance')
+    if (ierr==3) call fatal('setup','drho/dr > 0 found in softened profile')
+ end select
+ hsoft = 0.5*rcore ! this is set by default so that we have the original unsoftened profile for r > hsoft
+
+ ! call core-softening subroutines
+ select case(isoftcore) ! choose type of core-softneing
+ case(1)
+    call set_cubic_core(mcore,rcore,hsoft,den,r,pres,m,ene,temp,ierr)
+    if (ierr /= 0) call fatal('setup','could not set softened core')
+ case(2)
+    call set_fixedS_softened_core(mcore,rcore,hsoft,den,r,pres,m,ene,temp,ierr)
+    !call set_fixedS_surface(mcore,mtab,den,r,pres,en,temp,ierr)
+    !call set_fixedS_star(mcore,rcore,mtab,den,r,pres,en,temp,ierr)
+    if (ierr /= 0) call fatal('setup','could not set fixed entropy softened core')
+ end select
 
 end subroutine set_softened_core
 
 
-!----------------------------------------------------------------
+!-----------------------------------------------------------------------
 !+
-!  Iteratively look for a value of mcore for given hsoft that
-!  produces a nice softened density profile
+!  Get composition (mean molecular weight, X, Z mass fractions) to be
+!  their values at R/2
 !+
-!----------------------------------------------------------------
-subroutine find_mcore_given_hsoft(hsoft,r,rho0,m0,mcore,ierr)
- real,    intent(in)  :: r(:),rho0(:),m0(:),hsoft
- real,    intent(out) :: mcore
- integer, intent(out) :: ierr
- real,    allocatable :: rho(:),drho(:),m(:)
- real                 :: h,mc,tolerance
- integer              :: hidx,counter=0
+!-----------------------------------------------------------------------
+subroutine get_composition(r,den,pres,temp,X,Y,Xfixed,Zfixed,mu)
+ use table_utils, only:interpolator
+ use physcon,     only:radconst,kb_on_mh
+ real, intent(in)     :: r(:),den(:),pres(:),temp(:),X(:),Y(:)
+ real, intent(out)    :: mu,Xfixed,Zfixed
+ real                 :: Rstar,pgas
+ integer              :: i
 
- h = hsoft * solarr ! Convert to cm
- call interpolator(r, h, hidx) ! Find index in r closest to h
- mc = 0.7*m0(hidx) ! Initialise profile to have very large softened mass
- tolerance = 1.3 ! How much we allow the softened density to exceed the original profile by
- ierr = 0
+ Rstar = r(size(r))
+ call interpolator(r, 0.5*Rstar, i)
+ pgas = pres(i) - radconst*temp(i)**4/3. ! Assuming pressure due to ideal gas + radiation
+ mu = (den(i) * kb_on_mh * temp(i)) / pgas
+ Xfixed = X(i)
+ Zfixed = 1. - Xfixed - Y(i)
 
- allocate(rho( size(rho0) ))
- allocate(m( size(m0) ))
- allocate(drho( size(rho0)-1 ))
- do
-    rho = rho0   ! Reset density
-    m   = m0     ! Reset mass
-    call calc_rho_and_m(rho, m, r, mc, h)
-    call diff(rho, drho)
-    if (all(rho/rho0 < tolerance) .and. all(drho(1:hidx) < 0)) exit
-    if (mc > 0.98*m0(hidx)) then
-       ierr = 1
-       exit
-    endif
-    mc = mc + 0.01*m0(hidx) ! Increase mcore/m(h) by 1 percent
-    counter = counter+1
- enddo
- ! Output mcore in solar masses
- mcore = mc / solarm
-end subroutine find_mcore_given_hsoft
-
-!----------------------------------------------------------------
-!+
-!  Iteratively look for a value of hsoft for given mcore that
-!  produces a nice softened density profile
-!+
-!----------------------------------------------------------------
-subroutine find_hsoft_given_mcore(mcore,r,rho0,m0,hsoft,ierr)
- real,    intent(in)  :: r(:),rho0(:),m0(:),mcore
- real,    intent(out) :: hsoft
- integer, intent(out) :: ierr
- real,    allocatable :: rho(:),drho(:),m(:)
- real                 :: h,mc,mh,tolerance
- integer              :: hidx
-
- mc = mcore * solarm ! Convert to g
- mh = mc / 0.7 ! Initialise h such that m(h) to be much larger than mcore
- tolerance = 1.3 ! How much we allow the softened density to exceed the original profile by
- ierr = 0
- allocate(rho( size(rho0) ))
- allocate(m( size(m0) ))
- allocate(drho( size(rho0)-1 ))
- do
-    call interpolator(m0, mh, hidx)
-    h   = r(hidx)
-    rho = rho0   ! Reset density
-    m   = m0     ! Reset mass
-    call calc_rho_and_m(rho, m, r, mc, h)
-    call diff(rho, drho)
-    if (all(rho/rho0 < tolerance) .and. all(drho(1:hidx) < 0)) exit
-    if (mc > 0.98*m0(hidx)) then
-       ierr = 1
-       exit
-    endif
-    call interpolator(m0, 1.3*mc, hidx)
-    mh = 1./(1./mh + 0.01/mc) ! Increase mcore/m(h) by 1 percent
- enddo
- ! Write out hsoft in solar radii
- hsoft = h / solarr
-end subroutine find_hsoft_given_mcore
-
-!----------------------------------------------------------------
-!+
-!  Check for sensible values of hsoft and mcore, returning errors.
-!  Called in setup_star.f90 when both hsoft and mcore are chosen
-!  by user
-!+
-!----------------------------------------------------------------
-subroutine check_hsoft_and_mcore(hsoft,mcore,r,rho0,m0,ierr)
- real,    intent(in)  :: r(:),rho0(:),m0(:),mcore
- real,    intent(out) :: hsoft
- integer, intent(out) :: ierr
- real,    allocatable :: rho(:),drho(:),m(:)
- real                 :: h,mc,msoft,tolerance
- integer              :: hidx
- ierr = 0
- tolerance = 1.5 ! How much we allow the softened density to exceed the original profile by
- h = hsoft * solarr ! Convert to cm
- mc = mcore * solarm ! Convert to g
- call interpolator(r, h, hidx) ! Find index in r closest to h
- msoft = m0(hidx) - mc
-
- if (msoft < 0.) ierr = 1
-
- allocate(rho( size(rho0) ))
- allocate(m( size(m0) ))
- allocate(drho( size(rho0)-1 ))
- rho = rho0
- m   = m0
- call calc_rho_and_m(rho, m, r, mc, h)
- if (any(rho/rho0 > tolerance)) ierr = 2
-
- call diff(rho, drho)
- if (any(drho(1:hidx) > 0)) ierr = 3
-end subroutine check_hsoft_and_mcore
-
-
-subroutine calc_rho_and_m(rho,m,r,mc,h)
- real, intent(in)    :: r(:)
- real, intent(inout) :: rho(:),m(:)
- real, intent(in)    :: mc,h
- real                :: a,b,d,msoft,drhodr_h
- integer             :: hidx
-
- call interpolator(r,h,hidx) ! Find index in r closest to h
- msoft    = m(hidx) - mc
- drhodr_h = (rho(hidx+1) - rho(hidx)) / (r(hidx+1) - r(hidx)) ! drho/dr at r = h
-
- ! a, b, d: Coefficients of cubic density profile defined by rho(r) = ar**3 + br**2 + d
- a = 2./h**2 * drhodr_h - 10./h**3 * rho(hidx) + 7.5/pi/h**6 * msoft
- b = 0.5*drhodr_h/h - 1.5*a*h
- d = rho(hidx) - 0.5*h*drhodr_h + 0.5*a*h**3
-
- rho(1:hidx) = a*r(1:hidx)**3 + b*r(1:hidx)**2 + d
-
- ! Mass is then given by m(r) = mcore + 4*pi (1/6 a r^6 + 1/5 b r^5 + 1/3 d r^3)
- m(1:hidx) = mc + 4.*pi * (1./6. * a * r(1:hidx)**6 + 0.2 * b * r(1:hidx)**5 + &
-                           1./3. * d * r(1:hidx)**3)
-end subroutine calc_rho_and_m
-
-
-subroutine calc_phi(r,mc,mgas,hphi,phi)
- use kernel, only:kernel_softening
- real, intent(in)               :: r(:),mgas(:),mc,hphi
- real, allocatable              :: q(:),q2(:),phi_core(:),phi_gas(:)
- real, allocatable, intent(out) :: phi(:)
- real                           :: dum
- integer                        :: i
-
- ! The gravitational potential is needed to integrate the pressure profile using the
- ! equation of hydrostatic equilibrium. First calculate gravitational potential due
- ! to point mass core, using softening kernel selected in Phantom. Then calculate the
- ! gravitational potential due to the softened gas.
-
- ! Gravitational potential due to primary core
- allocate(phi(size(r)), phi_core(size(r)), phi_gas(size(r)), q(size(r)), q2(size(r)))
- q  = r / hphi
- q2 = q**2
- do i = 1,size(r)
-    call kernel_softening(q2(i),q(i),phi_core(i),dum)
- enddo
- deallocate(q,q2)
- phi_core = gg * phi_core * mc / hphi
-
- ! Gravitational potential due to softened gas
- phi_gas(size(r)) = - gg * mgas(size(r)) / r(size(r)) ! Surface boundary condition for phi
- do i = 1,size(r)-1
-    phi_gas(size(r)-i) = phi_gas(size(r)-i+1) - gg * mgas(size(r)-i) / r(size(r)-i)**2. &
-                                               * (r(size(r)-i+1) - r(size(r)-i))
- enddo
-
- phi = phi_gas + phi_core
-
-end subroutine calc_phi
-
-!----------------------------------------------------------------
-!+
-!  Calculate pressure by integrating the equation of hydrostatic
-!  equilibrium given the gravitational potential and the density
-!  profile
-!+
-!----------------------------------------------------------------
-subroutine calc_pres(r,rho,phi,pres)
- real, intent(in)  :: rho(:),phi(:),r(:)
- real, intent(out) :: pres(:)
- integer           :: i
-
- pres(size(r)) = 0 ! Set boundary condition of zero pressure at stellar surface
- do i = 1,size(r)-1
-    ! Reverse Euler
-    pres(size(r)-i) = pres(size(r)-i+1) + rho(size(r)-i+1) * (phi(size(r)-i+1) - phi(size(r)-i))
- enddo
-
-end subroutine calc_pres
+end subroutine get_composition
 
 end module setsoftenedcore

--- a/src/setup/set_stellar_core.f90
+++ b/src/setup/set_stellar_core.f90
@@ -23,9 +23,9 @@ contains
 !  Add a sink particle as a stellar core
 !+
 !-----------------------------------------------------------------------
-subroutine set_stellar_core(nptmass,xyzmh_ptmass,vxyz_ptmass,mcore,hsoft,ihsoft)
+subroutine set_stellar_core(nptmass,xyzmh_ptmass,vxyz_ptmass,mcore,hsoft)
+ use part, only:ihsoft
  integer, intent(out) :: nptmass
- integer, intent(in)  :: ihsoft
  real, intent(out)    :: xyzmh_ptmass(:,:),vxyz_ptmass(:,:)
  real, intent(in)     :: mcore,hsoft
  integer              :: n

--- a/src/setup/set_stellar_core.f90
+++ b/src/setup/set_stellar_core.f90
@@ -23,12 +23,11 @@ contains
 !  Add a sink particle as a stellar core
 !+
 !-----------------------------------------------------------------------
-subroutine set_stellar_core(nptmass,xyzmh_ptmass,vxyz_ptmass,mcore,hsoft)
- use part, only:ihsoft
+subroutine set_stellar_core(nptmass,xyzmh_ptmass,vxyz_ptmass,ihsoft,mcore,hsoft)
  integer, intent(out) :: nptmass
  real, intent(out)    :: xyzmh_ptmass(:,:),vxyz_ptmass(:,:)
  real, intent(in)     :: mcore,hsoft
- integer              :: n
+ integer              :: n,ihsoft
  nptmass                = 1
  n                      = nptmass
  xyzmh_ptmass(:,n)      = 0. ! zero all quantities by default

--- a/src/setup/setup_star.f90
+++ b/src/setup/setup_star.f90
@@ -122,7 +122,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use units,           only:set_units,select_unit,utime,unit_density,unit_pressure,unit_ergg
  use kernel,          only:hfact_default
  use rho_profile,     only:rho_uniform,rho_polytrope,rho_piecewise_polytrope, &
-                           rho_evrard,read_mesa_file,read_mesa,read_kepler_file, &
+                           rho_evrard,read_mesa,read_kepler_file, &
                            write_softened_profile
  use extern_densprofile, only:write_rhotab,rhotabfile,read_rhotab_wrapper
  use eos,             only:init_eos,init_eos_9,finish_eos,equationofstate,gmw,X_in,Z_in

--- a/src/setup/setup_star.f90
+++ b/src/setup/setup_star.f90
@@ -128,7 +128,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use eos,             only:init_eos,init_eos_9,finish_eos,equationofstate,gmw,X_in,Z_in
  use eos_idealplusrad,only:get_idealplusrad_enfromtemp,get_idealgasplusrad_tempfrompres
  use eos_mesa,        only:get_eos_eT_from_rhop_mesa, get_eos_pressure_temp_mesa
- use part,            only:eos_vars,itemp,store_temperature
+ use part,            only:eos_vars,itemp,store_temperature,ihsoft
  use setstellarcore,  only:set_stellar_core
  use setsoftenedcore, only:set_softened_core
  use part,            only:nptmass,xyzmh_ptmass,vxyz_ptmass
@@ -287,7 +287,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
     if (isoftcore > 0) then
        call set_softened_core(isoftcore,isofteningopt,r,den,pres,mtab,en,temp,Xfrac,Yfrac,rcore,mcore,ierr) ! sets mcore, rcore
        hsoft = 0.5 * rcore
-       call set_stellar_core(nptmass,xyzmh_ptmass,vxyz_ptmass,mcore,hsoft)
+       call set_stellar_core(nptmass,xyzmh_ptmass,vxyz_ptmass,ihsoft,mcore,hsoft)
        call write_softened_profile(outputfilename,mtab,pres,temp,r,den,en)
        densityfile = outputfilename ! Have the read_mesa subroutine read the softened profile instead
     else
@@ -332,7 +332,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  !
  ! add sink particle stellar core
  !
- if (isinkcore) call set_stellar_core(nptmass,xyzmh_ptmass,vxyz_ptmass,mcore,hsoft)
+ if (isinkcore) call set_stellar_core(nptmass,xyzmh_ptmass,vxyz_ptmass,ihsoft,mcore,hsoft)
 
  nstar = int(npart_total,kind=(kind(nstar)))
  massoftype(igas) = Mstar/nstar

--- a/src/setup/setup_star.f90
+++ b/src/setup/setup_star.f90
@@ -73,7 +73,7 @@ module setup
  integer            :: need_iso, need_temp
  real(kind=8)       :: udist,umass
  real               :: Rstar,Mstar,rhocentre,maxvxyzu,ui_coef
- real               :: initialtemp, initialgmw, initialx, initialz
+ real               :: initialtemp
  real               :: mcore,rcore,hsoft
  logical            :: iexist,input_polyk,isinkcore
  logical            :: use_exactN,relax_star_in_setup,write_rho_to_file
@@ -179,9 +179,9 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  iprofile    = 1
  EOSopt      = 1
  initialtemp = 1.0e7
- initialgmw  = 2.381
- initialx    = 0.74
- initialz    = 0.02
+ gmw         = 0.5988
+ X_in        = 0.74
+ Z_in        = 0.02
  isoftcore   = 0
  isinkcore   = .false.
  mcore         = 0.
@@ -247,7 +247,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  !
  call set_units(dist=udist,mass=umass,G=1.d0)
  !
- ! setup particles
+ ! set up particles
  !
  npartoftype(:) = 0
  nstar          = 0
@@ -257,7 +257,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  !polytropic
  calc_polyk = .true.
  !
- ! setup tabulated density profile
+ ! set up tabulated density profile
  !
  calc_polyk = .true.
  if (ieos==9) call init_eos_9(EOSopt)
@@ -562,9 +562,9 @@ subroutine setup_interactive(polyk,gamma,iexist,id,master,ierr)
           call prompt('Enter softening length of the sink particle core',hsoft,0.)
        endif
        if (ieos==10) then
-          call prompt('Enter mean molecular weight',initialgmw,0.0)
-          call prompt('Enter hydrogen mass fraction (X)',initialx,0.0,1.0)
-          call prompt('Enter metals mass fraction (Z)',initialz,0.0,1.0)
+          call prompt('Enter mean molecular weight',gmw,0.0)
+          call prompt('Enter hydrogen mass fraction (X)',X_in,0.0,1.0)
+          call prompt('Enter metals mass fraction (Z)',Z_in,0.0,1.0)
        endif
     case(1)
        isinkcore = .true. ! Create sink particle core automatically
@@ -738,9 +738,9 @@ subroutine write_setupfile(filename,gamma,polyk)
     if (input_polyk) call write_inopt(polyk,'polyk','polytropic constant (cs^2 if isothermal)',iunit)
  case(10)
     if (isoftcore == 0) then
-       call write_inopt(initialgmw,'mu','mean molecular weight',iunit)
-       call write_inopt(initialx,'X','hydrogen mass fraction',iunit)
-       call write_inopt(initialz,'Z','metallicity',iunit)
+       call write_inopt(gmw,'mu','mean molecular weight',iunit)
+       call write_inopt(X_in,'X','hydrogen mass fraction',iunit)
+       call write_inopt(Z_in,'Z','metallicity',iunit)
     endif
  end select
  if (iprofile==ievrard) then
@@ -847,9 +847,9 @@ subroutine read_setupfile(filename,gamma,polyk,ierr)
  case(10)
     ! if softening stellar core, composition is automatically determined at R/2
     if (isoftcore == 0) then
-       call read_inopt(initialgmw,'mu',db,errcount=nerr)
-       call read_inopt(initialx,'X',db,errcount=nerr)
-       call read_inopt(initialz,'Z',db,errcount=nerr)
+       call read_inopt(gmw,'mu',db,errcount=nerr)
+       call read_inopt(X_in,'X',db,errcount=nerr)
+       call read_inopt(Z_in,'Z',db,errcount=nerr)
     endif
  end select
  if (iprofile==ievrard) then

--- a/src/utils/moddump_binary.f90
+++ b/src/utils/moddump_binary.f90
@@ -35,7 +35,8 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  use extern_corotate,   only:icompanion_grav,companion_xpos,companion_mass,primarycore_xpos,&
                              primarycore_mass,primarycore_hsoft,hsoft
  use infile_utils,      only:open_db_from_file,inopts,read_inopt,close_db
- use rho_profile,       only:read_mesa_file
+ use table_utils,       only:yinterp
+ use rho_profile,       only:read_mesa
  use dim,               only:maxptmass
  use io,                only:fatal
  use timestep,          only:tmax,dtmax
@@ -44,15 +45,14 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  integer, intent(inout)    :: npartoftype(:)
  real,    intent(inout)    :: massoftype(:)
  real,    intent(inout)    :: xyzh(:,:),vxyzu(:,:)
- integer                   :: i,ierr,setup_case,two_sink_case = 1,three_sink_case = 1,npts,irhomax,n
+ integer                   :: i,ierr,setup_case,two_sink_case = 1,three_sink_case = 1,irhomax,n
  integer                   :: iremove = 2
  real                      :: primary_mass,companion_mass_1,companion_mass_2,mass_ratio,m1,a,hsoft2
  real                      :: mass_donor,separation,newCoM,period,m2,primarycore_xpos_old
  real                      :: a1,a2,e,omega_vec(3),omegacrossr(3),vr = 0.0,hsoft_default = 3
  real                      :: hacc1,hacc2,hacc3,hsoft_primary,mcore,comp_shift=100,sink_dist,vel_shift
  real                      :: mcut,rcut,Mstar,radi,rhopart,rhomax = 0.0
- integer, parameter        :: ng_max = 5000
- real                      :: r(ng_max),den(ng_max),pres(ng_max),temp(ng_max),enitab(ng_max)
+ real, allocatable         :: r(:),den(:),pres(:),temp(:),enitab(:),Xfrac(:),Yfrac(:),m(:)
  logical                   :: corotate_answer,iprimary_grav_ans
  character(len=20)         :: filename = 'binary.in'
  character(len=100)        :: densityfile
@@ -295,7 +295,9 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
        call prompt('Enter filename of the input stellar profile', densityfile)
        call prompt('Enter mass of the created point mass core', mcut)
        call prompt('Enter softening length of the point mass', hsoft_default)
-       call read_mesa_file(trim(densityfile),ng_max,npts,r,den,pres,temp,enitab,Mstar,ierr,mcut,rcut)
+
+       call read_mesa(densityfile,den,r,pres,m,enitab,temp,Xfrac,Yfrac,Mstar,ierr,cgsunits=.false.)
+       rcut = yinterp(r,m,mcut)
 
        irhomax = 1
        do i=1,npart
@@ -314,7 +316,6 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
        xyzmh_ptmass(4,n)   = 0.  ! zero mass
        xyzmh_ptmass(ihsoft,n) = hsoft_default
        vxyz_ptmass(:,n) = 0.     ! zero velocity, get this by accreting
-
 
        do i=1,npart
           radi = sqrt((xyzh(1,i)-xyzh(1,irhomax))**2 + &


### PR DESCRIPTION
Cleanup of star setup, core-softening, and MESA file reading modules. Closes issue #91
- setup: Wrap up core-softening code into subroutine `set_softened_core` in the new module `setsoftenedcore`. `set_softened_core` finds the composition, finds the core mass and radius, and calls the softening routines `set_cubic_core` or `set_fixedS_softened_core` depending on the softening option. The cubic core softening module has been renamed from `setsoftenedcore` to `setcubiccore`
- setup: Variable name `hdens` has been changed to `rcore`.
- MESA reading in `rho_profile`: Subroutine `read_mesa` has been upgraded to read both P12-styled profiles and MESA profiles. `read_mesa_file` is no longer necessary.
