### PR TITLE
New sink formation criteria

### DIFF
--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -521,6 +521,11 @@ subroutine startrun(infile,logfile,evfile,dumpfile)
  endif
  call init_ptmass(nptmass,logfile,dumpfile)
  if (gravity .and. icreate_sinks > 0) then
+    if (icreate_sinks==1) then
+       write(iprint,*) 'Sink will be created if particles within h_acc meet formation criteria.'
+    elseif (icreate_sinks==2) then
+       write(iprint,*) 'Sink will be created if particles within 2h meet formation criteria.'
+    endif
     write(iprint,*) 'Sink radius and critical densities:'
     write(iprint,*) ' h_acc                    == ',h_acc*udist,'cm'
     write(iprint,*) ' h_fact*(m/rho_crit)^(1/3) = ',hfactfile*(massoftype(igas)/rho_crit)**(1./3.)*udist,'cm'

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -521,11 +521,6 @@ subroutine startrun(infile,logfile,evfile,dumpfile)
  endif
  call init_ptmass(nptmass,logfile,dumpfile)
  if (gravity .and. icreate_sinks > 0) then
-    if (icreate_sinks==1) then
-       write(iprint,*) 'Sink will be created if particles within h_acc meet formation criteria.'
-    elseif (icreate_sinks==2) then
-       write(iprint,*) 'Sink will be created if particles within 2h meet formation criteria.'
-    endif
     write(iprint,*) 'Sink radius and critical densities:'
     write(iprint,*) ' h_acc                    == ',h_acc*udist,'cm'
     write(iprint,*) ' h_fact*(m/rho_crit)^(1/3) = ',hfactfile*(massoftype(igas)/rho_crit)**(1./3.)*udist,'cm'

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -1053,7 +1053,7 @@ subroutine copy_particle(src,dst,new_part)
  fext(:,dst)  = fext(:,src)
  if (mhd) then
     Bevol(:,dst) = Bevol(:,src)
-    Bxyz(:,dst)  = Bxyz(:,dst)
+    Bxyz(:,dst)  = Bxyz(:,src)
  endif
  if (do_radiation) then
     rad(:,dst) = rad(:,src)

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -54,7 +54,7 @@ module ptmass
 #endif
 
  ! settings affecting routines in module (read from/written to input file)
- integer, public :: icreate_sinks = 0
+ integer, public :: icreate_sinks = 0  ! 0 = do not create sinks; 1 (2) = create sink if particles with hacc (2h) meet criteria
  real,    public :: rho_crit_cgs  = 1.e-10
  real,    public :: r_crit = 5.e-3
  real,    public :: h_acc  = 1.e-3
@@ -818,7 +818,7 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,vxyzu,fxyzu,fext,divcurlv,pote
                   ispinx,ispiny,ispinz,fxyz_ptmass_sinksink
  use dim,    only:maxp,maxneigh,maxvxyzu
  use kdtree, only:getneigh
- use kernel, only:kernel_softening
+ use kernel, only:kernel_softening,radkern
  use io,     only:id,iprint,fatal,iverbose,nprocs
 #ifdef PERIODIC
  use boundary, only:dxbound,dybound,dzbound
@@ -853,13 +853,14 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,vxyzu,fxyzu,fext,divcurlv,pote
  real    :: xyzcache(maxcache,3)
  real    :: dptmass(ndptmass,nptmass+1)
  real    :: xi,yi,zi,hi,hi1,hi21,xj,yj,zj,hj1,hj21,xk,yk,zk,hk1
- real    :: rij2,rik2,rjk2,dx,dy,dz,h_acc2
+ real    :: rij2,rik2,rjk2,dx,dy,dz
  real    :: vxi,vyi,vzi,dv2,dvx,dvy,dvz,rhomax
  real    :: alpha_grav,alphabeta_grav,radxy2,radxz2,radyz2
  real    :: etot,epot,ekin,etherm,erot,erotx,eroty,erotz
  real    :: rcrossvx,rcrossvy,rcrossvz,fxj,fyj,fzj
  real    :: pmassi,pmassj,pmassk,ponrhoj,rhoj,spsoundj
  real    :: q2i,qi,psofti,psoftj,psoftk,fsoft,epot_mass,epot_rad,pmassgas1
+ real    :: hcheck,hcheck2,f_acc_local
  real(4) :: divvi,potenj_min,poteni
  integer :: ifail,nacc,j,k,n,nk,itype,itypej,itypek,ifail_array(inosink_max),id_rhomax
  logical :: accreted,iactivej,isgasj,isdustj,calc_exact_epot
@@ -915,6 +916,19 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,vxyzu,fxyzu,fext,divcurlv,pote
  call bcast_mpi(ibin_itest,id_rhomax)
 #endif
  call bcast_mpi(poteni,id_rhomax)
+ !
+ ! determine radius in which to check the criteria
+ !
+ if (icreate_sinks==2) then
+    ! the sphNG radius
+    hcheck      = radkern*hi ! will fail a check and exit if hcheck > h_acc
+    f_acc_local = max(f_acc,hcheck/h_acc)
+ else
+    ! the default (original Phantom radius)
+    hcheck      = h_acc
+    f_acc_local = 1.0
+ endif
+ hcheck2 = hcheck*hcheck
 
  hi1  = 1.0/hi
  hi21 = hi1**2
@@ -961,7 +975,6 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,vxyzu,fxyzu,fext,divcurlv,pote
     ifail_array(inosink_h) = 1
  endif
 
- h_acc2 = h_acc*h_acc
  ekin   = 0.
  epot   = -epsilon(epot)
  etherm = 0.
@@ -972,16 +985,16 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,vxyzu,fxyzu,fext,divcurlv,pote
  epot_mass = 0.
  epot_rad  = 0.
 
- ! CHECK 3: all neighbours within h_acc are all active ( & perform math for checks 4-6)
- ! find neighbours within h_acc
- call getneigh_pos((/xi,yi,zi/),0.,h_acc,3,listneigh,nneigh,xyzh,xyzcache,maxcache,ifirstincell)
+ ! CHECK 3: all neighbours are all active ( & perform math for checks 4-6)
+ ! find neighbours within the checking radius of h_acc or 2h
+ call getneigh_pos((/xi,yi,zi/),0.,hcheck,3,listneigh,nneigh,xyzh,xyzcache,maxcache,ifirstincell)
  ! determine if we should approximate epot
  calc_exact_epot = .true.
  if ((nneigh_thresh > 0 .and. nneigh > nneigh_thresh) .or. (nprocs > 1)) calc_exact_epot = .false.
 !$omp parallel default(none) &
 !$omp shared(nprocs) &
 !$omp shared(maxp,maxphase) &
-!$omp shared(nneigh,listneigh,h_acc2,xyzh,xyzcache,vxyzu,massoftype,iphase,pmassgas1,calc_exact_epot) &
+!$omp shared(nneigh,listneigh,xyzh,xyzcache,vxyzu,massoftype,iphase,pmassgas1,calc_exact_epot,hcheck2) &
 !$omp shared(itest,id,id_rhomax,ifail,xi,yi,zi,hi,vxi,vyi,vzi,hi1,hi21,itype,pmassi,ieos,gamma,poten) &
 #ifdef PERIODIC
 !$omp shared(dxbound,dybound,dzbound) &
@@ -1024,7 +1037,7 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,vxyzu,fxyzu,fext,divcurlv,pote
     if (abs(dz) > 0.5*dzbound) dz = dz - dzbound*SIGN(1.0,dz)
 #endif
     rij2 = dx*dx + dy*dy + dz*dz
-    if (rij2 < h_acc2) then
+    if (rij2 < hcheck2) then
 
 #ifdef IND_TIMESTEPS
        ibin_wake(j) = max(ibin_wake(j),ibin_itest)
@@ -1042,7 +1055,7 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,vxyzu,fxyzu,fext,divcurlv,pote
        hj21 = hj1**2
 
        ! kinetic energy
-       dv2 = dvx*dvx + dvy*dvy + dvz*dvz
+       dv2  = dvx*dvx + dvy*dvy + dvz*dvz
        ekin = ekin + pmassj*dv2
 
        ! rotational energies around each axis
@@ -1121,7 +1134,7 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,vxyzu,fxyzu,fext,divcurlv,pote
                 if (abs(dz) > 0.5*dzbound) dz = dz - dzbound*SIGN(1.0,dz)
 #endif
                 rik2 = dx*dx + dy*dy + dz*dz
-                if (rik2 < h_acc2) then
+                if (rik2 < hcheck2) then
                    dx = xj - xk
                    dy = yj - yk
                    dz = zj - zk
@@ -1300,7 +1313,7 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,vxyzu,fxyzu,fext,divcurlv,pote
        call ptmass_accrete(nptmass,nptmass,xyzh(1,j),xyzh(2,j),xyzh(3,j),xyzh(4,j),&
                            vxyzu(1,j),vxyzu(2,j),vxyzu(3,j),fxj,fyj,fzj, &
                            itypej,pmassj,xyzmh_ptmass,vxyz_ptmass,accreted, &
-                           dptmass,time,1.0,ibin_wakei,ibin_wakei)
+                           dptmass,time,f_acc_local,ibin_wakei,ibin_wakei)
 
        if (accreted) nacc = nacc + 1
     enddo

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -54,7 +54,7 @@ module ptmass
 #endif
 
  ! settings affecting routines in module (read from/written to input file)
- integer, public :: icreate_sinks = 0  ! 0 = do not create sinks; 1 (2) = create sink if particles with hacc (2h) meet criteria
+ integer, public :: icreate_sinks = 0
  real,    public :: rho_crit_cgs  = 1.e-10
  real,    public :: r_crit = 5.e-3
  real,    public :: h_acc  = 1.e-3
@@ -919,17 +919,12 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,vxyzu,fxyzu,fext,divcurlv,pote
  !
  ! determine radius in which to check the criteria
  !
- if (icreate_sinks==2) then
-    ! the sphNG radius
-    hcheck      = radkern*hi ! will fail a check and exit if hcheck > h_acc
-    f_acc_local = max(f_acc,hcheck/h_acc)
- else
-    ! the default (original Phantom radius)
-    hcheck      = h_acc
-    f_acc_local = 1.0
- endif
- hcheck2 = hcheck*hcheck
-
+ hcheck      = radkern*hi               ! = h_acc in previous versions of Phantom; current method is faster
+ f_acc_local = max(f_acc,hcheck/h_acc)  ! = 1.0   in previous versions of Phantom; current method is faster
+ hcheck2     = hcheck*hcheck
+ !
+ ! initialise variables
+ !
  hi1  = 1.0/hi
  hi21 = hi1**2
  if (maxphase==maxp) then
@@ -986,7 +981,7 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,vxyzu,fxyzu,fext,divcurlv,pote
  epot_rad  = 0.
 
  ! CHECK 3: all neighbours are all active ( & perform math for checks 4-6)
- ! find neighbours within the checking radius of h_acc or 2h
+ ! find neighbours within the checking radius of hcheck
  call getneigh_pos((/xi,yi,zi/),0.,hcheck,3,listneigh,nneigh,xyzh,xyzcache,maxcache,ifirstincell)
  ! determine if we should approximate epot
  calc_exact_epot = .true.

--- a/src/setup/set_unifdis.f90
+++ b/src/setup/set_unifdis.f90
@@ -72,7 +72,7 @@ subroutine set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
 
  integer            :: i,j,k,l,m,nx,ny,nz,npnew,npin,ierr
  integer            :: jy,jz,ipart,maxp,iseed,icoord,igeom
- integer(kind=8)    :: iparttot
+ integer(kind=8)    :: iparttot,iparttot0
  real               :: delx,dely
  real               :: deltax,deltay,deltaz,dxbound,dybound,dzbound
  real               :: xstart,ystart,zstart,xi,yi,zi,rcyl2,rr2
@@ -143,6 +143,7 @@ subroutine set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
  else
     iparttot = 0
  endif
+ iparttot0 = iparttot
 
  ! Suppress output to the terminal if wished - handy for setups which call this subroutine frequently
  is_verbose = .true.
@@ -520,7 +521,7 @@ subroutine set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
     nz = nint(dzbound/delta)
     npnew = nx*ny*nz
 
-    do while (iparttot < np+npnew)
+    do while (iparttot < iparttot0+npnew)
        xi = xmin + ran2(iseed)*dxbound
        yi = ymin + ran2(iseed)*dybound
        zi = zmin + ran2(iseed)*dzbound

--- a/src/setup/setup_disc.F90
+++ b/src/setup/setup_disc.F90
@@ -247,6 +247,9 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
 
  !--compute number of discs based on setup options
  call number_of_discs()
+ iuse_disc(1) = .false.
+ iuse_disc(2) = .true.
+ iuse_disc(3) = .true.
 
  !--setup equation of state
  call equation_of_state(gamma)

--- a/src/tests/test_ptmass.F90
+++ b/src/tests/test_ptmass.F90
@@ -62,7 +62,7 @@ subroutine test_ptmass(ntests,npass)
 #endif
  use mpiutils,        only:bcast_mpi,reduce_in_place_mpi,reduceloc_mpi
  integer, intent(inout) :: ntests,npass
- integer                :: i,nsteps,nbinary_tests,itest,jtest,nerr,nwarn,itestp
+ integer                :: i,nsteps,nbinary_tests,itest,nerr,nwarn,itestp
  integer                :: nparttot
  logical                :: test_binary,test_accretion,test_createsink, test_softening
  logical                :: accreted
@@ -473,23 +473,12 @@ subroutine test_ptmass(ntests,npass)
 !  Test sink particle creation
 !
  testcreatesink: if (test_createsink) then
-    do jtest=1,2
-    select case(jtest)
-    case(1)
-       icreate_sinks = 1
-    case default
-       icreate_sinks = 2
-    end select
     do itest=1,2
        select case(itest)
        case(2)
-          if (id==master) then
-             write(*,"(/,a,I1)") '--> testing sink particle creation (sin) for icreate_sinks = ',icreate_sinks
-          endif
+          if (id==master) write(*,"(/,a)") '--> testing sink particle creation (sin)'
        case default
-          if (id==master) then
-             write(*,"(/,a,I1)") '--> testing sink particle creation (uniform density) for icreate_sinks = ',icreate_sinks
-          endif
+          if (id==master) write(*,"(/,a)") '--> testing sink particle creation (uniform density)'
        end select
        xyzmh_ptmass(:,:) = 0.
        vxyz_ptmass(:,:) = 0.
@@ -541,6 +530,7 @@ subroutine test_ptmass(ntests,npass)
        ! and make sure that gravitational potential energy has been computed
        !
        tree_accuracy = 0.
+       icreate_sinks = 1
        iverbose = 1
        call get_derivs_global()
        !
@@ -605,7 +595,6 @@ subroutine test_ptmass(ntests,npass)
 
        iverbose = 0
        call finish_ptmass(nptmass)
-    enddo
     enddo
  endif testcreatesink
 

--- a/src/tests/test_ptmass.F90
+++ b/src/tests/test_ptmass.F90
@@ -62,7 +62,7 @@ subroutine test_ptmass(ntests,npass)
 #endif
  use mpiutils,        only:bcast_mpi,reduce_in_place_mpi,reduceloc_mpi
  integer, intent(inout) :: ntests,npass
- integer                :: i,nsteps,nbinary_tests,itest,nerr,nwarn,itestp
+ integer                :: i,nsteps,nbinary_tests,itest,jtest,nerr,nwarn,itestp
  integer                :: nparttot
  logical                :: test_binary,test_accretion,test_createsink, test_softening
  logical                :: accreted
@@ -473,12 +473,23 @@ subroutine test_ptmass(ntests,npass)
 !  Test sink particle creation
 !
  testcreatesink: if (test_createsink) then
+    do jtest=1,2
+    select case(jtest)
+    case(1)
+       icreate_sinks = 1
+    case default
+       icreate_sinks = 2
+    end select
     do itest=1,2
        select case(itest)
        case(2)
-          if (id==master) write(*,"(/,a)") '--> testing sink particle creation (sin)'
+          if (id==master) then
+             write(*,"(/,a,I1)") '--> testing sink particle creation (sin) for icreate_sinks = ',icreate_sinks
+          endif
        case default
-          if (id==master) write(*,"(/,a)") '--> testing sink particle creation (uniform density)'
+          if (id==master) then
+             write(*,"(/,a,I1)") '--> testing sink particle creation (uniform density) for icreate_sinks = ',icreate_sinks
+          endif
        end select
        xyzmh_ptmass(:,:) = 0.
        vxyz_ptmass(:,:) = 0.
@@ -530,7 +541,6 @@ subroutine test_ptmass(ntests,npass)
        ! and make sure that gravitational potential energy has been computed
        !
        tree_accuracy = 0.
-       icreate_sinks = 1
        iverbose = 1
        call get_derivs_global()
        !
@@ -596,13 +606,15 @@ subroutine test_ptmass(ntests,npass)
        iverbose = 0
        call finish_ptmass(nptmass)
     enddo
+    enddo
  endif testcreatesink
 
  !--reset stuff
  nptmass = 0
 
- ! clean up temporary files
+ ! clean up temporary files & turn off sink creation
  itmp = 201
+ icreate_sinks = 0
  close(iskfile,iostat=ierr)
  write(filename,"(i3)") iskfile
  filename = 'fort.'//trim(adjustl(filename))

--- a/src/tests/test_sedov.F90
+++ b/src/tests/test_sedov.F90
@@ -177,7 +177,7 @@ subroutine test_sedov(ntests,npass)
     momtotend = totmom
 
     nfailed(:) = 0
-    call checkval(etotend,etotin,1.3e-4,nfailed(1),'total energy')
+    call checkval(etotend,etotin,2.0e-4,nfailed(1),'total energy')  ! the required tolerance is 1.3e-4 (2e-4) for individual (global) timestepping
     call checkval(momtotend,momtotin,7.e-15,nfailed(2),'linear momentum')
 
     ! delete temporary files


### PR DESCRIPTION
added icreate_sinks=2, where the checks for sink formation are performed on the particles within 2h of the candidate gas particle; this is what sphNG does.  This method facilitates the quicker formation of sink particles than the original/default icreate_sinks=1 which checks all particles within h_acc.  
 