### PR TITLE
Thermal Floor + added Balsara & Kim defaults

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -746,6 +746,7 @@ endif
 
 ifeq ($(SETUP), balsarakim)
 #   Balsara-Kim 2004
+#   set BalsaraKim=.true. in setup_unifdis.f90 to initialise the correct defaults
     PERIODIC=yes
     SETUPFILE= setup_unifdis.f90
     MHD=yes

--- a/src/main/eos.F90
+++ b/src/main/eos.F90
@@ -119,6 +119,7 @@ module eos
     ierr_units_not_set   = 3, &
     ierr_isink_not_set   = 4, &
     ierr_iso_Tfloor      = 5
+
 contains
 
 !----------------------------------------------------------------
@@ -391,8 +392,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
        spsoundi = sqrt(gamma_local*ponrhoi)
        if (present(tempi)) tempi = temperature_coef*gmw*ponrhoi
     else
-       call fatal('eos','invoking KROME to calculate local gamma but variable '&
-                        'not passed in equationofstate (bad value for eos?)')
+       call fatal('eos','invoking KROME to calculate local gamma but variable not passed in equationofstate (bad ieos?)')
     endif
 
  case default

--- a/src/main/eos.F90
+++ b/src/main/eos.F90
@@ -99,6 +99,10 @@ module eos
  !--Mean molecular weight if temperature required
  real,    public :: gmw            = 2.381
  real,    public :: X_in = 0.74, Z_in = 0.02
+ !--Minimum temperature (failsafe to prevent u < 0)
+ logical, public, parameter :: use_Tfloor = .false.
+ real,    public            :: Tfloor     = 10. ![K]
+ real,    public            :: ufloor
 
  real            :: rhocritT,rhocrit0,rhocrit1,rhocrit2,rhocrit3
  real            :: fac2,fac3,log10polyk2,log10rhocritT,rhocritT0slope
@@ -113,8 +117,8 @@ module eos
     ierr_file_not_found  = 1, &
     ierr_option_conflict = 2, &
     ierr_units_not_set   = 3, &
-    ierr_isink_not_set   = 4
-
+    ierr_isink_not_set   = 4, &
+    ierr_iso_Tfloor      = 5
 contains
 
 !----------------------------------------------------------------
@@ -554,13 +558,13 @@ end function gamma_pwp
 !+
 !-----------------------------------------------------------------------
 subroutine init_eos(eos_type,ierr)
- use units,    only:unit_density,unit_velocity,unit_pressure
+ use units,    only:unit_density,unit_velocity,unit_pressure,unit_ergg
  use physcon,  only:mass_proton_cgs,kboltz
  use io,       only:error,warning
  use eos_mesa, only:init_eos_mesa
  use eos_helmholtz, only:eos_helmholtz_init
  use eos_shen, only:init_eos_shen_NL3
- use dim,      only:do_radiation
+ use dim,      only:maxvxyzu,do_radiation
 
  integer, intent(in)  :: eos_type
  integer, intent(out) :: ierr
@@ -576,6 +580,14 @@ subroutine init_eos(eos_type,ierr)
  !  c_s^2 = gamma*P/rho = gamma*kT/(gmw*m_p) -> T = P/rho * (gmw*m_p)/k
  !
  temperature_coef = mass_proton_cgs/kboltz * unit_velocity**2
+
+ !--calculate the energy floor in code units
+ if (gamma > 1.) then
+    ufloor = kboltz*Tfloor/((gamma-1.)*gmw*mass_proton_cgs)/unit_ergg
+ else
+    ufloor = 3.0*kboltz*Tfloor/(2.0*gmw*mass_proton_cgs)/unit_ergg
+ endif
+ if (use_Tfloor .and. maxvxyzu < 4) ierr = ierr_iso_Tfloor ! cannot floor isothermal simulation
 
  select case(eos_type)
  case(6)
@@ -1068,7 +1080,7 @@ end function diff
 subroutine eosinfo(eos_type,iprint)
  use dim,           only:maxvxyzu,gr
  use io,            only:fatal
- use units,         only:unit_density, unit_velocity
+ use units,         only:unit_density,unit_velocity,unit_ergg
  use eos_helmholtz, only:eos_helmholtz_eosinfo
  integer, intent(in) :: eos_type,iprint
  real, parameter     :: uthermcheck = 3.14159, rhocheck = 23.456
@@ -1154,6 +1166,11 @@ subroutine eosinfo(eos_type,iprint)
     call eos_helmholtz_eosinfo(iprint)
 
  end select
+ if (use_Tfloor) then
+    write(iprint,*)
+    write(iprint,"(3(a,Es10.3),a)") 'WARNING! Imposing temperature floor of = ',Tfloor,' K = ', &
+    ufloor*unit_ergg,' erg/g = ',ufloor,' code units'
+ endif
  write(iprint,*)
 
  return

--- a/src/main/h2cooling.f90
+++ b/src/main/h2cooling.f90
@@ -374,7 +374,6 @@ subroutine cool_func(temp, yn, dl, divv, abundances, ylam, rates)
  else
     itemp = int(log10(temp) / dtlog) + 1
     if (itemp  <=  0 .or. itemp  >  nmd) then
-       !print*, 'Fatal error in cool_func.F', itemp, temp
        call fatal('cool_func','bad temperature in cooling function',var='temp',val=temp,ival=itemp)
     endif
     dtemp = temp - temptab(itemp)

--- a/src/main/inject_sne.f90
+++ b/src/main/inject_sne.f90
@@ -81,14 +81,15 @@ subroutine inject_particles(time,dtlast_u,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
                             npart,npartoftype,dtinject)
  use io,      only:id,master
  use eos,     only:gamma
- use part,    only:rhoh,massoftype,igas
+ use part,    only:rhoh,massoftype,iphase,igas,iunknown
+ use partinject, only: updated_particle
  real,    intent(in)    :: time, dtlast_u
  real,    intent(inout) :: xyzh(:,:), vxyzu(:,:), xyzmh_ptmass(:,:), vxyz_ptmass(:,:)
  integer, intent(inout) :: npart
  integer, intent(inout) :: npartoftype(:)
  real,    intent(out)   :: dtinject
- integer            :: i,i_sn,ipart
- real    :: dx(3),uval,t_sn,r2
+ integer :: i,i_sn,ipart
+ real    :: dx(3),uval,t_sn,r2,rhoi
  logical :: inject_sn
  !
  ! parameters for supernovae injection, as in Balsara & Kim (2004)
@@ -104,6 +105,7 @@ subroutine inject_particles(time,dtlast_u,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
  inject_sn = abs(t_sn - i_sn) < 1.e-8
  print*,' time = ',time,' i_sn = ',i_sn,t_sn,' inject = ',inject_sn
  if (i_sn < 1 .or. i_sn > maxsn) return
+ dtinject = dt_sn
  !
  !--inject sn by changing internal energy of particles
  !
@@ -116,19 +118,19 @@ subroutine inject_particles(time,dtlast_u,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
        dx = xyzh(1:3,i) - xyz_sn(1:3,i_sn)
        r2 = dot_product(dx,dx)
        if (r2 < r_sn**2) then
-          uval = pr_sn / ((gamma - 1.)*rhoh(xyzh(4,i),massoftype(igas)))
-          print*,uval
+          rhoi = rhoh(xyzh(4,i),massoftype(igas))
+          uval = pr_sn / ((gamma - 1.)*rhoi)
+          print*,'New & Old thermal energy: ',uval,vxyzu(4,i)
           vxyzu(4,i) = uval
-          ipart = ipart + 1
+          iphase(i)  = iunknown ! flag this particle to update its timestep
+          ipart      = ipart + 1
+          dtinject   = min(dtinject,0.01*xyzh(4,i)*sqrt(rhoi/(gamma*pr_sn)))
+          updated_particle = .true.
        endif
     enddo
     print*,' energy injected into ',ipart,' particles'
     print*,'--------'
  endif
- !
- !-timestep constraint
- !
- dtinject = dt_sn
 
 end subroutine inject_particles
 

--- a/src/main/readwrite_infile.F90
+++ b/src/main/readwrite_infile.F90
@@ -253,11 +253,12 @@ subroutine write_infile(infile,logfile,evfile,dumpfile,iwritein,iprint)
  call write_options_photoevap(iwritein)
 #endif
 
- write(iwritein,"(/,a)") '# options for injecting/removing particles'
 #ifdef INJECT_PARTICLES
  call write_options_inject(iwritein)
  call write_options_dust_formation(iwritein)
 #endif
+
+ write(iwritein,"(/,a)") '# options for injecting/removing particles'
  call write_inopt(rkill,'rkill','deactivate particles outside this radius (<0 is off)',iwritein)
 
  if (sink_radiation) then

--- a/src/main/utils_summary.F90
+++ b/src/main/utils_summary.F90
@@ -67,8 +67,11 @@ module io_summary
  !  Number of steps
  integer, parameter :: iosum_nreal = iowake + 1     ! number of 'real' steps taken
  integer, parameter :: iosum_nsts  = iowake + 2     ! number of 'actual' steps (including STS) taken
+ !  Number of steps
+ integer, parameter :: iosum_flrvp = iosum_nsts + 1 ! number of times vpred(4,i) is floored in step_leapfrog (predict_sph loop)
+ integer, parameter :: iosum_flrv  = iosum_nsts + 2 ! number of times vxyzu(4,i) is floored in step_leapfrog (corrector loop)
  ! Maximum number of values to summarise
- integer, parameter :: maxiosum = iosum_nsts        ! Number of values to summarise
+ integer, parameter :: maxiosum = iosum_flrv        ! Number of values to summarise
  !
  !  Reason sink particle was not created
  integer, parameter :: inosink_notgas = 1           ! not gas particles
@@ -94,7 +97,7 @@ module io_summary
  integer,           private :: iosum_rxi  (maxrhomx  ), iosum_rxp  (maxrhomx), iosum_rxf(inosink_max,maxrhomx)
  real,              private :: iosum_rxa  (maxrhomx  ), iosum_rxx  (maxrhomx)
  integer,           private :: accretefail(3)
- logical,           private :: print_dt,print_sts,print_ext,print_dust,print_tolv,print_h,print_wake
+ logical,           private :: print_dt,print_sts,print_ext,print_dust,print_tolv,print_h,print_wake,print_floor
  logical,           private :: print_afail,print_early
  real(kind=4),      private :: dtsum_wall
  character(len=19), private :: freason(9)
@@ -164,6 +167,7 @@ subroutine summary_reset
  print_afail  = .false.
  print_early  = .false.
  print_wake   = .false.
+ print_floor  = .false.
  !
 end subroutine summary_reset
 !----------------------------------------------------------------
@@ -216,6 +220,7 @@ subroutine summary_variable(cval,ival,nval,meanvalue,maxvalue,addnval)
  if (trim(cval)=='tolv' ) print_tolv = .true.
  if (trim(cval)=='hupdn') print_h    = .true.
  if (trim(cval)=='wake' ) print_wake = .true.
+ if (trim(cval)=='floor') print_floor= .true.
  !
 end subroutine summary_variable
 !----------------------------------------------------------------
@@ -350,7 +355,8 @@ subroutine summary_printout(iprint,nptmass)
  !
  !--summarise logicals for cleanliness
  !
- if (print_dt .or. print_dust .or. print_sts .or. print_ext .or. print_tolv .or. print_h .or. print_wake) then
+ if (print_dt .or. print_dust .or. print_sts .or. print_ext .or. print_tolv .or. &
+     print_h  .or. print_wake .or. print_floor ) then
     get_averages = .true.
  else
     get_averages = .false.
@@ -547,6 +553,17 @@ subroutine summary_printout(iprint,nptmass)
     write(iprint,'(a)') '------------------------------------------------------------------------------'
  endif
 115 format(a,i9,a,f18.2,a,i17,30x,a)
+ !
+ !--Summary flooring the energy
+ if ( print_floor ) then
+    write(iprint,'(a)') '|* particles whose internal energies are floored                            *|'
+    write(iprint,'(a)') '|         |  #steps  | mean # part |  max # part                             |'
+    if (iosum_nstep(iosum_flrvp)/=0) write(iprint,120) '| vpred   | ' &
+      ,iosum_nstep(iosum_flrvp),'|',iosum_ave(iosum_flrvp),'|',int(iosum_max(iosum_flrvp)),'|'
+    if (iosum_nstep(iosum_flrv )/=0) write(iprint,120) '| vxuzy   | ' &
+      ,iosum_nstep(iosum_flrv ),'|',iosum_ave(iosum_flrv ),'|',int(iosum_max(iosum_flrv )),'|'
+    write(iprint,'(a)') '------------------------------------------------------------------------------'
+ endif
  !
  !--Summary of Restricted h jumps
  if ( print_h ) then

--- a/src/main/utils_summary.F90
+++ b/src/main/utils_summary.F90
@@ -68,10 +68,11 @@ module io_summary
  integer, parameter :: iosum_nreal = iowake + 1     ! number of 'real' steps taken
  integer, parameter :: iosum_nsts  = iowake + 2     ! number of 'actual' steps (including STS) taken
  !  Number of steps
- integer, parameter :: iosum_flrvp = iosum_nsts + 1 ! number of times vpred(4,i) is floored in step_leapfrog (predict_sph loop)
- integer, parameter :: iosum_flrv  = iosum_nsts + 2 ! number of times vxyzu(4,i) is floored in step_leapfrog (corrector loop)
+ integer, parameter :: iosumflrp   = iosum_nsts + 1 ! number of times vxyzu(4,i) is floored in step_leapfrog (predict loop)
+ integer, parameter :: iosumflrps  = iosum_nsts + 2 ! number of times vpred(4,i) is floored in step_leapfrog (predict_sph loop)
+ integer, parameter :: iosumflrc   = iosum_nsts + 3 ! number of times vxyzu(4,i) is floored in step_leapfrog (corrector loop)
  ! Maximum number of values to summarise
- integer, parameter :: maxiosum = iosum_flrv        ! Number of values to summarise
+ integer, parameter :: maxiosum = iosumflrc         ! Number of values to summarise
  !
  !  Reason sink particle was not created
  integer, parameter :: inosink_notgas = 1           ! not gas particles
@@ -556,12 +557,14 @@ subroutine summary_printout(iprint,nptmass)
  !
  !--Summary flooring the energy
  if ( print_floor ) then
-    write(iprint,'(a)') '|* particles whose internal energies are floored                            *|'
+    write(iprint,'(a)') '|* particles whose internal energies are floored in the labelled loops      *|'
     write(iprint,'(a)') '|         |  #steps  | mean # part |  max # part                             |'
-    if (iosum_nstep(iosum_flrvp)/=0) write(iprint,120) '| vpred   | ' &
-      ,iosum_nstep(iosum_flrvp),'|',iosum_ave(iosum_flrvp),'|',int(iosum_max(iosum_flrvp)),'|'
-    if (iosum_nstep(iosum_flrv )/=0) write(iprint,120) '| vxuzy   | ' &
-      ,iosum_nstep(iosum_flrv ),'|',iosum_ave(iosum_flrv ),'|',int(iosum_max(iosum_flrv )),'|'
+    if (iosum_nstep(iosumflrp)/=0) write(iprint,120)  '| predict | ' &
+      ,iosum_nstep(iosumflrp),'|',iosum_ave(iosumflrp),'|',int(iosum_max(iosumflrp)),'|'
+    if (iosum_nstep(iosumflrps)/=0) write(iprint,120) '| pred_sph| ' &
+      ,iosum_nstep(iosumflrps),'|',iosum_ave(iosumflrps),'|',int(iosum_max(iosumflrps)),'|'
+    if (iosum_nstep(iosumflrc )/=0) write(iprint,120) '| correct | ' &
+      ,iosum_nstep(iosumflrc ),'|',iosum_ave(iosumflrc ),'|',int(iosum_max(iosumflrc )),'|'
     write(iprint,'(a)') '------------------------------------------------------------------------------'
  endif
  !

--- a/src/main/writeheader.F90
+++ b/src/main/writeheader.F90
@@ -170,12 +170,7 @@ subroutine write_header(icall,infile,evfile,logfile,dumpfile,ntot)
     if (use_dustfrac)     write(iprint,"(1x,a)") 'One-fluid dust is ON'
     if (use_dustgrowth)   write(iprint,"(1x,a)") 'Dust growth is ON'
     if (cooling_explicit) write(iprint,"(1x,a)") 'Cooling is explicitly calculated in force'
-    if (cooling_implicit) then
-       write(iprint,"(1x,a)") 'Cooling is implicitly calculated in step'
-       write(iprint,"(1x,a)") 'WARNING!  Implicit cooling timestep has not been properly initialised!!!'
-       ! The initial cooling timestep is an explicit timestep that neglects heating; all subsequent (non-restart)
-       ! cooling timesteps are correct.  JHW
-    endif
+    if (cooling_implicit) write(iprint,"(1x,a)") 'Cooling is implicitly calculated in step'
     call eosinfo(ieos,iprint)
 
     if (maxalpha==maxp) then

--- a/src/setup/set_Bfield.f90
+++ b/src/setup/set_Bfield.f90
@@ -240,7 +240,6 @@ subroutine set_Bfield(npart,npartoftype,xyzh,massoftype,vxyzu,polyk, &
     endif
     print "(' Alfven speed = ',es12.4,/,' Plasma beta  = ',es12.4)",valfven,betazero
  endif
-
 !
 !--spit out flux to mass ratio (assumes spherical geometry at the moment)
 !

--- a/src/setup/setup_unifdis.f90
+++ b/src/setup/setup_unifdis.f90
@@ -37,10 +37,10 @@ module setup
  implicit none
  public :: setpart
 
- integer :: npartx,ilattice
- real    :: cs0,xmini,xmaxi,ymini,ymaxi,zmini,zmaxi
+ integer           :: npartx,ilattice
+ real              :: cs0,xmini,xmaxi,ymini,ymaxi,zmini,zmaxi
  character(len=20) :: dist_unit,mass_unit
- real(kind=8) :: udist,umass
+ real(kind=8)      :: udist,umass
  !--dust
  real    :: dust_to_gas
 
@@ -62,7 +62,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use part,         only:periodic,abundance,iHI,dustfrac,ndustsmall,ndusttypes,grainsize,graindens
  use physcon,      only:pi,mass_proton_cgs,kboltz,years,pc,solarm,micron
  use set_dust,     only:set_dustfrac
- use units,        only:set_units,udist,unit_density
+ use units,        only:set_units,unit_density
  use domain,       only:i_belong
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart

--- a/src/setup/setup_unifdis.f90
+++ b/src/setup/setup_unifdis.f90
@@ -31,16 +31,20 @@ module setup
 !   options, part, physcon, prompting, set_dust, setup_params, unifdis,
 !   units
 !
- use dim,          only:use_dust
+ use dim,          only:use_dust,mhd
  use options,      only:use_dustfrac
  use setup_params, only:rhozero
  implicit none
  public :: setpart
 
  integer           :: npartx,ilattice
- real              :: cs0,xmini,xmaxi,ymini,ymaxi,zmini,zmaxi
+ real              :: cs0,xmini,xmaxi,ymini,ymaxi,zmini,zmaxi,Bzero
  character(len=20) :: dist_unit,mass_unit
  real(kind=8)      :: udist,umass
+
+ !--change default defaults to reproduce the test from Section 5.6.7 of Price+(2018)
+ logical :: BalsaraKim = .false.
+
  !--dust
  real    :: dust_to_gas
 
@@ -55,15 +59,19 @@ contains
 !----------------------------------------------------------------
 subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,time,fileprefix)
  use dim,          only:maxvxyzu,h2chemistry,gr
- use setup_params, only:npart_total
+ use setup_params, only:npart_total,ihavesetupB
  use io,           only:master
  use unifdis,      only:set_unifdis
  use boundary,     only:xmin,ymin,zmin,xmax,ymax,zmax,dxbound,dybound,dzbound,set_boundary
- use part,         only:periodic,abundance,iHI,dustfrac,ndustsmall,ndusttypes,grainsize,graindens
+ use part,         only:Bxyz,periodic,abundance,iHI,dustfrac,ndustsmall,ndusttypes,grainsize,graindens
  use physcon,      only:pi,mass_proton_cgs,kboltz,years,pc,solarm,micron
  use set_dust,     only:set_dustfrac
  use units,        only:set_units,unit_density
  use domain,       only:i_belong
+ use eos,          only:gmw
+ use options,      only:icooling,alpha,alphau
+ use timestep,     only:dtmax,tmax,C_cour,C_force,C_cool,tolv
+ use h2cooling,    only:abundc,abundo,abundsi,abunde,dust_to_gas_ratio,iphoto
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -101,9 +109,9 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  !
  ! set default values for input parameters
  !
- npartx = 64
+ npartx   = 64
  ilattice = 1
- rhozero = 1.
+ rhozero  = 1.
  if (gr) then
     cs0 = 1.e-4
  else
@@ -111,11 +119,48 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  endif
  if (use_dust) then
     use_dustfrac = .true.
-    dust_to_gas = 0.01
-    ndustsmall = 1
-    ndusttypes = 1
+    dust_to_gas  = 0.01
+    ndustsmall   = 1
+    ndusttypes   = 1
     grainsize(1) = 1.*micron/udist
     graindens(1) = 3./unit_density
+ endif
+ if (BalsaraKim) then
+    ! there is a typo in Price+ (2018) in stating the physical density;
+    ! this mass_unit yields the correct value of 2.3e-24g/cm^3
+    mass_unit = '33982786.25*solarm'
+    dist_unit = 'kpc'
+    xmini = -0.1; xmaxi = 0.1
+    ymini = -0.1; ymaxi = 0.1
+    zmini = -0.1; zmaxi = 0.1
+    Bzero = 0.056117
+    cs0   = sqrt(0.3*gamma)
+    ilattice = 2
+    filename=trim(fileprefix)//'.in'
+    inquire(file=filename,exist=iexist)
+    if (.not.iexist) then
+       tmax    = 0.035688
+       dtmax   = 1.250d-4
+       C_cour  = 0.200
+       C_force = 0.150
+       C_cool  = 0.15
+       tolv    = 1.0d3
+       alpha   = 1
+       alphau  = 0.1
+       gmw     = 1.22
+       if (h2chemistry) then
+       ! flags controlling h2chemistry
+          icooling = 1
+          abundc  = 2.0d-4
+          abundo  = 4.5d-4
+          abundsi = 3.0d-5
+          abunde  = 2.0d-4
+          iphoto  = 0
+          dust_to_gas_ratio = 0.010
+       else
+          icooling = 0
+       endif
+    endif
  endif
  !
  ! get disc setup parameters from file or interactive setup
@@ -193,6 +238,14 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
        abundance(iHI,i) = 1.  ! assume all atomic hydrogen initially
     enddo
  endif
+
+ if (mhd .and. balsarakim) then
+    Bxyz = 0.
+    do i = 1,npart
+       Bxyz(1,i) = Bzero
+    enddo
+    ihavesetupB = .true.
+ endif
 end subroutine setpart
 
 !------------------------------------------------------------------------
@@ -208,7 +261,7 @@ subroutine setup_interactive(id,polyk)
  use units,     only:select_unit
  integer, intent(in)  :: id
  real,    intent(out) :: polyk
- integer :: ierr
+ integer              :: ierr
 
  if (id==master) then
     ierr = 1
@@ -259,6 +312,12 @@ subroutine setup_interactive(id,polyk)
     call bcast_mpi(dust_to_gas)
  endif
  !
+ ! magnetic field strength
+ if (mhd .and. balsarakim) then
+    call prompt('Enter magnetic field strength in code units ',Bzero,0.)
+    call bcast_mpi(Bzero)
+ endif
+ !
  ! type of lattice
  !
  if (id==master) then
@@ -303,6 +362,9 @@ subroutine write_setupfile(filename)
  call write_inopt(cs0,'cs0','initial sound speed in code units',iunit)
  if (use_dustfrac) then
     call write_inopt(dust_to_gas,'dust_to_gas','dust-to-gas ratio',iunit)
+ endif
+ if (mhd .and. balsarakim) then
+    call write_inopt(Bzero,'Bzero','magnetic field strength in code units',iunit)
  endif
  call write_inopt(ilattice,'ilattice','lattice type (1=cubic, 2=closepacked)',iunit)
  close(iunit)
@@ -350,6 +412,9 @@ subroutine read_setupfile(filename,ierr)
  call read_inopt(cs0,'cs0',db,min=0.,errcount=nerr)
  if (use_dustfrac) then
     call read_inopt(dust_to_gas,'dust_to_gas',db,min=0.,errcount=nerr)
+ endif
+ if (mhd .and. balsarakim) then
+    call read_inopt(Bzero,'Bzero',db,min=0.,errcount=nerr)
  endif
  call read_inopt(ilattice,'ilattice',db,min=1,max=2,errcount=nerr)
  call close_db(db)


### PR DESCRIPTION
I have added an option to impose a thermal floor to prevent a simulation from crashing with utherm < 0.  This is controlled by the logical use_Tfloor and the value Tfloor in eos.F90.  This should be used only as a last resort, which is why they're hardcoded and not in the .in file.  By default, the thermal floor is off.

@rieder and myself have found a few extreme simulations where this is necessary, and simply reducing the timestep does not work as a result of the predictor-corrector method.  