### PR TITLE
Fix typos in hdf5 utils

### DIFF
--- a/src/main/utils_dumpfiles_hdf5.f90
+++ b/src/main/utils_dumpfiles_hdf5.f90
@@ -148,7 +148,8 @@ module utils_dumpfiles_hdf5
                got_krome_mols(max_krome_nmols_hdf5), &
                got_krome_gamma,                      &
                got_krome_mu,                         &
-               got_krome_T
+               got_krome_T,                          &
+               got_orig
  end type
 
  type arrays_options_hdf5
@@ -972,7 +973,7 @@ subroutine read_hdf5_arrays( &
  endif
 
  call read_from_hdf5(iorig, 'iorig', group_id, got, error)
- if (got) got_arrays%got_orig = .true
+ if (got) got_arrays%got_orig = .true.
 
  ! Close the particles group
  call close_hdf5group(group_id, error)


### PR DESCRIPTION
Fix some trivial typos in HDF5 utils. Introduced in c21cf7c2fb281dfea67c7e929985d3b1102b2df6; these changes were probably not tested before committing. 