### PR TITLE
Fix seg fault in test suite on sink particle creation

### DIFF
--- a/src/main/linklist_kdtree.F90
+++ b/src/main/linklist_kdtree.F90
@@ -34,6 +34,7 @@ module linklist
  type(kdnode), public,  allocatable :: node(:)
  integer,               allocatable :: nodemap(:)
  integer,      public ,            allocatable :: listneigh(:)
+ integer,      public ,            allocatable :: listneigh_global(:)
 !$omp threadprivate(listneigh)
  integer(kind=8), public :: ncells
  real, public            :: dxcell
@@ -66,6 +67,7 @@ subroutine allocate_linklist
 !$omp parallel
  call allocate_array('listneigh',listneigh,maxp)
 !$omp end parallel
+ call allocate_array('listneigh_global',listneigh_global,maxp)
 
 end subroutine allocate_linklist
 
@@ -80,6 +82,7 @@ subroutine deallocate_linklist
 !$omp parallel
  if (allocated(listneigh)) deallocate(listneigh)
 !$omp end parallel
+ if (allocated(listneigh_global)) deallocate(listneigh_global)
  call deallocate_kdtree()
 
 end subroutine deallocate_linklist

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -580,7 +580,7 @@ subroutine ptmass_accrete(is,nptmass,xi,yi,zi,hi,vxi,vyi,vzi,fxi,fyi,fzi, &
  real,              intent(in)    :: xyzmh_ptmass(nsinkproperties,maxptmass)
  real,              intent(in)    :: vxyz_ptmass(3,maxptmass)
  logical,           intent(out)   :: accreted
- real,              intent(inout) :: dptmass(ndptmass,maxptmass)
+ real,              intent(inout) :: dptmass(:,:)
  integer(kind=1),   intent(in)    :: nbinmax
  integer(kind=1),   intent(inout) :: ibin_wakei
  integer, optional, intent(out)   :: nfaili

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -850,7 +850,7 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,vxyzu,fxyzu,fext,divcurlv,pote
 #ifdef IND_TIMESTEPS
  integer(kind=1)    :: ibin_itest
 #endif
- real    :: xyzcache(maxcache,3)
+ real, save :: xyzcache(maxcache,3)
  real    :: dptmass(ndptmass,nptmass+1)
  real    :: xi,yi,zi,hi,hi1,hi21,xj,yj,zj,hj1,hj21,xk,yk,zk,hk1
  real    :: rij2,rik2,rjk2,dx,dy,dz

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -826,7 +826,7 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,vxyzu,fxyzu,fext,divcurlv,pote
 #ifdef IND_TIMESTEPS
  use part,     only:ibin,ibin_wake
 #endif
- use linklist, only:getneigh_pos,ifirstincell
+ use linklist, only:getneigh_pos,ifirstincell,listneigh=>listneigh_global
  use eos,      only:equationofstate,gamma,gamma_pwp,utherm
  use options,  only:ieos
  use units,    only:unit_density
@@ -844,7 +844,6 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,vxyzu,fxyzu,fext,divcurlv,pote
  real,            intent(in)    :: time
  integer(kind=1)    :: iphasei,ibin_wakei
  integer            :: nneigh
- integer            :: listneigh(maxneigh)
  integer, parameter :: maxcache      = 12000
  integer, parameter :: nneigh_thresh = 1024 ! approximate epot if neigh>neigh_thresh; (-ve for off)
 #ifdef IND_TIMESTEPS

--- a/src/setup/set_shock.f90
+++ b/src/setup/set_shock.f90
@@ -35,6 +35,7 @@ contains
 subroutine set_shock(latticetype,id,master,itype,rholeft,rhoright,xmin,xmax,ymin,ymax,zmin,zmax,&
                      xshock,dxleft,hfact,smooth_fac,npart,xyzh,massoftype,iverbose,ierr,mask)
  use unifdis, only:set_unifdis,get_ny_nz_closepacked,is_closepacked,mask_prototype,mask_true
+ use stretchmap, only:rho_func
  character(len=*), intent(in) :: latticetype
  integer, intent(in) :: id,master,itype,iverbose
  real,    intent(in) :: rholeft,rhoright,xshock,xmin,xmax,ymin,ymax,zmin,zmax
@@ -44,6 +45,7 @@ subroutine set_shock(latticetype,id,master,itype,rholeft,rhoright,xmin,xmax,ymin
  integer, intent(out)   :: ierr
  procedure(mask_prototype), optional :: mask
  procedure(mask_prototype), pointer  :: my_mask
+ procedure(rho_func), pointer :: density_func
  integer :: npartold,ny,nz
  real :: totmass,volume,dxright
  real :: xminleft(3),xmaxleft(3),xminright(3),xmaxright(3)
@@ -61,6 +63,9 @@ subroutine set_shock(latticetype,id,master,itype,rholeft,rhoright,xmin,xmax,ymin
  else
     my_mask => mask_true
  endif
+
+ density_func => rhosmooth
+
  !
  ! set limits of the different domains
  !
@@ -80,7 +85,7 @@ subroutine set_shock(latticetype,id,master,itype,rholeft,rhoright,xmin,xmax,ymin
     ! set up a uniform lattice for left half
     call set_unifdis(latticetype,id,master,xminleft(1),xmaxleft(1),xminleft(2), &
                      xmaxleft(2),xminleft(3),xmaxleft(3),dxleft,hfact,npart,xyzh,&
-                     periodic,rhofunc=rhosmooth,mask=my_mask)
+                     periodic,rhofunc=density_func,mask=my_mask)
 
     ! set particle mass
     volume            = product(xmaxleft-xminleft)
@@ -101,7 +106,7 @@ subroutine set_shock(latticetype,id,master,itype,rholeft,rhoright,xmin,xmax,ymin
 
     call set_unifdis(latticetype,id,master,xminright(1),xmaxright(1), &
          xminright(2),xmaxright(2),xminright(3),xmaxright(3),dxright,hfact,&
-         npart,xyzh,periodic,npy=ny,npz=nz,rhofunc=rhosmooth,mask=my_mask) ! set right half
+         npart,xyzh,periodic,npy=ny,npz=nz,rhofunc=density_func,mask=my_mask) ! set right half
 
  else  ! set all of volume if densities are equal
     write(*,'(3(a,es16.8))') 'shock: uniform density  ',xminleft(1), ' to ',xmaxright(1), ' with dx  = ',dxleft

--- a/src/setup/set_sphere.f90
+++ b/src/setup/set_sphere.f90
@@ -53,14 +53,14 @@ contains
 !-----------------------------------------------------------------------
 subroutine set_sphere(lattice,id,master,rmin,rmax,delta,hfact,np,xyzh, &
                       rhofunc,rhotab,rtab,xyz_origin,nptot,dir,exactN,np_requested,mask)
- use stretchmap, only:set_density_profile
+ use stretchmap, only:set_density_profile,rho_func
  character(len=*), intent(in)    :: lattice
  integer,          intent(in)    :: id,master
  integer,          intent(inout) :: np
  real,             intent(in)    :: rmin,rmax,hfact
  real,             intent(out)   :: xyzh(:,:)
  real,             intent(inout) :: delta
- real,             external,      optional :: rhofunc
+ procedure(rho_func), pointer, optional :: rhofunc
  real,             intent(in),    optional :: rhotab(:), rtab(:)
  integer,          intent(in),    optional :: dir
  integer,          intent(in),    optional :: np_requested

--- a/src/setup/set_unifdis.f90
+++ b/src/setup/set_unifdis.f90
@@ -49,7 +49,7 @@ subroutine set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
                        rmin,rmax,rcylmin,rcylmax,rellipsoid,in_ellipsoid, &
                        nptot,npy,npz,rhofunc,inputiseed,verbose,centre,dir,geom,mask,err)
  use random,     only:ran2
- use stretchmap, only:set_density_profile
+ use stretchmap, only:set_density_profile,rho_func
  !use domain,     only:i_belong
  character(len=*), intent(in)    :: lattice
  integer,          intent(in)    :: id,master
@@ -63,7 +63,7 @@ subroutine set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
  real,             intent(in),    optional :: rellipsoid(3)
  integer(kind=8),  intent(inout), optional :: nptot
  integer,          intent(in),    optional :: npy,npz,dir,geom
- real, external,                  optional :: rhofunc
+ procedure(rho_func), pointer,    optional :: rhofunc
  integer,          intent(in),    optional :: inputiseed
  logical,          intent(in),    optional :: verbose,centre,in_ellipsoid
  integer,          intent(out),   optional :: err

--- a/src/tests/test_ptmass.F90
+++ b/src/tests/test_ptmass.F90
@@ -61,6 +61,7 @@ subroutine test_ptmass(ntests,npass)
  use part,            only:ibin,ibin_old
 #endif
  use mpiutils,        only:bcast_mpi,reduce_in_place_mpi,reduceloc_mpi
+ use stretchmap,      only:rho_func
  integer, intent(inout) :: ntests,npass
  integer                :: i,nsteps,nbinary_tests,itest,nerr,nwarn,itestp
  integer                :: nparttot
@@ -79,8 +80,11 @@ subroutine test_ptmass(ntests,npass)
  integer                :: id_rhomax,ipart_rhomax_global
  integer(kind=1)        :: ibin_wakei
  character(len=20)      :: dumpfile,filename
+ procedure(rho_func), pointer :: density_func
 
  if (id==master) write(*,"(/,a,/)") '--> TESTING PTMASS MODULE'
+
+ density_func => gaussianr
 
  test_binary = .true.
  test_accretion = .true.
@@ -501,7 +505,7 @@ subroutine test_ptmass(ntests,npass)
        psep = 0.05  ! required as a variable since this may change under conditions not requested here
        if (itest==2) then
           ! use random so particle with maximum density is unique
-          call set_sphere('cubic',id,master,0.,0.2,psep,hfact,npartoftype(igas),xyzh,rhofunc=gaussianr)
+          call set_sphere('cubic',id,master,0.,0.2,psep,hfact,npartoftype(igas),xyzh,rhofunc=density_func)
        else
           call set_sphere('cubic',id,master,0.,0.2,psep,hfact,npartoftype(igas),xyzh)
        endif


### PR DESCRIPTION
Fixes #94

- Fix incorrect array size
- Use modern fortran procedure pointer
- save xyzcache in ptmass