### PR TITLE
Finish implementing MPI for particle waking

### DIFF
--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -1263,9 +1263,7 @@ subroutine compute_forces(i,iamgasi,iamdusti,xpartveci,hi,hi1,hi21,hi41,gradhi,g
           ! Particle j is a neighbour of an active particle;
           ! flag it to see if it needs to be woken up next step.
           if (.not.iamboundary(iamtypej)) then
-! #ifndef MPI
              ibin_wake(j)  = max(ibinnow_m1,ibin_wake(j))
-! #endif
              ibin_neighi = max(ibin_neighi,ibin_old(j))
           endif
 #endif

--- a/src/main/mpi_derivs.F90
+++ b/src/main/mpi_derivs.F90
@@ -402,6 +402,9 @@ subroutine recv_cellforce(target_stack,xbuf,irequestrecv)
              target_stack%cells(iwait)%fsums(:,k) = target_stack%cells(iwait)%fsums(:,k) + xbuf(iproc)%fsums(:,k)
              target_stack%cells(iwait)%tsmin(k) = min(target_stack%cells(iwait)%tsmin(k), xbuf(iproc)%tsmin(k))
              target_stack%cells(iwait)%vsigmax(k) = max(target_stack%cells(iwait)%vsigmax(k), xbuf(iproc)%vsigmax(k))
+#ifdef IND_TIMESTEPS
+             target_stack%cells(iwait)%ibinneigh = max(target_stack%cells(iwait)%ibinneigh(k), xbuf(iproc)%ibinneigh(k))
+#endif
           enddo
 #ifdef GRAVITY
           do k = 1,20

--- a/src/main/mpi_derivs.F90
+++ b/src/main/mpi_derivs.F90
@@ -403,7 +403,7 @@ subroutine recv_cellforce(target_stack,xbuf,irequestrecv)
              target_stack%cells(iwait)%tsmin(k) = min(target_stack%cells(iwait)%tsmin(k), xbuf(iproc)%tsmin(k))
              target_stack%cells(iwait)%vsigmax(k) = max(target_stack%cells(iwait)%vsigmax(k), xbuf(iproc)%vsigmax(k))
 #ifdef IND_TIMESTEPS
-             target_stack%cells(iwait)%ibinneigh = max(target_stack%cells(iwait)%ibinneigh(k), xbuf(iproc)%ibinneigh(k))
+             target_stack%cells(iwait)%ibinneigh(k) = max(target_stack%cells(iwait)%ibinneigh(k), xbuf(iproc)%ibinneigh(k))
 #endif
           enddo
 #ifdef GRAVITY

--- a/src/main/mpi_force.F90
+++ b/src/main/mpi_force.F90
@@ -192,7 +192,13 @@ subroutine get_mpitype_of_cellforce(dtype)
  disp(nblock) = addr - start
 
  nblock = nblock + 1
- blens(nblock) = 8 - mod(4 * (7 + minpart + maxprocs) + minpart, 8)
+ blens(nblock) = size(cell%ibinneigh)
+ mpitypes(nblock) = MPI_INTEGER1
+ call MPI_GET_ADDRESS(cell%ibinneigh,addr,mpierr)
+ disp(nblock) = addr - start
+
+ nblock = nblock + 1
+ blens(nblock) = 8 - mod(4 * (7 + minpart + maxprocs) + 2*minpart, 8)
  mpitypes(nblock) = MPI_INTEGER1
  call MPI_GET_ADDRESS(cell%pad,addr,mpierr)
  disp(nblock) = addr - start


### PR DESCRIPTION
331970bfeb17423a92d3231b05d9c14a203c930b begins an MPI-enabled implementation for particle waking by carrying ibin_neigh in the cell back from remote tasks. 

However, it does not unpack and reduce the value on arrival. This causes ibin_neigh to be incorrect, and particle waking to be broken.

This was not picked up in the checks for #147 because the test suite does not check particle waking with MPI.