### PR TITLE
(ptmass) use logfile prefix for sink ev prefix instead of dumpfile pr…

### DIFF
--- a/docs/fork.rst
+++ b/docs/fork.rst
@@ -1,27 +1,17 @@
 Forking Phantom
 ===============
 
-Warning
--------
-
-This instructions on this page are out of date.
-
-
 Why fork?
 ---------
 
-You can work on a fork of Phantom if you wish to keep local changes
-without having to push them into the public code. We discourage this in
-general, because it is nearly impossible to merge changes in code which
-diverged from the master code a long time ago. But, warning heeded, here
-is how to do it…
+Working on a fork allows you to work on your own copy of phantom, contributing code back to the main code via a "pull request"
 
 How to fork
 -----------
 
 First, click “Fork this repository” on the main phantom repository in
-bitbucket. You then have your own bitbucket copy of Phantom in
-bitbucket.org/USERNAME/phantom
+github. You then have your own copy of Phantom in
+github.com/USERNAME/phantom
 
 How to work on your fork
 ------------------------
@@ -30,7 +20,7 @@ Clone a copy of your fork onto a local machine
 
 ::
 
-   git clone https://bitbucket.org/USERNAME/phantom
+   git clone https://github.com/USERNAME/phantom
 
 push and pull from your fork as you would with the regular phantom
 repository
@@ -42,7 +32,7 @@ First, make a remote branch that tracks the main repo:
 
 ::
 
-   git remote add upstream https://bitbucket.org/danielprice/phantom
+   git remote add upstream https://github.com/danieljprice/phantom
    git fetch upstream
 
 Then every time you want to update, in your forked copy, type:

--- a/docs/gitinfo.rst
+++ b/docs/gitinfo.rst
@@ -6,7 +6,7 @@ Make sure you have the git version control system installed.
 Getting your first copy
 -----------------------
 
-Once you have a GitHub account, you must create your own :doc:'fork <fork>`.
+Once you have a GitHub account, you must create your own :doc:`fork <fork>`.
 This is done using the “fork” button (the big button on top right of the
 repo page).  You can then clone your fork to your computer:
 
@@ -107,15 +107,10 @@ This will push all the remote changes to your forked version of Phantom.
 Committing changes to the master branch
 ---------------------------------------
 
-This is done through a “pull request” which I must approve.  To do this,
+This is done through a “pull request”.  To do this,
 you can click the big “pull request” button on the GitHub page to request
 that your changes be pulled into the master copy of Phantom. Please do
 this frequently. Many small pull requests are much better than one giant
 pull request!
 
-Before making a pull request, :doc:`ENSURE THAT YOUR CHANGES WILL NOT
-BREAK ANYONE ELSE’S STUFF <testing>`).  Automated tests will be performed
-on all pull requests.  Compilation failures are automatically checked by
-the buildbot, which runs every night there have been commits made to the
-code and checks for any compilation failures and/or new compiler
-warnings and **emails those responsible**.
+Automated tests will be performed on all pull requests to ensure nothing gets broken. Once these pass and the code has been reviewed, the code can be merged.

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -505,7 +505,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile)
     write(iprint,*) 'dt(sink-gas)  = ',dtsinkgas
     dtextforce = min(dtextforce,dtsinkgas)
  endif
- call init_ptmass(nptmass,logfile,dumpfile)
+ call init_ptmass(nptmass,logfile)
  if (gravity .and. icreate_sinks > 0) then
     write(iprint,*) 'Sink radius and critical densities:'
     write(iprint,*) ' h_acc                    == ',h_acc*udist,'cm'

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -1366,7 +1366,7 @@ subroutine init_ptmass(nptmass,logfile)
  !
  idot = index(logfile,'.')
  if (idot==0) idot = len_trim(logfile) + 1
- write(pt_prefix,"(a)") logfile(1:idot-3)
+ pt_prefix = logfile(1:idot-3)
 
  !
  !--Define file name components and finalise suffix & open files

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -36,7 +36,7 @@ module ptmass
 !
  use dim,  only:maxptmass
  use part, only:nsinkproperties,gravity,is_accretable
- use io,   only:iscfile,iskfile
+ use io,   only:iscfile,iskfile,id,master
  implicit none
  character(len=80), parameter, public :: &  ! module version
     modid="$Id$"
@@ -1361,6 +1361,8 @@ subroutine init_ptmass(nptmass,logfile)
  character(len=*), intent(in) :: logfile
  integer                      :: i,idot
  character(len=150)           :: filename
+
+ if (id /= master) return ! only do this on master thread
  !
  !--Extract prefix & suffix
  !
@@ -1433,6 +1435,8 @@ subroutine pt_open_sinkev(num)
  integer             :: iunit
  character(len=200)  :: filename
 
+ if (id /= master) return ! only do this on master thread
+
  if (write_one_ptfile) then
     write(filename,'(2a)') trim(pt_prefix),trim(pt_suffix)
  else
@@ -1474,13 +1478,16 @@ end subroutine pt_open_sinkev
 subroutine pt_close_sinkev(nptmass)
  integer, intent(in) :: nptmass
  integer             :: i,iunit
- if (write_one_ptfile) then
-    close(iskfile)
- else
-    do i = 1,nptmass
-       iunit = iskfile+i
-       close(iunit)
-    enddo
+
+ if (id == master) then ! only on master thread
+    if (write_one_ptfile) then
+       close(iskfile)
+    else
+       do i = 1,nptmass
+          iunit = iskfile+i
+          close(iunit)
+       enddo
+    endif
  endif
 
 end subroutine pt_close_sinkev
@@ -1490,10 +1497,12 @@ end subroutine pt_close_sinkev
 !+
 !-----------------------------------------------------------------------
 subroutine pt_write_sinkev(nptmass,time,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_sinksink)
- use part,        only: ispinx,ispiny,ispinz,imacc
+ use part,        only:ispinx,ispiny,ispinz,imacc
  integer, intent(in) :: nptmass
  real,    intent(in) :: time, xyzmh_ptmass(:,:),vxyz_ptmass(:,:),fxyz_ptmass(:,:),fxyz_ptmass_sinksink(:,:)
  integer             :: i,iunit
+
+ if (id /= master) return ! only do this on master thread
 
  iunit = iskfile
  do i = 1,nptmass

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -1356,18 +1356,18 @@ end subroutine ptmass_create
 !  Open files to track sink particle data
 !+
 !-----------------------------------------------------------------------
-subroutine init_ptmass(nptmass,logfile,dumpfile)
+subroutine init_ptmass(nptmass,logfile)
  integer,          intent(in) :: nptmass
- character(len=*), intent(in) :: logfile,dumpfile
- integer                      :: i,idot,idash
+ character(len=*), intent(in) :: logfile
+ integer                      :: i,idot
  character(len=150)           :: filename
  !
  !--Extract prefix & suffix
  !
- idash = index(dumpfile,'_')
- write(pt_prefix,"(a)") dumpfile(1:idash-1)
  idot = index(logfile,'.')
  if (idot==0) idot = len_trim(logfile) + 1
+ write(pt_prefix,"(a)") logfile(1:idot-3)
+
  !
  !--Define file name components and finalise suffix & open files
  !


### PR DESCRIPTION
…efix

Would fix #134 . However, need to check that getting the ptmass ev file prefix with `logfile(1:idot-3)` isn't dangerous—this change assumes the logfile number takes up two characters.