### PR TITLE
Particle ID tracking for MPI

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -2186,7 +2186,7 @@ diffdumps: checksys checkparams $(OBJDUMP) utils_testsuite.o diffdumps.o
 	@echo ""
 	@echo "diffdumps: we welcome you"
 	@echo ""
-	$(FC) $(FFLAGS) -o $(BINDIR)/$@ $(OBJDUMP) utils_testsuite.o diffdumps.o
+	$(FC) $(FFLAGS) -o $(BINDIR)/$@ $(OBJDUMP) utils_testsuite.o diffdumps.o $(LDFLAGS)
 
 cleandiffdumps:
 	rm -f $(BINDIR)/phantom2divb

--- a/build/Makefile
+++ b/build/Makefile
@@ -1855,7 +1855,8 @@ SRCDUMP= physcon.f90 ${CONFIG} ${SRCKERNEL} io.F90 units.f90 boundary.f90 mpi_ut
          utils_sphNG.f90 \
          setup_params.f90 ${SRCFASTMATH} checkoptions.F90 \
          viscosity.f90 options.f90 checkconserved.f90 prompting.f90 ${SRCDUST} \
-         ${SRCREADWRITE_DUMPS}
+         ${SRCREADWRITE_DUMPS} \
+         utils_sort.f90 sort_particles.F90
 OBJDUMP1= $(SRCDUMP:.f90=.o)
 OBJDUMP= $(OBJDUMP1:.F90=.o)
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -2052,7 +2052,7 @@ mess_up_SPH.o: checkmcfost $(MCFOST_DIR)/src/mess_up_SPH.f90
 OBJAN1= ${ANALYSIS:.f90=.o}
 OBJAN2= ${OBJAN1:.F90=.o}
 OBJAN= ${OBJAN2:.f=.o}
-OBJA= utils_sort.o leastsquares.o solvelinearsystem.o \
+OBJA= leastsquares.o solvelinearsystem.o \
       ${OBJDUMP} utils_disc.o utils_gravwave.o set_dust.o utils_binary.o set_binary.o ${OBJAN}
 
 ifndef ANALYSISBIN

--- a/build/Makefile
+++ b/build/Makefile
@@ -2021,7 +2021,7 @@ ifndef MODDUMPBIN
 MODDUMPBIN=phantommoddump
 endif
 OBJMOD1 = utils_omp.F90 utils_summary.f90 utils_indtimesteps.F90 \
-          utils_sort.f90 set_Bfield.f90 \
+          set_Bfield.f90 \
           random.f90 set_disc.F90 set_dust.f90 \
           ${SRCTURB} ${SRCNIMHD} ${SRCCHEM} dust_formation.F90 ptmass_radiation.F90 \
           icosahedron.f90 radiation_utils.f90 cons2prim.f90 \

--- a/build/Makefile
+++ b/build/Makefile
@@ -1882,13 +1882,13 @@ libsetup: $(OBJLIBSETUP)
 .PHONY: phantomsetup
 phantomsetup: setup
 
-SRCSETUP= utils_omp.F90 utils_sort.f90 utils_timing.f90 utils_summary.F90 utils_gravwave.f90 \
+SRCSETUP= utils_omp.F90 utils_timing.f90 utils_summary.F90 utils_gravwave.f90 \
           mpi_balance.F90 set_dust_options.f90 \
           utils_indtimesteps.F90 partinject.F90 stack.F90 mpi_dens.F90 mpi_force.F90 mpi_derivs.F90 \
           ${SRCTURB} ${SRCNIMHD} ${SRCCHEM} \
           ptmass.F90 energies.F90 density_profiles.f90 set_slab.f90 set_disc.F90 relax_star.f90 \
 	  set_cubic_core.f90 set_fixedentropycore.f90 set_softened_core.f90 \
-          set_vfield.f90 sort_particles.F90 dust_formation.F90 ptmass_radiation.F90 ${SRCINJECT} \
+          set_vfield.f90 dust_formation.F90 ptmass_radiation.F90 ${SRCINJECT} \
           ${SETUPFILE} checksetup.F90 \
           set_Bfield.f90 damping.f90 readwrite_infile.f90 ${SRCKROME}
 

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -160,9 +160,6 @@ subroutine startrun(infile,logfile,evfile,dumpfile)
                             h_acc,r_crit,r_crit2,rho_crit,rho_crit_cgs,icreate_sinks
  use timestep,         only:time,dt,dtextforce,C_force,dtmax
  use timing,           only:get_timings
-#ifdef SORT
- use sort_particles,   only:sort_part
-#endif
 #ifdef IND_TIMESTEPS
  use timestep,         only:dtmax
  use timestep_ind,     only:istepfrac,ibinnow,maxbins,init_ibin
@@ -384,14 +381,6 @@ subroutine startrun(infile,logfile,evfile,dumpfile)
     ibelong(i) = id
  enddo
  call balancedomains(npart)
-#endif
-
-!
-!--check that sorting is allowed
-!  and if so sort particles
-!
-#ifdef SORT
- call sort_part()
 #endif
 
 !

--- a/src/main/mpi_utils.F90
+++ b/src/main/mpi_utils.F90
@@ -110,7 +110,7 @@ module mpiutils
 !--generic interface fill_buffer
 !
  interface fill_buffer
-  module procedure fill_buffer_r8,fill_buffer_r4,fill_buffer_r8val,fill_buffer_r4val,fill_buffer_ival
+  module procedure fill_buffer_r8,fill_buffer_r4,fill_buffer_r8val,fill_buffer_r4val,fill_buffer_i1val,fill_buffer_i8val
  end interface
 !
 !--generic interface unfill_buf
@@ -1540,7 +1540,7 @@ subroutine fill_buffer_r4val(xbuffer,xval,nbuf)
 
 end subroutine fill_buffer_r4val
 
-subroutine fill_buffer_ival(xbuffer,ival,nbuf)
+subroutine fill_buffer_i1val(xbuffer,ival,nbuf)
  real,            intent(inout) :: xbuffer(:)
  integer(kind=1), intent(in)    :: ival
  integer,         intent(inout) :: nbuf
@@ -1548,7 +1548,17 @@ subroutine fill_buffer_ival(xbuffer,ival,nbuf)
  nbuf = nbuf + 1
  xbuffer(nbuf) = real(ival)
 
-end subroutine fill_buffer_ival
+end subroutine fill_buffer_i1val
+
+subroutine fill_buffer_i8val(xbuffer,ival,nbuf)
+   real,            intent(inout) :: xbuffer(:)
+   integer(kind=8), intent(in)    :: ival
+   integer,         intent(inout) :: nbuf
+
+   nbuf = nbuf + 1
+   xbuffer(nbuf) = real(ival)
+
+  end subroutine fill_buffer_i8val
 
 !--------------------------------------------------------------------------
 !+

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -296,14 +296,14 @@ module part
    +3                                   &  ! fext
    +usedivcurlv                         &  ! divcurlv
 #if !defined(CONST_AV) && !defined(DISC_VISCOSITY)
-   +nalpha                              &  ! alphaind
+ +nalpha                              &  ! alphaind
 #endif
 #ifndef ANALYSIS
  +ngradh                              &  ! gradh
 #endif
 #ifdef MHD
  +maxBevol                            &  ! Bevol
-   +maxBevol                            &  ! Bpred
+ +maxBevol                            &  ! Bpred
 #endif
 #ifdef RADIATION
  +3*maxirad + maxradprop              &  ! rad,radpred,drad,radprop
@@ -313,11 +313,11 @@ module part
 #endif
 #ifdef DUST
  +maxdusttypes                        &  ! dustfrac
-   +maxdustsmall                        &  ! dustevol
-   +maxdustsmall                        &  ! dustpred
+ +maxdustsmall                        &  ! dustevol
+ +maxdustsmall                        &  ! dustpred
 #ifdef DUSTGROWTH
-   +1                                   &  ! dustproppred
-   +1                                   &  ! ddustprop
+ +1                                   &  ! dustproppred
+ +1                                   &  ! ddustprop
 #endif
 #endif
 #ifdef H2CHEM
@@ -325,17 +325,17 @@ module part
 #endif
 #ifdef NUCLEATION
  +1                                   &  ! nucleation rate
-   +4                                   &  ! moments
-   +1                                   &  ! mean molecular weight
+ +4                                   &  ! moments
+ +1                                   &  ! mean molecular weight
 #endif
 #ifdef KROME
  +krome_nmols                         &  ! abundance
-   +1                                   &  ! variable gamma
-   +1                                   &  ! variable mu
-   +1                                   &  ! temperature
-   +1                                   &  ! cooling rate
+ +1                                   &  ! variable gamma
+ +1                                   &  ! variable mu
+ +1                                   &  ! temperature
+ +1                                   &  ! cooling rate
 #endif
-   +maxeosvars                          &  ! eos_vars
+ +maxeosvars                          &  ! eos_vars
 #ifdef GRAVITY
  +1                                   &  ! poten
 #endif
@@ -344,11 +344,12 @@ module part
 #endif
 #ifdef IND_TIMESTEPS
  +1                                   &  ! ibin
-   +1                                   &  ! ibin_old
-   +1                                   &  ! ibin_wake
-   +1                                   &  ! dt_in
-   +1                                   &  ! twas
+ +1                                   &  ! ibin_old
+ +1                                   &  ! ibin_wake
+ +1                                   &  ! dt_in
+ +1                                   &  ! twas
 #endif
+ +1                                   &  ! iorig
  +0
 
  real            :: hfact,Bextx,Bexty,Bextz
@@ -1401,6 +1402,7 @@ subroutine fill_sendbuf(i,xtemp)
     call fill_buffer(xtemp,dt_in(i),nbuf)
     call fill_buffer(xtemp,twas(i),nbuf)
 #endif
+    call fill_buffer(xtemp,iorig(i),nbuf)
  endif
  if (nbuf /= ipartbufsize) call fatal('fill_sendbuf','error in send buffer size')
 
@@ -1469,6 +1471,7 @@ subroutine unfill_buffer(ipart,xbuf)
  dt_in(ipart)           = real(unfill_buf(xbuf,j),kind=kind(dt_in))
  twas(ipart)            = unfill_buf(xbuf,j)
 #endif
+ iorig(ipart)           = nint(unfill_buf(xbuf,j),kind=8)
 
 !--just to be on the safe side, set other things to zero
  if (mhd) then

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -1238,6 +1238,7 @@ subroutine reorder_particles(iorder,np)
  call copy_arrayint1(ibin_wake(1:np), iorder(1:np))
  !call copy_array1(twas(1:np),          iorder(1:np))
 #endif
+ call copy_arrayint8(iorig(1:np), iorder(1:np))
 
  return
 end subroutine reorder_particles
@@ -1544,7 +1545,7 @@ end subroutine copy_array1
 !----------------------------------------------------------------
 !+
 !  utility to reorder an array
-!  (real4, rank 1 arrays)
+!  (int1, rank 1 arrays)
 !+
 !----------------------------------------------------------------
 
@@ -1558,6 +1559,24 @@ subroutine copy_arrayint1(iarray,ilist)
 
  return
 end subroutine copy_arrayint1
+
+!----------------------------------------------------------------
+!+
+!  utility to reorder an array
+!  (int8, rank 1 arrays)
+!+
+!----------------------------------------------------------------
+
+subroutine copy_arrayint8(iarray,ilist)
+   integer(kind=8), intent(inout) :: iarray(:)
+   integer,         intent(in)    :: ilist(:)
+   integer(kind=8) :: iarraytemp(size(iarray(:)))
+
+   iarraytemp(:) = iarray(ilist(:))
+   iarray = iarraytemp
+
+   return
+  end subroutine copy_arrayint8
 
 !----------------------------------------------------------------
 !+

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -59,8 +59,8 @@ module part
 !
 !--tracking particle IDs
 !
- integer              :: norig
- integer, allocatable :: iorig(:)
+ integer(kind=8)              :: norig
+ integer(kind=8), allocatable :: iorig(:)
 !
 !--storage of dust properties
 !

--- a/src/main/readwrite_dumps_common.F90
+++ b/src/main/readwrite_dumps_common.F90
@@ -140,7 +140,7 @@ subroutine check_arrays(i1,i2,npartoftype,npartread,nptmass,nsinkproperties,mass
  logical,         intent(in)    :: got_krome_mols(:),got_krome_gamma,got_krome_mu,got_krome_T
  logical,         intent(in)    :: got_psi,got_temp,got_Tdust,got_pxyzu(:),got_raden(:),got_kappa,got_iorig
  integer(kind=1), intent(inout) :: iphase(:)
- integer,         intent(inout) :: iorig(:)
+ integer(kind=8), intent(inout) :: iorig(:)
  real,            intent(inout) :: vxyzu(:,:),Bevol(:,:),pxyzu(:,:)
  real(kind=4),    intent(inout) :: alphaind(:,:)
  real,            intent(inout) :: xyzh(:,:),xyzmh_ptmass(:,:)

--- a/src/main/sort_particles.F90
+++ b/src/main/sort_particles.F90
@@ -17,16 +17,12 @@ module sort_particles
 ! :Dependencies: dim, io, linklist, part, sortutils
 !
  implicit none
- public :: sort_part_radius, sort_part_id
-#ifdef SORT
- public :: sort_part
-#endif
+ public :: sort_part_radius, sort_part_id, sort_part
 
  private
 
 contains
 
-#ifdef SORT
 ! do not even compile with this routine if not sorting
 !----------------------------------------------------------------
 !+
@@ -113,7 +109,6 @@ subroutine sort_part
  write(iprint,*) '> sort completed in ',t2-t1,'s'
 
 end subroutine sort_part
-#endif
 
 !----------------------------------------------------------------
 !+

--- a/src/main/sort_particles.F90
+++ b/src/main/sort_particles.F90
@@ -34,11 +34,12 @@ subroutine sort_part
  use io,       only:iprint,fatal
  use part,     only:reorder_particles,npart,ll,xyzh,vxyzu,isdead
  use linklist, only:set_linklist,ncells,ifirstincell
- integer :: i,icell,ipart,iprev,ifirst
- real    :: t0,t1,t2
+ integer         :: i,ipart,iprev,ifirst
+ integer(kind=8) :: icell
+ real            :: t0,t1,t2
 
  call cpu_time(t0)
- call set_linklist(npart,xyzh,vxyzu)  ! don't include MPI ghosts
+ call set_linklist(npart,npart,xyzh,vxyzu)  ! don't include MPI ghosts
  call cpu_time(t1)
  write(iprint,*) '> sorting particles...',t1-t0,'s for linklist'
 

--- a/src/main/sort_particles.F90
+++ b/src/main/sort_particles.F90
@@ -17,7 +17,7 @@ module sort_particles
 ! :Dependencies: dim, io, linklist, part, sortutils
 !
  implicit none
- public :: sort_part_radius
+ public :: sort_part_radius, sort_part_id
 #ifdef SORT
  public :: sort_part
 #endif
@@ -143,5 +143,32 @@ subroutine sort_part_radius(np)
  write(iprint,*) '> sort completed in ',t2-t1,'s'
 
 end subroutine sort_part_radius
+
+!----------------------------------------------------------------
+!+
+!  this version sorts the particles by ID
+!+
+!----------------------------------------------------------------
+subroutine sort_part_id
+   use io,        only:iprint,error
+   use part,      only:reorder_particles,npart,ll,iorig
+   use sortutils, only:indexx
+   real :: t1,t2
+
+   call cpu_time(t1)
+   write(iprint,*) '> sorting particles by ID...'
+
+   call indexx(npart,real(iorig),ll)
+
+   write(iprint,*) ' copying arrays...'
+  !
+  !--copy arrays into correct order
+  !
+   call reorder_particles(ll,npart)
+
+   call cpu_time(t2)
+   write(iprint,*) '> sort completed in ',t2-t1,'s'
+
+  end subroutine sort_part_id
 
 end module sort_particles

--- a/src/main/sort_particles.F90
+++ b/src/main/sort_particles.F90
@@ -158,7 +158,7 @@ subroutine sort_part_id
    call cpu_time(t1)
    write(iprint,*) '> sorting particles by ID...'
 
-   call indexx(npart,real(iorig),ll)
+   call indexx(npart,iorig,ll)
 
    write(iprint,*) ' copying arrays...'
   !

--- a/src/main/utils_dumpfiles.f90
+++ b/src/main/utils_dumpfiles.f90
@@ -1993,9 +1993,9 @@ subroutine read_array_int8(iarr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag,ma
  integer,          intent(in)    :: ikind,i1,i2,noffset,iunit
  logical,          intent(inout) :: matched
  integer,          intent(out)   :: ierr
- integer      :: i
- real(kind=8) :: dum
- logical      :: match_datatype
+ integer         :: i
+ integer(kind=8) :: dum
+ logical         :: match_datatype
 
  if (matched) return
  match_datatype = (ikind==i_int8)

--- a/src/main/utils_dumpfiles.f90
+++ b/src/main/utils_dumpfiles.f90
@@ -1929,9 +1929,9 @@ subroutine read_array_int1(iarr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag,ma
  integer,          intent(in)    :: ikind,i1,i2,noffset,iunit
  logical,          intent(inout) :: matched
  integer,          intent(out)   :: ierr
- integer      :: i
- real(kind=4) :: dum
- logical      :: match_datatype
+ integer         :: i
+ integer(kind=1) :: dum
+ logical         :: match_datatype
 
  if (matched) return
  match_datatype = (ikind==i_int1)
@@ -1994,7 +1994,7 @@ subroutine read_array_int8(iarr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag,ma
  logical,          intent(inout) :: matched
  integer,          intent(out)   :: ierr
  integer      :: i
- real(kind=4) :: dum
+ real(kind=8) :: dum
  logical      :: match_datatype
 
  if (matched) return

--- a/src/main/utils_dumpfiles_hdf5.f90
+++ b/src/main/utils_dumpfiles_hdf5.f90
@@ -375,7 +375,7 @@ subroutine write_hdf5_arrays( &
                                 divcurlv(:,:),     &
                                 divcurlB(:,:)
  integer(kind=1), intent(in) :: iphase(:)
- integer,         intent(in) :: iorig(:)
+ integer(kind=8), intent(in) :: iorig(:)
  type (arrays_options_hdf5), intent(in) :: array_options
 
  integer(HID_T) :: group_id
@@ -799,7 +799,7 @@ subroutine read_hdf5_arrays( &
  type (arrays_options_hdf5), intent(in)  :: array_options
  type (got_arrays_hdf5),     intent(out) :: got_arrays
  integer(kind=1), intent(out) :: iphase(:)
- integer,         intent(out) :: iorig(:)
+ integer(kind=8), intent(out) :: iorig(:)
  real,            intent(out) :: xyzh(:,:),         &
                                  vxyzu(:,:),        &
                                  xyzmh_ptmass(:,:), &

--- a/src/main/utils_sort.f90
+++ b/src/main/utils_sort.f90
@@ -18,6 +18,9 @@ module sortutils
 !
  implicit none
  public :: indexx,indexxfunc,r2func,r2func_origin,set_r2func_origin
+ interface indexx
+  module procedure indexx_r4, indexx_i8
+ end interface indexx
 
  private
  real, private :: x0,y0,z0
@@ -58,10 +61,10 @@ real function r2func_origin(xyzh)
 end function r2func_origin
 !----------------------------------------------------------------
 !+
-!  standard sorting routine using Quicksort
+!  standard sorting routine using Quicksort for real*4
 !+
 !----------------------------------------------------------------
-subroutine indexx(n, arr, indx)
+subroutine indexx_r4(n, arr, indx)
  integer, parameter :: m=7, nstack=500
  integer, intent(in)  :: n
  real,    intent(in)  :: arr(n)
@@ -150,7 +153,104 @@ subroutine indexx(n, arr, indx)
  endif
 
  goto 1
-end subroutine indexx
+
+end subroutine indexx_r4
+
+!----------------------------------------------------------------
+!+
+!  standard sorting routine using Quicksort for integer*8
+!+
+!----------------------------------------------------------------
+subroutine indexx_i8(n, arr, indx)
+   integer,            parameter :: m=7, nstack=500
+   integer,            intent(in)  :: n
+   integer(kind=8),    intent(in)  :: arr(n)
+   integer,            intent(out) :: indx(n)
+
+   integer :: i,j,k,l,ir,jstack,indxt,itemp
+   integer :: istack(nstack)
+   integer(kind=8) :: a
+
+   do j = 1, n
+      indx(j) = j
+   enddo
+   jstack = 0
+   l = 1
+   ir = n
+
+  1 if (ir - l < m) then
+      do j = l + 1, ir
+         indxt = indx(j)
+         a = arr(indxt)
+         do i = j - 1, 1, -1
+            if (arr(indx(i)) <= a) goto 2
+            indx(i + 1) = indx(i)
+         enddo
+         i = 0
+  2      indx(i + 1) = indxt
+      enddo
+      if (jstack==0) return
+      ir = istack(jstack)
+      l = istack(jstack - 1)
+      jstack = jstack - 2
+   else
+      k = (l + ir)/2
+      itemp = indx(k)
+      indx(k) = indx(l + 1)
+      indx(l + 1) = itemp
+      if (arr(indx(l + 1)) > arr(indx(ir))) then
+         itemp = indx(l + 1)
+         indx(l + 1) = indx(ir)
+         indx(ir) = itemp
+      endif
+      if (arr(indx(l)) > arr(indx(ir))) then
+         itemp = indx(l)
+         indx(l) = indx(ir)
+         indx(ir) = itemp
+      endif
+      if (arr(indx(l + 1)) > arr(indx(l))) then
+         itemp = indx(l + 1)
+         indx(l + 1) = indx(l)
+         indx(l) = itemp
+      endif
+      i = l + 1
+      j = ir
+      indxt = indx(l)
+      a = arr(indxt)
+
+  3   continue
+      i = i + 1
+      if (arr(indx(i)) < a) goto 3
+  4   continue
+      j = j - 1
+      if (arr(indx(j)) > a) goto 4
+      if (j < i) goto 5
+      itemp = indx(i)
+      indx(i) = indx(j)
+      indx(j) = itemp
+      goto 3
+
+  5   indx(l) = indx(j)
+      indx(j) = indxt
+      jstack = jstack + 2
+      if (jstack > nstack) then
+         print*,'fatal error!!! stacksize exceeded in sort'
+         print*,'need to set parameter nstack higher in subroutine indexx '
+         stop
+      endif
+      if (ir - i + 1 >= j - l) then
+         istack(jstack) = ir
+         istack(jstack - 1) = i
+         ir = j - 1
+      else
+         istack(jstack) = j - 1
+         istack(jstack - 1) = l
+         l = i
+      endif
+   endif
+
+   goto 1
+  end subroutine indexx_i8
 
 !----------------------------------------------------------------
 !+

--- a/src/tests/test_rwdump.F90
+++ b/src/tests/test_rwdump.F90
@@ -244,9 +244,9 @@ subroutine test_rwdump(ntests,npass)
        call checkval(Bextz,Bextzwas,tiny(Bextz),nfailed(20),'Bextz')
     endif
     if (itest==1) then  ! iorig is not dumped to small dumps
-       call checkval(iorig(2),    ngas,    0,nfailed(65),'iorig(2)')
-       call checkval(iorig(ngas), npart+1, 0,nfailed(66),'iorig(ngas)')
-       call checkval(iorig(npart),npart,   0,nfailed(67),'iorig(N)')
+       call checkval(iorig(2),    int(ngas   ,kind=8), 0,nfailed(65),'iorig(2)')
+       call checkval(iorig(ngas), int(npart+1,kind=8), 0,nfailed(66),'iorig(ngas)')
+       call checkval(iorig(npart),int(npart  ,kind=8), 0,nfailed(67),'iorig(N)')
     endif
 
     call update_test_scores(ntests,nfailed,npass)

--- a/src/tests/utils_testsuite.f90
+++ b/src/tests/utils_testsuite.f90
@@ -30,7 +30,7 @@ module testutils
  interface checkval
   module procedure checkvalconst,checkvalconstr4,checkvalconsti1
   module procedure checkval1_r4,checkval1_r8,checkval1_int,checkval1_int8,checkval1_logical
-  module procedure checkval_r8arr,checkval_r4arr
+  module procedure checkval_r8arr,checkval_r4arr,checkval_i8arr
  end interface checkval
 
  interface checkvalf
@@ -46,7 +46,7 @@ module testutils
  end interface checkvalbuf_end
 
  interface printerr
-  module procedure printerr_real,printerr_int,printerr_logical
+  module procedure printerr_real,printerr_int,printerr_int8,printerr_logical
  end interface
 
  interface printresult
@@ -538,6 +538,54 @@ end subroutine checkval_r4arr
 
 !----------------------------------------------------------------
 !+
+!  checks an array of integer*8 values against an array of expected answers
+!+
+!----------------------------------------------------------------
+subroutine checkval_i8arr(n,x,xexact,tol,ndiff,label,checkmask)
+   integer,          intent(in)  :: n
+   integer(kind=8),  intent(in)  :: x(:),xexact(:)
+   integer(kind=8),  intent(in)  :: tol
+   integer,          intent(out) :: ndiff
+   character(len=*), intent(in)  :: label
+   logical, optional,intent(in)  :: checkmask(:)
+   integer :: i,nval
+   integer(kind=8) :: val
+   integer(kind=8) :: erri,errmax
+   integer :: itol, ierrmax
+
+   call print_testinfo(trim(label))
+
+   ndiff = 0
+   errmax = 0
+   nval = 0
+   do i=1,n
+      if (present(checkmask)) then
+         if (.not. checkmask(i)) cycle
+      endif
+      val = xexact(i)
+      erri = abs(x(i)-val)
+
+      if (erri > tol .or. erri /= erri) then
+         ndiff = ndiff + 1
+         if (ndiff==1) write(*,*)
+         if (ndiff < 10 .or. erri > 2.*errmax) then
+            call printerr(label,x(i),val,erri,tol)
+         endif
+      endif
+      nval = nval + 1
+      errmax = max(errmax,erri)
+   enddo
+
+   ierrmax = int(errmax)
+   itol = int(tol)
+
+   call printresult(n,ndiff,ierrmax,itol)
+
+   return
+  end subroutine checkval_i8arr
+
+!----------------------------------------------------------------
+!+
 !  start a buffered error check
 !+
 !----------------------------------------------------------------
@@ -711,6 +759,26 @@ subroutine printerr_int(label,ix,ival,erri,itol)
 
  return
 end subroutine printerr_int
+
+!----------------------------------------------------------------
+!+
+!  formatting for printing errors in test results
+!+
+!----------------------------------------------------------------
+subroutine printerr_int8(label,ix,ival,erri,itol)
+   character(len=*), intent(in) :: label
+   integer(kind=8),  intent(in) :: ix, ival, erri, itol
+
+   if (itol > 0) then
+      write(*,"(1x,4(a,i10),a)") &
+        trim(label)//' = ',ix,' should be ',ival,' err =',erri,' (tol =',itol,')'
+   else
+      write(*,"(1x,3(a,i10),a)") &
+        trim(label)//' = ',ix,' should be ',ival,' err =',erri
+   endif
+
+   return
+  end subroutine printerr_int8
 
 !----------------------------------------------------------------
 !+

--- a/src/tests/utils_testsuite.f90
+++ b/src/tests/utils_testsuite.f90
@@ -770,10 +770,10 @@ subroutine printerr_int8(label,ix,ival,erri,itol)
    integer(kind=8),  intent(in) :: ix, ival, erri, itol
 
    if (itol > 0) then
-      write(*,"(1x,4(a,i10),a)") &
+      write(*,"(1x,4(a,i19),a)") &
         trim(label)//' = ',ix,' should be ',ival,' err =',erri,' (tol =',itol,')'
    else
-      write(*,"(1x,3(a,i10),a)") &
+      write(*,"(1x,3(a,i19),a)") &
         trim(label)//' = ',ix,' should be ',ival,' err =',erri
    endif
 

--- a/src/utils/diffdumps.f90
+++ b/src/utils/diffdumps.f90
@@ -91,7 +91,7 @@ program diffdumps
  idiff = .false.
  ndiffu = 0
  err = 0.
- call checkval(npart,iorig(:),iorig2(:),0.0,ndiffid,'iorig')
+ call checkval(npart,iorig(:),iorig2(:),int(0,kind=8),ndiffid,'id')
 
  call checkval(npart,xyzh(1,:),xyzh2(1,:),tolerance,ndiffx,'x',rmserr=err(1))
  call checkval(npart,xyzh(2,:),xyzh2(2,:),tolerance,ndiffy,'y',rmserr=err(2))

--- a/src/utils/diffdumps.f90
+++ b/src/utils/diffdumps.f90
@@ -19,7 +19,7 @@ program diffdumps
 ! :Dependencies: dim, io, part, readwrite_dumps, testutils
 !
  use dim,     only:maxp,maxvxyzu,tagline
- use part,    only:xyzh,vxyzu,npart,hfact
+ use part,    only:xyzh,vxyzu,npart,hfact,iorig
  use io,      only:set_io_unit_numbers,iprint,idisk1,real4
  use readwrite_dumps, only:read_dump
  use testutils,       only:checkval
@@ -27,9 +27,10 @@ program diffdumps
  implicit none
  integer                      :: nargs
  character(len=120)           :: dumpfile,dumpfile2,tolstring
- real, allocatable :: xyzh2(:,:)
- real, allocatable :: vxyzu2(:,:)
- integer :: ierr,ndiff,ndiffx,ndiffy,ndiffz,ndiffh,ndiffvx,ndiffvy,ndiffvz,ndiffu
+ integer(kind=8), allocatable :: iorig2(:)
+ real,            allocatable :: xyzh2(:,:)
+ real,            allocatable :: vxyzu2(:,:)
+ integer :: ierr,ndiff,ndiffx,ndiffy,ndiffz,ndiffh,ndiffvx,ndiffvy,ndiffvz,ndiffu,ndiffid
  real    :: time,time2,hfact2,tolerance,err(8)
  logical :: idiff
 
@@ -60,6 +61,9 @@ program diffdumps
  call read_dump(trim(dumpfile),time,hfact,idisk1,iprint,0,1,ierr)
  if (ierr /= 0) stop 'error reading first dumpfile'
 
+ allocate (iorig2(maxp),stat=ierr)
+ if (ierr /= 0) stop 'error allocating memory to store iorig'
+
  allocate (xyzh2(4,maxp),stat=ierr)
  if (ierr /= 0) stop 'error allocating memory to store positions'
 
@@ -69,6 +73,7 @@ program diffdumps
 !  Sort first dump by ID
  call sort_part_id
 
+ iorig2 = iorig
  xyzh2 = xyzh
  vxyzu2 = vxyzu
 !
@@ -86,6 +91,8 @@ program diffdumps
  idiff = .false.
  ndiffu = 0
  err = 0.
+ call checkval(npart,iorig(:),iorig2(:),0.0,ndiffid,'iorig')
+
  call checkval(npart,xyzh(1,:),xyzh2(1,:),tolerance,ndiffx,'x',rmserr=err(1))
  call checkval(npart,xyzh(2,:),xyzh2(2,:),tolerance,ndiffy,'y',rmserr=err(2))
  call checkval(npart,xyzh(3,:),xyzh2(3,:),tolerance,ndiffz,'z',rmserr=err(3))
@@ -97,12 +104,14 @@ program diffdumps
  if (maxvxyzu >= 4) call checkval(npart,vxyzu(4,:),vxyzu2(4,:),tolerance,ndiffu,'u',rmserr=err(8))
 
  print "(/,a,/)",' diffdumps: we wish you a pleasant journey '
+ print *,'      particle IDs differ ',ndiffid,' times'
  print *,'         positions differ ',max(ndiffx,ndiffy,ndiffz),' times'
  print *,' smoothing lengths differ ',ndiffh,' times'
  print *,'        velocities differ ',max(ndiffvx,ndiffvy,ndiffvz),' times'
  if (maxvxyzu >=4) print *,'  thermal energies differ ',ndiffu,' times'
 
- ndiff = ndiffx + ndiffy + ndiffz + ndiffh + ndiffvx + ndiffvy + ndiffvz + ndiffu
+ ndiff = ndiffid + ndiffx + ndiffy + ndiffz + ndiffh + ndiffvx + ndiffvy + ndiffvz + ndiffu
+ if (allocated(iorig2)) deallocate(iorig2)
  if (allocated(xyzh2)) deallocate(xyzh2)
  if (allocated(vxyzu2)) deallocate(vxyzu2)
 

--- a/src/utils/diffdumps.f90
+++ b/src/utils/diffdumps.f90
@@ -23,6 +23,7 @@ program diffdumps
  use io,      only:set_io_unit_numbers,iprint,idisk1,real4
  use readwrite_dumps, only:read_dump
  use testutils,       only:checkval
+ use sort_particles,  only:sort_part_id
  implicit none
  integer                      :: nargs
  character(len=120)           :: dumpfile,dumpfile2,tolstring
@@ -65,6 +66,9 @@ program diffdumps
  allocate (vxyzu2(maxvxyzu,maxp),stat=ierr)
  if (ierr /= 0) stop 'error allocating memory to store velocities'
 
+!  Sort first dump by ID
+ call sort_part_id
+
  xyzh2 = xyzh
  vxyzu2 = vxyzu
 !
@@ -72,6 +76,9 @@ program diffdumps
 !
  call read_dump(trim(dumpfile2),time2,hfact2,idisk1+1,iprint,0,1,ierr)
  if (ierr /= 0) stop 'error reading second dumpfile'
+
+!  Sort second dump by ID
+ call sort_part_id
 
 ! call diffarr(hfact2,hfact,0,'hfact',ndiffh)
 ! call diffarr(time2,time,0,'time',ndiffh)

--- a/src/utils/libphantom-evolve.F90
+++ b/src/utils/libphantom-evolve.F90
@@ -179,9 +179,6 @@ subroutine finalize_step(infile, logfile, evfile, dumpfile)
 #ifdef DRIVING
  use forcing,          only:write_forcingdump
 #endif
-#ifdef SORT
- use sort_particles,   only:sort_part
-#endif
 #ifdef CORRECT_BULK_MOTION
  use centreofmass,     only:correct_bulk_motion
 #endif
@@ -332,9 +329,6 @@ subroutine finalize_step(infile, logfile, evfile, dumpfile)
        ncount_fulldumps = ncount_fulldumps + 1
 
 #ifndef IND_TIMESTEPS
-#ifdef SORT
-       if (time < tmax) call sort_part()
-#endif
 #endif
     else
        call write_smalldump(time,dumpfile)


### PR DESCRIPTION
Implement particle tracking for MPI by carrying the `iorig` array in MPI communications.

Change `iorig` to `int*8` as suggested by @danieljprice.

Particle order in the output files of MPI runs will in general be different, so `diffdumps` will not function correctly. This is fixed by sorting particles by ID prior to comparing arrays so that the same particles are being compared.

Needs #157 to function correctly.

Resolves #154.