### PR TITLE
fix mpi buffer size when DISC_VISCOSITY is enabled

### DIFF
--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -295,7 +295,7 @@ module part
    +maxvxyzu                            &  ! fxyzu
    +3                                   &  ! fext
    +usedivcurlv                         &  ! divcurlv
-#ifndef CONST_AV
+#if !defined(CONST_AV) && !defined(DISC_VISCOSITY)
    +nalpha                              &  ! alphaind
 #endif
 #ifndef ANALYSIS


### PR DESCRIPTION
alphaind is not used with DISC_VISCOSITY