### PR TITLE
Add HDF5 support to diffdumps

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -2185,7 +2185,7 @@ diffdumps: checksys checkparams $(OBJDUMP) utils_testsuite.o diffdumps.o
 	@echo ""
 	@echo "diffdumps: we welcome you"
 	@echo ""
-	$(FC) $(FFLAGS) -o $(BINDIR)/$@ $(OBJDUMP) utils_testsuite.o diffdumps.o
+	$(FC) $(FFLAGS) -o $(BINDIR)/$@ $(OBJDUMP) utils_testsuite.o diffdumps.o $(LDFLAGS)
 
 cleandiffdumps:
 	rm -f $(BINDIR)/phantom2divb

--- a/src/utils/diffdumps.f90
+++ b/src/utils/diffdumps.f90
@@ -21,7 +21,7 @@ program diffdumps
  use dim,     only:maxp,maxvxyzu,tagline
  use part,    only:xyzh,vxyzu,npart,hfact
  use io,      only:set_io_unit_numbers,iprint,idisk1,real4
- use readwrite_dumps, only:read_dump
+ use readwrite_dumps, only:read_dump,init_readwrite_dumps
  use testutils,       only:checkval
  implicit none
  integer                      :: nargs
@@ -53,6 +53,12 @@ program diffdumps
  endif
 
  print "(/,a,/)",' diffdumps: we welcome you'
+
+!
+!--Init readwrite dumps (switches between native and HDF5 outputs)
+!
+ call init_readwrite_dumps
+
 !
 !--read particle setup from first dumpfile
 !


### PR DESCRIPTION
Add a missing init call and LDFLAGS in makefile.

Needed to test if #159 applies to HDF5 outputs.