### PR TITLE
Remove deprecated MPI_TYPE_STRUCT 

### DIFF
--- a/src/main/dtype_kdtree.F90
+++ b/src/main/dtype_kdtree.F90
@@ -157,7 +157,7 @@ subroutine get_mpitype_of_kdnode(dtype)
  disp(nblock) = addr - start
 #endif
 
- call MPI_TYPE_STRUCT(nblock,blens(1:nblock),disp(1:nblock),mpitypes(1:nblock),dtype,mpierr)
+ call MPI_TYPE_CREATE_STRUCT(nblock,blens(1:nblock),disp(1:nblock),mpitypes(1:nblock),dtype,mpierr)
  call MPI_TYPE_COMMIT(dtype,mpierr)
 
  ! check extent okay

--- a/src/main/dtype_kdtree.F90
+++ b/src/main/dtype_kdtree.F90
@@ -79,6 +79,7 @@ contains
 subroutine get_mpitype_of_kdnode(dtype)
  use mpi
  use mpiutils, only:mpierr
+ use io,       only:error
 
  integer, parameter              :: ndata = 20
 
@@ -163,12 +164,7 @@ subroutine get_mpitype_of_kdnode(dtype)
  ! check extent okay
  call MPI_TYPE_GET_EXTENT(dtype,lb,extent,mpierr)
  if (extent /= sizeof(node)) then
-    dtype_old = dtype
-    lb = 0
-    extent = sizeof(node)
-    call MPI_TYPE_CREATE_RESIZED(dtype_old,lb,extent,dtype,mpierr)
-    call MPI_TYPE_COMMIT(dtype,mpierr)
-    call MPI_TYPE_FREE(dtype_old,mpierr)
+    call error('dtype_kdtree','MPI_TYPE_GET_EXTENT has calculated the extent incorrectly')
  endif
 
 end subroutine get_mpitype_of_kdnode


### PR DESCRIPTION
Fixes #144

`MPI_TYPE_STRUCT` was removed from the MPI 3.0 standard, and replaced with `MPI_TYPE_CREATE_STRUCT`, which has the same interface.

Presumably the old subroutine requires `disp` to be `kind=4`, and breaks for anything else (e.g. MPI_ADDRESS_KIND==8) . Replacing this call with `MPI_TYPE_CREATE_STRUCT` solves the problem.

Throw error when the extent is incorrect, instead of trying to recover.