### PR TITLE
Save perflog (stats.txt) to web server

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -145,7 +145,7 @@ jobs:
     - name: "Update stats.txt on phantom-data-files"
       working-directory: phantom-benchmarks
       run: |
-        for dir in "$@"; do
+        for dir in ./*; do
           if [ -d ${dir} ]; then
             list+=("${dir}")
             rsync -vau ${dir}/stats.txt ${WEB_USER}@${WEB_SERVER}:${HTML_DIR}${BENCH_LOG_DIR}${dir}/

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -142,6 +142,16 @@ jobs:
       env:
         PHANTOM_DIR: ${{ github.workspace }}
 
+    - name: "Update stats.txt on phantom-data-files"
+      working-directory: phantom-benchmarks
+      run: |
+        for dir in "$@"; do
+          if [ -d ${dir} ]; then
+            list+=("${dir}")
+            rsync -vau ${dir}/stats.txt ${WEB_USER}@${WEB_SERVER}:${HTML_DIR}${BENCH_LOG_DIR}${dir}/
+          fi
+        done
+
     - name: "Copy plots to phantom-data-files"
       working-directory: phantom-benchmarks
       run: |


### PR DESCRIPTION
`plot-benchmarks` only appends the latest value to stats.txt each time it is run. It does not rebuild the whole log, so stats.txt needs to be stored on the server for the full plot to be generated.