### PR TITLE
Fix reading integer arrays from native phantom files

### DIFF
--- a/src/main/utils_dumpfiles.f90
+++ b/src/main/utils_dumpfiles.f90
@@ -1929,9 +1929,9 @@ subroutine read_array_int1(iarr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag,ma
  integer,          intent(in)    :: ikind,i1,i2,noffset,iunit
  logical,          intent(inout) :: matched
  integer,          intent(out)   :: ierr
- integer      :: i
- real(kind=4) :: dum
- logical      :: match_datatype
+ integer         :: i
+ integer(kind=1) :: dum
+ logical         :: match_datatype
 
  if (matched) return
  match_datatype = (ikind==i_int1)
@@ -1993,9 +1993,9 @@ subroutine read_array_int8(iarr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag,ma
  integer,          intent(in)    :: ikind,i1,i2,noffset,iunit
  logical,          intent(inout) :: matched
  integer,          intent(out)   :: ierr
- integer      :: i
- real(kind=4) :: dum
- logical      :: match_datatype
+ integer         :: i
+ integer(kind=8) :: dum
+ logical         :: match_datatype
 
  if (matched) return
  match_datatype = (ikind==i_int8)

--- a/src/main/utils_dumpfiles.f90
+++ b/src/main/utils_dumpfiles.f90
@@ -1961,9 +1961,9 @@ subroutine read_array_int4(iarr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag,ma
  integer,          intent(in)    :: ikind,i1,i2,noffset,iunit
  logical,          intent(inout) :: matched
  integer,          intent(out)   :: ierr
- integer      :: i
- real(kind=4) :: dum
- logical      :: match_datatype
+ integer         :: i
+ integer(kind=4) :: dum
+ logical         :: match_datatype
 
  if (matched) return
  match_datatype = (ikind==i_int4)


### PR DESCRIPTION
When support for `integer(kind=1)` arrays was added for native phantom files, the incorrect type for `dum` was used, causing the read offset to be set incorrectly. This results in integer arrays being read incorrectly whenever an offset was required.

The same mistake was made when c21cf7c2fb281dfea67c7e929985d3b1102b2df6 added support for `integer(kind=8)`.

This is fixed by using the correct type and kind.

Fixes #156, and may also fix #150.