### PR TITLE
Fix showarrays incorrectly reading files as single precision

### DIFF
--- a/src/main/utils_dumpfiles.f90
+++ b/src/main/utils_dumpfiles.f90
@@ -2384,6 +2384,8 @@ subroutine print_arrays_in_file(iunit,filename)
  integer(kind=1) :: i1(ndisplay)
  logical         :: singleprec
 
+ singleprec = .false.
+
  ! open file for read
  call open_dumpfile_rh(iunit,filename,nblocks,narraylengths,ierr,id=fileid)
  if (ierr == ierr_realsize) then


### PR DESCRIPTION
singleprec is not initialised to .false., so double precision files may be incorrectly read as single precision, causing showarrays to print out junk values.

Resolves #163. The problem is not with the native phantom outputs themselves; it is caused by a bad reader. This problem did not arise with HDF5 outputs because an external HDF5 file reader was used to examine the values. This problem was not unique to sink particles; it affected all arrays.