### PR TITLE
Sinks can now merge

### DIFF
--- a/src/main/centreofmass.f90
+++ b/src/main/centreofmass.f90
@@ -130,13 +130,15 @@ subroutine get_centreofmass(xcom,vcom,npart,xyzh,vxyzu,nptmass,xyzmh_ptmass,vxyz
  if (id==master .and. present(xyzmh_ptmass) .and. present(vxyz_ptmass) .and. present(nptmass)) then
     do i=1,nptmass
        pmassi = xyzmh_ptmass(4,i)
-       totmass = totmass + pmassi
-       xpos  = xpos  + pmassi*xyzmh_ptmass(1,i)
-       ypos  = ypos  + pmassi*xyzmh_ptmass(2,i)
-       zpos  = zpos  + pmassi*xyzmh_ptmass(3,i)
-       vxpos = vxpos + pmassi*vxyz_ptmass(1,i)
-       vypos = vypos + pmassi*vxyz_ptmass(2,i)
-       vzpos = vzpos + pmassi*vxyz_ptmass(3,i)
+       if (pmassi > 0.) then
+          totmass = totmass + pmassi
+          xpos  = xpos  + pmassi*xyzmh_ptmass(1,i)
+          ypos  = ypos  + pmassi*xyzmh_ptmass(2,i)
+          zpos  = zpos  + pmassi*xyzmh_ptmass(3,i)
+          vxpos = vxpos + pmassi*vxyz_ptmass(1,i)
+          vypos = vypos + pmassi*vxyz_ptmass(2,i)
+          vzpos = vzpos + pmassi*vxyz_ptmass(3,i)
+       endif
     enddo
  endif
  xcom = (/xpos,ypos,zpos/)
@@ -219,11 +221,13 @@ subroutine correct_bulk_motion()
 !
 !$omp do
  do i=1,nptmass
-    pmassi  = xyzmh_ptmass(4,i)
-    totmass = totmass + pmassi
-    xmom    = xmom + pmassi*vxyz_ptmass(1,i)
-    ymom    = ymom + pmassi*vxyz_ptmass(2,i)
-    zmom    = zmom + pmassi*vxyz_ptmass(3,i)
+    if (pmassi > 0.) then
+       pmassi  = xyzmh_ptmass(4,i)
+       totmass = totmass + pmassi
+       xmom    = xmom + pmassi*vxyz_ptmass(1,i)
+       ymom    = ymom + pmassi*vxyz_ptmass(2,i)
+       zmom    = zmom + pmassi*vxyz_ptmass(3,i)
+    endif
  enddo
 !$omp enddo
 !$omp end parallel

--- a/src/main/checksetup.F90
+++ b/src/main/checksetup.F90
@@ -522,7 +522,9 @@ subroutine check_setup_ptmass(nerror,nwarn,hmin)
  !  or within each others accretion radii
  !
  do i=1,nptmass
+    if (xyzmh_ptmass(4,i) < 0.) cycle
     do j=i+1,nptmass
+       if (xyzmh_ptmass(4,j) < 0.) cycle
        dx = xyzmh_ptmass(1:3,j) - xyzmh_ptmass(1:3,i)
        r  = sqrt(dot_product(dx,dx))
        if (r <= tiny(r)) then
@@ -541,21 +543,20 @@ subroutine check_setup_ptmass(nerror,nwarn,hmin)
  !
  n = 0
  do i=1,nptmass
-    if (.not.in_range(xyzmh_ptmass(4,i),0.)) then
+    if (.not.in_range(xyzmh_ptmass(4,i))) then
        nerror = nerror + 1
        print*,' Error in setup: sink ',i,' mass = ',xyzmh_ptmass(4,i)
-    elseif (xyzmh_ptmass(4,i) < tiny(0.)) then
+    elseif (xyzmh_ptmass(4,i) < 0.) then
+       print*,' Sink ',i,' has previously merged with another sink'
        n = n + 1
     endif
  enddo
- if (n > 0) then
-    print*,'WARNING: ',n,' sink particles have zero mass '
-    nwarn = nwarn + 1
- endif
+ if (n > 0) print*,'The ptmass arrays have ',n,' sinks that have previously merged (i.e. have mass < 0)'
  !
  !  check that accretion radii are positive
  !
  do i=1,nptmass
+    if (xyzmh_ptmass(4,i) < 0.) cycle
     hsink = max(xyzmh_ptmass(ihacc,i),xyzmh_ptmass(ihsoft,i))
     if (hsink <= 0.) then
        nerror = nerror + 1

--- a/src/main/cooling.F90
+++ b/src/main/cooling.F90
@@ -7,6 +7,14 @@
 module cooling
 !
 ! Gas cooling
+!  Current options:
+!     0 = none
+!     1 = 'explicit' cooling [implicitly calculated, ironically] [default]
+!         (not sure what this actually means, but requires a lot of non-default inputs)
+!     2 = Townsend (2009) cooling tables [implicitly calculated]
+!     3 = Gammie cooling [explicitly calculated]
+!     5 = Koyama & Inutuska (2002) [explicitly calculated]
+!     6 = Koyama & Inutuska (2002) [implicitly calculated][not yet implemented; JHW]
 !
 ! :References:
 !   Koyama & Inutsuka (2002), ApJL 564, 97-100
@@ -51,17 +59,17 @@ module cooling
  private
  integer, parameter :: nTg = 64
  integer, parameter :: maxt = 1000
- real,    parameter :: Tref = 1.d5, T_floor = 10.
+ real,    parameter :: Tref = 1.d5, T_floor = 10.   ! required for exact_cooling
  integer :: nt
  real    :: temper(maxt),lambda(maxt),slope(maxt),yfunc(maxt)
  real    :: beta_cool  = 3.
  real    :: habund     = 0.7
- real    :: temp_floor = 1.e4
+ real    :: temp_floor = 1.e4                       ! required for exact_cooling_table
  real    :: Tgrid(nTg)
  real    :: crate_coef
  integer :: icool_radiation_H0 = 0, icool_relax_Bowen = 0, icool_dust_collision = 0, icool_relax_Stefan = 0
  character(len=120) :: cooltable = 'cooltable.dat'
- !--Minimum temperature (failsafe to prevent u < 0)
+ !--Minimum temperature (failsafe to prevent u < 0); optional for ALL cooling options
  real,    public :: Tfloor = 0. ! [K]; set in .in file.  On if Tfloor > 0.
  real,    public :: ufloor = 0. ! [code units]; set in init_cooling
 
@@ -694,7 +702,7 @@ subroutine write_options_cooling(iunit)
     case(2)
        call write_inopt(cooltable,'cooltable','data file containing cooling function',iunit)
        call write_inopt(habund,'habund','Hydrogen abundance assumed in cooling function',iunit)
-       call write_inopt(temp_floor,'temp_floor','Minimum allowed temperature in K',iunit)
+       call write_inopt(temp_floor,'temp_floor','Minimum allowed temperature in K for Townsend cooling table',iunit)
     case(3)
        call write_inopt(beta_cool,'beta_cool','beta factor in Gammie (2001) cooling',iunit)
     end select

--- a/src/main/energies.F90
+++ b/src/main/energies.F90
@@ -545,6 +545,7 @@ subroutine compute_energies(t)
        yi     = xyzmh_ptmass(2,i)
        zi     = xyzmh_ptmass(3,i)
        pmassi = xyzmh_ptmass(4,i)
+       if (pmassi < 0.) cycle
 
        vxi    = vxyz_ptmass(1,i)
        vyi    = vxyz_ptmass(2,i)

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -638,7 +638,8 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
                 !
                 use_part = .true.
                 over_ptmass: do j=1,nptmass
-                   if ((xyzh(1,i) - xyzmh_ptmass(1,j))**2 &
+                   if (xyzmh_ptmass(4,j) > 0. .and.
+                       (xyzh(1,i) - xyzmh_ptmass(1,j))**2 &
                      + (xyzh(2,i) - xyzmh_ptmass(2,j))**2 &
                      + (xyzh(3,i) - xyzmh_ptmass(3,j))**2 < r_crit2) then
                       use_part = .false.

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -638,7 +638,7 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
                 !
                 use_part = .true.
                 over_ptmass: do j=1,nptmass
-                   if (xyzmh_ptmass(4,j) > 0. .and.
+                   if (xyzmh_ptmass(4,j) > 0. .and.       &
                        (xyzh(1,i) - xyzmh_ptmass(1,j))**2 &
                      + (xyzh(2,i) - xyzmh_ptmass(2,j))**2 &
                      + (xyzh(3,i) - xyzmh_ptmass(3,j))**2 < r_crit2) then

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -120,7 +120,8 @@ end subroutine initialise
 !----------------------------------------------------------------
 subroutine startrun(infile,logfile,evfile,dumpfile)
  use mpiutils,         only:reduce_mpi,waitmyturn,endmyturn,reduceall_mpi,barrier_mpi
- use dim,              only:maxp,maxalpha,maxvxyzu,nalpha,mhd,maxdusttypes,do_radiation,gravity,use_dust
+ use dim,              only:maxp,maxalpha,maxvxyzu,maxptmass,maxdusttypes, &
+                            nalpha,mhd,do_radiation,gravity,use_dust
  use deriv,            only:derivs
  use evwrite,          only:init_evfile,write_evfile,write_evlog
  use io,               only:idisk1,iprint,ievfile,error,iwritein,flush_warnings,&
@@ -157,7 +158,8 @@ subroutine startrun(infile,logfile,evfile,dumpfile)
  use nicil_sup,        only:use_consistent_gmw
 #endif
  use ptmass,           only:init_ptmass,get_accel_sink_gas,get_accel_sink_sink, &
-                            h_acc,r_crit,r_crit2,rho_crit,rho_crit_cgs,icreate_sinks
+                            h_acc,r_crit,r_crit2,rho_crit,rho_crit_cgs,icreate_sinks, &
+                            r_merge_uncond,r_merge_cond,r_merge_uncond2,r_merge_cond2,r_merge2
  use timestep,         only:time,dt,dtextforce,C_force,dtmax
  use timing,           only:get_timings
 #ifdef SORT
@@ -225,7 +227,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile)
  use fileutils,        only:make_tags_unique
  character(len=*), intent(in)  :: infile
  character(len=*), intent(out) :: logfile,evfile,dumpfile
- integer         :: ierr,i,j,nerr,nwarn,ialphaloc
+ integer         :: ierr,i,j,nerr,nwarn,ialphaloc,merge_n,merge_ij(maxptmass)
  integer(kind=8) :: npartoftypetot(maxtypes)
  real            :: poti,dtf,hfactfile,fextv(3)
  real            :: hi,pmassi,rhoi1
@@ -474,6 +476,9 @@ subroutine startrun(infile,logfile,evfile,dumpfile)
  dtsinkgas = huge(dtsinkgas)
  r_crit2   = r_crit*r_crit
  rho_crit  = rho_crit_cgs/unit_density
+ r_merge_uncond2 = r_merge_uncond**2
+ r_merge_cond2   = r_merge_cond**2
+ r_merge2        = max(r_merge_uncond2,r_merge_cond2)
  if (rhofinal_cgs > 0.) then
     rhofinal1 = unit_density/rhofinal_cgs
  else
@@ -484,7 +489,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile)
 
     ! compute initial sink-sink forces and get timestep
     call get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,epot_sinksink,dtsinksink,&
-                             iexternalforce,time)
+                             iexternalforce,time,merge_ij,merge_n)
     dtsinksink = C_force*dtsinksink
     write(iprint,*) 'dt(sink-sink) = ',dtsinksink
     dtextforce = min(dtextforce,dtsinksink)
@@ -512,6 +517,9 @@ subroutine startrun(infile,logfile,evfile,dumpfile)
     write(iprint,*) ' h_fact*(m/rho_crit)^(1/3) = ',hfactfile*(massoftype(igas)/rho_crit)**(1./3.)*udist,'cm'
     write(iprint,*) ' rho_crit         == ',rho_crit_cgs,'g cm^{-3}'
     write(iprint,*) ' m(h_fact/h_acc)^3 = ', massoftype(igas)*(hfactfile/h_acc)**3*unit_density,'g cm^{-3}'
+    if (r_merge_uncond < 2.0*h_acc) then
+       write(iprint,*) ' WARNING! Sink creation is on, but but merging is off!  Suggest setting r_merge_uncond >= 2.0*h_acc'
+    endif
  endif
 !
 !--inject particles at t=0, and get timestep constraint on this

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -1713,7 +1713,7 @@ real function Omega_k(i)
     m_star = xyzmh_ptmass(4,1)
  else
     do j=1,nptmass
-       m_star = m_star + xyzmh_ptmass(4,j)
+       if (xyzmh_ptmass(4,j) > 0.) m_star = m_star + xyzmh_ptmass(4,j)
     enddo
  endif
 

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -43,6 +43,7 @@ module ptmass
  public :: init_ptmass, finish_ptmass
  public :: pt_write_sinkev, pt_close_sinkev
  public :: get_accel_sink_gas, get_accel_sink_sink
+ public :: merge_sinks
  public :: ptmass_predictor, ptmass_corrector
  public :: ptmass_not_obscured
  public :: ptmass_accrete, ptmass_create
@@ -61,10 +62,15 @@ module ptmass
  real,    public :: f_acc  = 0.8
  real,    public :: h_soft_sinkgas  = 0.0
  real,    public :: h_soft_sinksink = 0.0
+ real,    public :: r_merge_uncond  = 0.0    ! sinks will unconditionally merge if they touch
+ real,    public :: r_merge_cond    = 0.0    ! sinks will merge if bound within this radius
 
  ! additional public variables
  integer, public :: ipart_rhomax
  real,    public :: r_crit2,rho_crit
+ real,    public :: r_merge2        = 0.0 ! initialise to prevent test failure
+ real,    public :: r_merge_uncond2 = 0.0 ! initialise to prevent test failure
+ real,    public :: r_merge_cond2   = 0.0 ! initialise to prevent test failure
 
  ! calibration of timestep control on sink-sink and sink-gas orbital integration
  ! this is hardwired because can be adjusted by changing C_force
@@ -149,6 +155,7 @@ subroutine get_accel_sink_gas(nptmass,xi,yi,zi,hi,xyzmh_ptmass,fxi,fyi,fzi,phi, 
     pmassj = xyzmh_ptmass(4,j)
     hsoft  = xyzmh_ptmass(ihsoft,j)
     if (hsoft > 0.0) hsoft = max(hsoft,hi)
+    if (pmassj < 0.0) cycle
 
     rr2    = dx*dx + dy*dy + dz*dz + epsilon(rr2)
 #ifdef FINVSQRT
@@ -228,7 +235,7 @@ end subroutine get_accel_sink_gas
 !+
 !----------------------------------------------------------------
 subroutine get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,phitot,dtsinksink,&
-            iexternalforce,ti)
+            iexternalforce,ti,merge_ij,merge_n)
 #ifdef FINVSQRT
  use fastmath,       only:finvsqrt
 #endif
@@ -240,8 +247,9 @@ subroutine get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,phitot,dtsinksin
  real,    intent(out) :: phitot,dtsinksink
  integer, intent(in)  :: iexternalforce
  real,    intent(in)  :: ti
+ integer, intent(out) :: merge_ij(:),merge_n
  real    :: xi,yi,zi,pmassi,pmassj,fxi,fyi,fzi,phii
- real    :: ddr,dx,dy,dz,rr2,dr3,f1,f2
+ real    :: ddr,dx,dy,dz,rr2,rr2j,dr3,f1,f2
  real    :: hsoft1,hsoft21,q2i,qi,psoft,fsoft
  real    :: fextx,fexty,fextz,phiext !,hsofti
  real    :: fterm,pterm,potensoft0
@@ -249,7 +257,9 @@ subroutine get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,phitot,dtsinksin
 
  dtsinksink = huge(dtsinksink)
  fxyz_ptmass(:,:) = 0.
- phitot = 0.
+ phitot   = 0.
+ merge_n  = 0
+ merge_ij = 0
  !
  !--get self-contribution to the potential if sink-sink softening is used
  !
@@ -266,22 +276,23 @@ subroutine get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,phitot,dtsinksin
  !--compute N^2 forces on point mass particles due to each other
  !
  !$omp parallel do default(none) &
- !$omp shared(nptmass,xyzmh_ptmass,fxyz_ptmass) &
+ !$omp shared(nptmass,xyzmh_ptmass,fxyz_ptmass,merge_ij,r_merge2) &
  !$omp shared(iexternalforce,ti,h_soft_sinksink,potensoft0,hsoft1,hsoft21) &
  !$omp private(i,xi,yi,zi,pmassi,pmassj) &
- !$omp private(dx,dy,dz,rr2,ddr,dr3,f1,f2) &
+ !$omp private(dx,dy,dz,rr2,rr2j,ddr,dr3,f1,f2) &
  !$omp private(fxi,fyi,fzi,phii) &
  !$omp private(fextx,fexty,fextz,phiext) &
  !$omp private(q2i,qi,psoft,fsoft) &
  !$omp private(fterm,pterm) &
  !$omp reduction(min:dtsinksink) &
- !$omp reduction(+:phitot)
+ !$omp reduction(+:phitot,merge_n)
  do i=1,nptmass
     xi     = xyzmh_ptmass(1,i)
     yi     = xyzmh_ptmass(2,i)
     zi     = xyzmh_ptmass(3,i)
     pmassi = xyzmh_ptmass(4,i)
     !hsofti = xyzmh_ptmass(5,i)
+    if (pmassi < 0.) cycle
     fxi    = 0.
     fyi    = 0.
     fzi    = 0.
@@ -293,6 +304,7 @@ subroutine get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,phitot,dtsinksin
        dz     = zi - xyzmh_ptmass(3,j)
        pmassj = xyzmh_ptmass(4,j)
        !hsoftj = xyzmh_ptmass(5,j)
+       if (pmassj < 0.) cycle
 
        rr2  = dx*dx + dy*dy + dz*dz + epsilon(rr2)
 
@@ -331,7 +343,19 @@ subroutine get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,phitot,dtsinksin
           pterm = -ddr
           phii  = phii + pmassj*pterm    ! potential (GM/r)
        endif
-
+       if (rr2 < r_merge2) then
+          merge_n = merge_n + 1
+          if (merge_ij(i)==0) then
+             merge_ij(i) = j
+          else
+             ! if we have already identified a nearby sink, replace the tag with the nearest sink
+             dx   = xi - xyzmh_ptmass(1,merge_ij(i))
+             dy   = yi - xyzmh_ptmass(2,merge_ij(i))
+             dz   = zi - xyzmh_ptmass(3,merge_ij(i))
+             rr2j = dx*dx + dy*dy + dz*dz + epsilon(rr2j)
+             if (rr2j < rr2) merge_ij(i) = j
+          endif
+       endif
        phitot = phitot + 0.5*pmassi*pmassj*pterm  ! total potential (G M_1 M_2/r)
     enddo
 
@@ -382,7 +406,7 @@ subroutine get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,phitot,dtsinksin
     !  so that with the default C_force of ~0.25 we get a few
     !  hundred steps per orbit
     !
-    if (f2  >  0) then
+    if (f2 > 0.) then
        dtsinksink = min(dtsinksink,dtfacphi*sqrt(abs(phii)/f2))
     endif
  enddo
@@ -403,7 +427,7 @@ subroutine ptmass_boundary_crossing(nptmass,xyzmh_ptmass)
 
  ncross = 0
  do i = 1,nptmass
-    call cross_boundary(isperiodic,xyzmh_ptmass(:,i),ncross)
+    if (xyzmh_ptmass(4,i) > 0.) call cross_boundary(isperiodic,xyzmh_ptmass(:,i),ncross)
  enddo
 
 end subroutine ptmass_boundary_crossing
@@ -427,15 +451,17 @@ subroutine ptmass_predictor(nptmass,dt,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass)
  !$omp shared(nptmass,dt,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass) &
  !$omp private(i,vxhalfi,vyhalfi,vzhalfi)
  do i=1,nptmass
-    vxhalfi = vxyz_ptmass(1,i) + 0.5*dt*fxyz_ptmass(1,i)
-    vyhalfi = vxyz_ptmass(2,i) + 0.5*dt*fxyz_ptmass(2,i)
-    vzhalfi = vxyz_ptmass(3,i) + 0.5*dt*fxyz_ptmass(3,i)
-    xyzmh_ptmass(1,i) = xyzmh_ptmass(1,i) + dt*vxhalfi
-    xyzmh_ptmass(2,i) = xyzmh_ptmass(2,i) + dt*vyhalfi
-    xyzmh_ptmass(3,i) = xyzmh_ptmass(3,i) + dt*vzhalfi
-    vxyz_ptmass(1,i) = vxhalfi
-    vxyz_ptmass(2,i) = vyhalfi
-    vxyz_ptmass(3,i) = vzhalfi
+    if (xyzmh_ptmass(4,i) > 0.) then
+       vxhalfi = vxyz_ptmass(1,i) + 0.5*dt*fxyz_ptmass(1,i)
+       vyhalfi = vxyz_ptmass(2,i) + 0.5*dt*fxyz_ptmass(2,i)
+       vzhalfi = vxyz_ptmass(3,i) + 0.5*dt*fxyz_ptmass(3,i)
+       xyzmh_ptmass(1,i) = xyzmh_ptmass(1,i) + dt*vxhalfi
+       xyzmh_ptmass(2,i) = xyzmh_ptmass(2,i) + dt*vyhalfi
+       xyzmh_ptmass(3,i) = xyzmh_ptmass(3,i) + dt*vzhalfi
+       vxyz_ptmass(1,i) = vxhalfi
+       vxyz_ptmass(2,i) = vyhalfi
+       vxyz_ptmass(3,i) = vzhalfi
+    endif
  enddo
  !$omp end parallel do
 
@@ -468,35 +494,38 @@ subroutine ptmass_corrector(nptmass,dt,vxyz_ptmass,fxyz_ptmass,xyzmh_ptmass,iext
     !$omp private(vxhalfi,vyhalfi,vzhalfi,fxi,fyi,fzi,fextv) &
     !$omp private(i)
     do i=1,nptmass
-       vxhalfi = vxyz_ptmass(1,i)
-       vyhalfi = vxyz_ptmass(2,i)
-       vzhalfi = vxyz_ptmass(3,i)
-       fxi = fxyz_ptmass(1,i)
-       fyi = fxyz_ptmass(2,i)
-       fzi = fxyz_ptmass(3,i)
-       call update_vdependent_extforce_leapfrog(iexternalforce,&
-            vxhalfi,vyhalfi,vzhalfi,fxi,fyi,fzi,fextv,dt,&
-            xyzmh_ptmass(1,i),xyzmh_ptmass(2,i),xyzmh_ptmass(3,i))
-       fxi = fxi + fextv(1)
-       fyi = fyi + fextv(2)
-       fzi = fzi + fextv(3)
-       vxyz_ptmass(1,i) = vxhalfi + 0.5*dt*fxi
-       vxyz_ptmass(2,i) = vyhalfi + 0.5*dt*fyi
-       vxyz_ptmass(3,i) = vzhalfi + 0.5*dt*fzi
+       if (xyzmh_ptmass(4,i) > 0.) then
+          vxhalfi = vxyz_ptmass(1,i)
+          vyhalfi = vxyz_ptmass(2,i)
+          vzhalfi = vxyz_ptmass(3,i)
+          fxi = fxyz_ptmass(1,i)
+          fyi = fxyz_ptmass(2,i)
+          fzi = fxyz_ptmass(3,i)
+          call update_vdependent_extforce_leapfrog(iexternalforce,&
+               vxhalfi,vyhalfi,vzhalfi,fxi,fyi,fzi,fextv,dt,&
+               xyzmh_ptmass(1,i),xyzmh_ptmass(2,i),xyzmh_ptmass(3,i))
+          fxi = fxi + fextv(1)
+          fyi = fyi + fextv(2)
+          fzi = fzi + fextv(3)
+          vxyz_ptmass(1,i) = vxhalfi + 0.5*dt*fxi
+          vxyz_ptmass(2,i) = vyhalfi + 0.5*dt*fyi
+          vxyz_ptmass(3,i) = vzhalfi + 0.5*dt*fzi
+       endif
     enddo
     !$omp end parallel do
  else
     !$omp parallel do schedule(static) default(none) &
-    !$omp shared(vxyz_ptmass,fxyz_ptmass,dt,nptmass) &
+    !$omp shared(xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,dt,nptmass) &
     !$omp private(i)
     do i=1,nptmass
-       vxyz_ptmass(1,i) = vxyz_ptmass(1,i) + 0.5*dt*fxyz_ptmass(1,i)
-       vxyz_ptmass(2,i) = vxyz_ptmass(2,i) + 0.5*dt*fxyz_ptmass(2,i)
-       vxyz_ptmass(3,i) = vxyz_ptmass(3,i) + 0.5*dt*fxyz_ptmass(3,i)
+       if (xyzmh_ptmass(4,i) > 0.) then
+          vxyz_ptmass(1,i) = vxyz_ptmass(1,i) + 0.5*dt*fxyz_ptmass(1,i)
+          vxyz_ptmass(2,i) = vxyz_ptmass(2,i) + 0.5*dt*fxyz_ptmass(2,i)
+          vxyz_ptmass(3,i) = vxyz_ptmass(3,i) + 0.5*dt*fxyz_ptmass(3,i)
+       endif
     enddo
     !$omp end parallel do
  endif
-
 
 end subroutine ptmass_corrector
 
@@ -605,6 +634,7 @@ subroutine ptmass_accrete(is,nptmass,xi,yi,zi,hi,vxi,vyi,vzi,fxi,fyi,fzi, &
  sinkloop : do i=is,nptmass
     hacc = xyzmh_ptmass(ihacc,i)
     mpt  = xyzmh_ptmass(4,i)
+    if (mpt < 0.) cycle
     dx = xi - xyzmh_ptmass(1,i)
     dy = yi - xyzmh_ptmass(2,i)
     dz = zi - xyzmh_ptmass(3,i)
@@ -1353,6 +1383,108 @@ end subroutine ptmass_create
 
 !-----------------------------------------------------------------------
 !+
+!  Merge sinks
+!  If sinks are within r_merge_uncond, they will be automatically merged
+!  If sinks are within r_merge_cond, they will merge if they are bound
+!  A system is bound if
+!     Ekin + Epot < 0
+!     0.5*mu*dv^2 - G*m1*m2/r < 0
+!  where
+!     mu = m1*m2/(m1+m2)
+!  is the reduced mass.  Therefore, a system is bound if
+!     0.5*m1*m2/(m1+m2) dv^2 - G*m1*m2/dr < 0
+!  which can be rearranged to
+!     0.5*dv^2 - G*(m1+m2)/dr < 0
+!  to remove a division.  Therefore, in code units, we use
+!     Ekin = 0.5*dv^2
+!     Epot = -(m1+m2)/dr
+!
+!  The merging is similar to that in update_ptmass.
+!  We do not remove merged sinks from the list, but tag them with a
+!  negative mass.
+!+
+!-----------------------------------------------------------------------
+subroutine merge_sinks(time,nptmass,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,merge_ij,merge_n)
+ use io,    only:iprint,warning
+ use part,  only:ispinx,ispiny,ispinz,imacc
+ real,    intent(in)    :: time
+ integer, intent(in)    :: nptmass,merge_n,merge_ij(nptmass)
+ real,    intent(inout) :: xyzmh_ptmass(nsinkproperties,maxptmass)
+ real,    intent(inout) :: vxyz_ptmass(3,maxptmass),fxyz_ptmass(4,maxptmass)
+ integer :: i,j
+ real    :: rr2,xi,yi,zi,mi,vxi,vyi,vzi,xj,yj,zj,mj,vxj,vyj,vzj,Epot,Ekin
+ real    :: mij,mij1
+ logical :: lmerge
+ character(len=15) :: typ
+
+ do i=1,nptmass
+    if (merge_ij(i) > 0 .and. xyzmh_ptmass(4,i) > 0.) then
+       j = merge_ij(i)
+       if (merge_ij(j) == i .and. xyzmh_ptmass(4,j) > 0.) then
+          lmerge = .false.
+          xi  = xyzmh_ptmass(1,i)
+          yi  = xyzmh_ptmass(2,i)
+          zi  = xyzmh_ptmass(3,i)
+          mi  = xyzmh_ptmass(4,i)
+          xj  = xyzmh_ptmass(1,j)
+          yj  = xyzmh_ptmass(2,j)
+          zj  = xyzmh_ptmass(3,j)
+          mj  = xyzmh_ptmass(4,j)
+          vxi = vxyz_ptmass(1,i)
+          vyi = vxyz_ptmass(2,i)
+          vzi = vxyz_ptmass(3,i)
+          vxj = vxyz_ptmass(1,j)
+          vyj = vxyz_ptmass(2,j)
+          vzj = vxyz_ptmass(3,j)
+          rr2 = (xi-xj)**2 + (yi-yj)**2 + (zi-zj)**2
+          if (rr2 < r_merge_uncond2) then
+             lmerge = .true.
+             typ    = 'unconditionally'
+          elseif (rr2 < r_merge_cond2) then
+             Ekin = 0.5*( (vxi-vxj)**2 + (vyi-vyj)**2 + (vzi-vzj)**2 )
+             Epot = -(mi+mj)/rr2
+             if (Ekin + Epot < 0.) lmerge = .true.
+             typ    = 'conditionally'
+          endif
+          if (lmerge) then
+             ! Add angular momentum of sink particle i using old properties (taken about the origin)
+             xyzmh_ptmass(ispinx,i) = xyzmh_ptmass(ispinx,i) + mi*(yi*vzi - zi*vyi)
+             xyzmh_ptmass(ispiny,i) = xyzmh_ptmass(ispinx,i) + mi*(zi*vxi - xi*vzi)
+             xyzmh_ptmass(ispinz,i) = xyzmh_ptmass(ispinx,i) + mi*(xi*vyi - yi*vxi)
+             ! Calculate new masses
+             mij  = mi + mj
+             mij1 = 1.0/mij
+             ! Update quantities
+             xyzmh_ptmass(1:3,i)    = (xyzmh_ptmass(1:3,i)*mi + xyzmh_ptmass(1:3,j)*mj)*mij1
+             xyzmh_ptmass(4,i)      = mij
+             xyzmh_ptmass(imacc,i)  = xyzmh_ptmass(imacc,i)  + xyzmh_ptmass(imacc,j)
+             xyzmh_ptmass(ispinx,i) = xyzmh_ptmass(ispinx,i) + xyzmh_ptmass(ispinx,j)
+             xyzmh_ptmass(ispiny,i) = xyzmh_ptmass(ispiny,i) + xyzmh_ptmass(ispinx,j)
+             xyzmh_ptmass(ispinz,i) = xyzmh_ptmass(ispinz,i) + xyzmh_ptmass(ispinx,j)
+             vxyz_ptmass(1:3,i)     = (vxyz_ptmass(1:3,i)*mi + vxyz_ptmass(1:3,j)*mj)*mij1
+             fxyz_ptmass(1:3,i)     = (fxyz_ptmass(1:3,i)*mi + fxyz_ptmass(1:3,j)*mj)*mij1
+             ! Subtract angular momentum of sink particle using new properties (taken about the origin)
+             xyzmh_ptmass(ispinx,i) = xyzmh_ptmass(ispinx,i) &
+                                    - mij*(xyzmh_ptmass(2,i)*vxyz_ptmass(3,i) - xyzmh_ptmass(3,i)*vxyz_ptmass(2,i))
+             xyzmh_ptmass(ispiny,i) = xyzmh_ptmass(ispiny,i) &
+                                    - mij*(xyzmh_ptmass(3,i)*vxyz_ptmass(1,i) - xyzmh_ptmass(1,i)*vxyz_ptmass(3,i))
+             xyzmh_ptmass(ispinz,i) = xyzmh_ptmass(ispinz,i) &
+                                    - mij*(xyzmh_ptmass(1,i)*vxyz_ptmass(2,i) - xyzmh_ptmass(2,i)*vxyz_ptmass(1,i))
+             ! Kill sink j by setting negative mass
+             xyzmh_ptmass(4,j)      = -abs(mj)
+             write(iprint,"(/,3a,I8,a,I8,a,F10.4)") 'merge_sinks: ',typ,' merged sinks ',i,' & ',j,' at time = ',time
+          endif
+       else
+          write(iprint,"(/,a,I8,a,I8)") &
+          'merge_sinks: There is a mismatch in sink indicies and relative proximity for ',i,' & ',j
+       endif
+    endif
+ enddo
+
+end subroutine merge_sinks
+
+!-----------------------------------------------------------------------
+!+
 !  Open files to track sink particle data
 !+
 !-----------------------------------------------------------------------
@@ -1507,11 +1639,13 @@ subroutine pt_write_sinkev(nptmass,time,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,fxy
  iunit = iskfile
  do i = 1,nptmass
     if (.not. write_one_ptfile) iunit = iskfile+i
-    write(iunit,"(18(1pe18.9,1x),2(I18,1x))") &
-    time, xyzmh_ptmass(1:4,i),vxyz_ptmass(1:3,i), &
-    xyzmh_ptmass(ispinx,i),xyzmh_ptmass(ispiny,i),xyzmh_ptmass(ispinz,i), &
-    xyzmh_ptmass(imacc,i),fxyz_ptmass(1:3,i),fxyz_ptmass_sinksink(1:3,i),i,nptmass
-    if (i==nptmass .or. (.not. write_one_ptfile)) call flush(iunit)
+    if (xyzmh_ptmass(4,i) > 0.) then
+       write(iunit,"(18(1pe18.9,1x),2(I18,1x))") &
+       time, xyzmh_ptmass(1:4,i),vxyz_ptmass(1:3,i), &
+       xyzmh_ptmass(ispinx,i),xyzmh_ptmass(ispiny,i),xyzmh_ptmass(ispinz,i), &
+       xyzmh_ptmass(imacc,i),fxyz_ptmass(1:3,i),fxyz_ptmass_sinksink(1:3,i),i,nptmass
+       if (i==nptmass .or. (.not. write_one_ptfile)) call flush(iunit)
+    endif
  enddo
 
 end subroutine pt_write_sinkev
@@ -1529,13 +1663,14 @@ subroutine calculate_mdot(nptmass,time,xyzmh_ptmass)
  real                :: dt
 
  do i=1,nptmass
-    dt = time - xyzmh_ptmass(i_tlast,i)
-    xyzmh_ptmass(imdotav,i) = (xyzmh_ptmass(imacc,i) - xyzmh_ptmass(i_mlast,i))/dt
-    xyzmh_ptmass(i_mlast,i) = xyzmh_ptmass(imacc,i)
-    xyzmh_ptmass(i_tlast,i) = time
+    if (xyzmh_ptmass(4,i) > 0.) then
+       dt = time - xyzmh_ptmass(i_tlast,i)
+       xyzmh_ptmass(imdotav,i) = (xyzmh_ptmass(imacc,i) - xyzmh_ptmass(i_mlast,i))/dt
+       xyzmh_ptmass(i_mlast,i) = xyzmh_ptmass(imacc,i)
+       xyzmh_ptmass(i_tlast,i) = time
+    endif
  enddo
 end subroutine calculate_mdot
-
 
 !-----------------------------------------------------------------------
 !+
@@ -1558,6 +1693,8 @@ subroutine write_options_ptmass(iunit)
  endif
  call write_inopt(h_soft_sinksink,'h_soft_sinksink','softening length between sink particles',iunit)
  call write_inopt(f_acc,'f_acc','particles < f_acc*h_acc accreted without checks',iunit)
+ call write_inopt(r_merge_uncond,'r_merge_uncond','sinks will unconditionally merge within this separation',iunit)
+ call write_inopt(r_merge_cond,'r_merge_cond','sinks will merge if bound within this radius',iunit)
 
 end subroutine write_options_ptmass
 
@@ -1567,7 +1704,7 @@ end subroutine write_options_ptmass
 !+
 !-----------------------------------------------------------------------
 subroutine read_options_ptmass(name,valstring,imatch,igotall,ierr)
- use io,         only:fatal
+ use io,         only:warning,fatal
  character(len=*), intent(in)  :: name,valstring
  logical,          intent(out) :: imatch,igotall
  integer,          intent(out) :: ierr
@@ -1614,15 +1751,25 @@ subroutine read_options_ptmass(name,valstring,imatch,igotall,ierr)
     if (f_acc < 0.0) call fatal(label,'f_acc < 0')
     if (f_acc > 1.0) call fatal(label,'f_acc > 1')
     ngot = ngot + 1
+ case('r_merge_uncond')
+    read(valstring,*,iostat=ierr) r_merge_uncond
+    if (icreate_sinks==1 .and. r_merge_uncond < 2.0*h_acc) then
+       call warning(label,'Strongly suggest r_merge_uncond >= 2.0*h_acc')
+    endif
+    ngot = ngot + 1
+ case('r_merge_cond')
+    read(valstring,*,iostat=ierr) r_merge_cond
+    if (r_merge_cond > 0. .and. r_merge_cond < r_merge_uncond) call fatal(label,'0 < r_merge_cond < r_merge_uncond')
+    ngot = ngot + 1
  case default
     imatch = .false.
  end select
 
  !--make sure we have got all compulsory options (otherwise, rewrite input file)
  if (icreate_sinks > 0) then
-    igotall = (ngot >= 6)
+    igotall = (ngot >= 8)
  else
-    igotall = (ngot >= 2)
+    igotall = (ngot >= 4)
  endif
 
 end subroutine read_options_ptmass

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -1449,8 +1449,8 @@ subroutine merge_sinks(time,nptmass,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,merge_i
           if (lmerge) then
              ! Add angular momentum of sink particle i using old properties (taken about the origin)
              xyzmh_ptmass(ispinx,i) = xyzmh_ptmass(ispinx,i) + mi*(yi*vzi - zi*vyi)
-             xyzmh_ptmass(ispiny,i) = xyzmh_ptmass(ispinx,i) + mi*(zi*vxi - xi*vzi)
-             xyzmh_ptmass(ispinz,i) = xyzmh_ptmass(ispinx,i) + mi*(xi*vyi - yi*vxi)
+             xyzmh_ptmass(ispiny,i) = xyzmh_ptmass(ispiny,i) + mi*(zi*vxi - xi*vzi)
+             xyzmh_ptmass(ispinz,i) = xyzmh_ptmass(ispinz,i) + mi*(xi*vyi - yi*vxi)
              ! Calculate new masses
              mij  = mi + mj
              mij1 = 1.0/mij
@@ -1458,9 +1458,9 @@ subroutine merge_sinks(time,nptmass,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,merge_i
              xyzmh_ptmass(1:3,i)    = (xyzmh_ptmass(1:3,i)*mi + xyzmh_ptmass(1:3,j)*mj)*mij1
              xyzmh_ptmass(4,i)      = mij
              xyzmh_ptmass(imacc,i)  = xyzmh_ptmass(imacc,i)  + xyzmh_ptmass(imacc,j)
-             xyzmh_ptmass(ispinx,i) = xyzmh_ptmass(ispinx,i) + xyzmh_ptmass(ispinx,j)
-             xyzmh_ptmass(ispiny,i) = xyzmh_ptmass(ispiny,i) + xyzmh_ptmass(ispinx,j)
-             xyzmh_ptmass(ispinz,i) = xyzmh_ptmass(ispinz,i) + xyzmh_ptmass(ispinx,j)
+             xyzmh_ptmass(ispinx,i) = xyzmh_ptmass(ispinx,i) + xyzmh_ptmass(ispinx,j) + mj*(yj*vzj - zj*vyj)
+             xyzmh_ptmass(ispiny,i) = xyzmh_ptmass(ispiny,i) + xyzmh_ptmass(ispiny,j) + mj*(zj*vxj - xj*vzj)
+             xyzmh_ptmass(ispinz,i) = xyzmh_ptmass(ispinz,i) + xyzmh_ptmass(ispinz,j) + mj*(xj*vyj - yj*vxj)
              vxyz_ptmass(1:3,i)     = (vxyz_ptmass(1:3,i)*mi + vxyz_ptmass(1:3,j)*mj)*mij1
              fxyz_ptmass(1:3,i)     = (fxyz_ptmass(1:3,i)*mi + fxyz_ptmass(1:3,j)*mj)*mij1
              ! Subtract angular momentum of sink particle using new properties (taken about the origin)

--- a/src/main/ptmass_radiation.F90
+++ b/src/main/ptmass_radiation.F90
@@ -70,6 +70,7 @@ subroutine get_rad_accel_from_ptmass(nptmass,npart,xyzh,xyzmh_ptmass,fext)
  integer                 :: i,j
 
  do j=1,nptmass
+    if (xyzmh_ptmass(4,j) < 0.) cycle
     Mstar_cgs  = xyzmh_ptmass(4,j)*umass
     Lstar_cgs  = xyzmh_ptmass(ilum,j)*unit_energ/utime
     !compute radiative acceleration if sink particle is assigned a non-zero luminosity

--- a/src/main/random.f90
+++ b/src/main/random.f90
@@ -38,6 +38,7 @@ real function ran2(s1)
  integer, intent(inout) :: s1
  integer, save :: s2 = 123456789
 
+ if (s1 < 0) s2 = 123456789
  ran2 = get_random(s1,s2)
 
 end function ran2

--- a/src/main/readwrite_dumps_common.F90
+++ b/src/main/readwrite_dumps_common.F90
@@ -320,7 +320,7 @@ subroutine check_arrays(i1,i2,npartoftype,npartread,nptmass,nsinkproperties,mass
        if (id==master .and. i1==1) write(*,*) 'WARNING! sink particle velocities not found'
     endif
     if (id==master .and. i1==1) then
-       print "(2(a,i2),a)",' got ',nsinkproperties,' sink properties from ',nptmass,' sink particles'
+       print "(2(a,i4),a)",' got ',nsinkproperties,' sink properties from ',nptmass,' sink particles'
        if (nptmass > 0) print "(1x,47('-'),/,1x,a,'|',4(a9,1x,'|'),/,1x,47('-'))",&
                               'ID',' Mass    ',' Racc    ',' Macc    ',' hsoft   '
        do i=1,min(nptmass,999)

--- a/src/main/readwrite_dumps_common.F90
+++ b/src/main/readwrite_dumps_common.F90
@@ -324,7 +324,8 @@ subroutine check_arrays(i1,i2,npartoftype,npartread,nptmass,nsinkproperties,mass
        if (nptmass > 0) print "(1x,47('-'),/,1x,a,'|',4(a9,1x,'|'),/,1x,47('-'))",&
                               'ID',' Mass    ',' Racc    ',' Macc    ',' hsoft   '
        do i=1,min(nptmass,999)
-          print "(i3,'|',4(1pg9.2,1x,'|'))",i,xyzmh_ptmass(4,i),xyzmh_ptmass(ihacc,i),xyzmh_ptmass(imacc,i),xyzmh_ptmass(ihsoft,i)
+          if (xyzmh_ptmass(4,i) > 0.) print "(i3,'|',4(1pg9.2,1x,'|'))",i,xyzmh_ptmass(4,i), &
+                                            xyzmh_ptmass(ihacc,i),xyzmh_ptmass(imacc,i),xyzmh_ptmass(ihsoft,i)
        enddo
        if (nptmass > 0) print "(1x,47('-'))"
     endif

--- a/src/tests/test_gravity.F90
+++ b/src/tests/test_gravity.F90
@@ -249,7 +249,7 @@ subroutine test_directsum(ntests,npass)
  use ptmass,    only:get_accel_sink_sink,get_accel_sink_gas,h_soft_sinksink
  integer, intent(inout) :: ntests,npass
  integer :: nfailed(18)
- integer :: maxvxyzu,nx,np,i,k
+ integer :: maxvxyzu,nx,np,i,k,merge_n,merge_ij(maxptmass)
  real :: psep,totvol,totmass,rhozero,tol,pmassi
  real :: time,rmin,rmax,phitot,dtsinksink,fonrmax,phii,epot_gas_sink
  real(kind=4) :: t1,t2
@@ -364,7 +364,7 @@ subroutine test_directsum(ntests,npass)
 !
 !--compute gravity on the sink particles
 !
-    call get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,epoti,dtsinksink,0,0.)
+    call get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,epoti,dtsinksink,0,0.,merge_ij,merge_n)
 !
 !--compare the results
 !
@@ -387,7 +387,7 @@ subroutine test_directsum(ntests,npass)
     call get_derivs_global()
 
     epoti = 0.
-    call get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,epoti,dtsinksink,0,0.)
+    call get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,epoti,dtsinksink,0,0.,merge_ij,merge_n)
     epot_gas_sink = 0.
     do i=1,npart
        call get_accel_sink_gas(nptmass,xyzh(1,i),xyzh(2,i),xyzh(3,i),xyzh(4,i),&

--- a/src/tests/test_ptmass.F90
+++ b/src/tests/test_ptmass.F90
@@ -63,25 +63,27 @@ subroutine test_ptmass(ntests,npass)
 #endif
  use mpiutils,        only:bcast_mpi,reduce_in_place_mpi,reduceloc_mpi
  use stretchmap,      only:rho_func
+ use random,          only:ran2
  integer, intent(inout) :: ntests,npass
- integer                :: i,nsteps,nbinary_tests,itest,nerr,nwarn,itestp
- integer                :: nparttot,merge_ij(maxptmass),merge_n
+ integer                :: i,j,nsteps,nbinary_tests,itest,nerr,nwarn,itestp
+ integer                :: nparttot,merge_ij(maxptmass),merge_n,nsink0,nsinkF
  logical                :: test_binary,test_accretion,test_createsink,test_softening,test_merger
  logical                :: accreted,merged,merged_expected
  real                   :: m1,m2,a,ecc,hacc1,hacc2,dt,dtext,t,dtnew,dr,v2
  real                   :: etotin,totmomin,dtsinksink,omega,mred,errmax,angmomin
- real                   :: r2,r2min,xcofm(3),totmass,dum,dum2,psep,tolen
+ real                   :: r2,r2min,xcofm(3),totmass,dum,dum2,psep,tolen,dtmp(3)
  real                   :: xyzm_ptmass_old(4,1), vxyz_ptmass_old(3,1)
- real                   :: q,phisoft,fsoft,mu,v_c1,v_c2,r1,omega1,omega2
+ real                   :: q,phisoft,fsoft,mu,v_c1,v_c2,r1,omega1,omega2,mv0,angmom0,mtot0,mvF,angmomF,mtotF
  real                   :: dptmass(ndptmass,maxptmass)
  real                   :: dptmass_thread(ndptmass,maxptmass)
  real                   :: fxyz_sinksink(4,maxptmass),rhomax_test,rhomax
- integer                :: norbits,itmp,ierr
- integer                :: nfailed(28),imin(1)
+ integer                :: norbits,itmp,ierr,iseed
+ integer                :: nfailed(56),imin(1)
  integer                :: id_rhomax,ipart_rhomax_global
  integer(kind=1)        :: ibin_wakei
  character(len=20)      :: dumpfile,filename
  procedure(rho_func), pointer :: density_func
+ logical                :: print_sink_paths = .false. ! print sink paths in the merger test
 
  if (id==master) write(*,"(/,a,/)") '--> TESTING PTMASS MODULE'
 
@@ -607,6 +609,7 @@ subroutine test_ptmass(ntests,npass)
 !  Test sink particle creation
 !
  testsinkmerger: if (test_merger) then
+    iseed           = -74205
     nfailed(:)      = 0
     iverbose        = 0
     nptmass         = 2
@@ -618,7 +621,7 @@ subroutine test_ptmass(ntests,npass)
     r_merge_uncond2 = r_merge_uncond**2
     r_merge_cond2   = r_merge_cond**2
     r_merge2        = max(r_merge_uncond2,r_merge_cond2)
-    do itest=1,7
+    do itest=1,8
        t                 = 0.
        xyzmh_ptmass(:,:) = 0.
        xyzmh_ptmass(4,:) = 1.
@@ -672,9 +675,26 @@ subroutine test_ptmass(ntests,npass)
           xyzmh_ptmass(1,1) = 2.5*h_acc
           vxyz_ptmass(2,1)  = 0.9*sqrt(0.25*xyzmh_ptmass(4,1)/xyzmh_ptmass(1,1))
           merged_expected   = .true.
+       case(8)
+          if (id==master) write(*,"(/,a)") '--> testing multiple sink interations'
+          nptmass = 100
+          do i = 1,nptmass
+             xyzmh_ptmass(1:3,i) = ( (/ran2(iseed),ran2(iseed),ran2(iseed)/) - 0.5) * 2.  ! in range (-1,1)
+             vxyz_ptmass(1:3,i)  = ( (/ran2(iseed),ran2(iseed),ran2(iseed)/) - 0.5) * 6.  ! in range (-3,3)
+!             do j = 1,3
+!                xyzmh_ptmass(j,i) = (ran2(iseed) - 0.5) * 2.  ! in range (-3,3)
+!                vxyz_ptmass(j,i)  = (ran2(iseed) - 0.5) * 6.  ! in range (-3,3)
+!             enddo
+          enddo
+          merged_expected   = .true. ! this logical does not have meaning here
        end select
-       xyzmh_ptmass(1:3,2) = -xyzmh_ptmass(1:3,1)
-       vxyz_ptmass(1:3,2)  = -vxyz_ptmass(1:3,1)
+       if (itest /= 8) then
+          xyzmh_ptmass(1:3,2) = -xyzmh_ptmass(1:3,1)
+          vxyz_ptmass(1:3,2)  = -vxyz_ptmass(1:3,1)
+       endif
+       !
+       ! get initial values
+       call get_momenta(nptmass,nsink0,xyzmh_ptmass,vxyz_ptmass,angmom0,mv0,mtot0,periodic)
        !
        ! initialise forces
        !
@@ -691,35 +711,68 @@ subroutine test_ptmass(ntests,npass)
        ! integrate
        !
        nsteps = 1000
-       v2     = dot_product(vxyz_ptmass(1:2,1),vxyz_ptmass(1:2,1))
-       dt     = 2./(sqrt(v2)*nsteps)
+       dt     = huge(dt)
+       do i = 1,nptmass-1
+          do j = i+1,nptmass
+             dtmp = xyzmh_ptmass(1:3,i)-xyzmh_ptmass(1:3,j)
+             r2   = dot_product(dtmp,dtmp)
+             dtmp = vxyz_ptmass(1:3,i)-vxyz_ptmass(1:3,j)
+             v2   = dot_product(dtmp,dtmp)+epsilon(v2)
+             dt   = min(dt,sqrt(r2/v2))
+          enddo
+       enddo
+       dt     = 2.*dt/nsteps
        dtmax  = dt*nsteps
+       t      = 0.
+       print*, itest,dt
        call init_step(npart,t,dtmax)
-       !write(333,*) itest,0,xyzmh_ptmass(1:4,1),xyzmh_ptmass(1:4,2)
+       if (print_sink_paths) then
+          write(333,*) itest,0,xyzmh_ptmass(1:4,1),xyzmh_ptmass(1:4,2)
+          if (itest==8) then
+             do j = 1,nptmass
+                if (xyzmh_ptmass(4,j) > 0.) write(334,*) t,j,xyzmh_ptmass(1:4,j)
+             enddo
+          endif
+       endif
        do i=1,nsteps
           t = t + dt
           dtext = dt
           if (id==master .and. iverbose > 2) write(*,*) ' t = ',t,' dt = ',dt
           call step(npart,npart,t,dt,dtext,dtnew)
-          !write(333,*) itest,i,xyzmh_ptmass(1:4,1),xyzmh_ptmass(1:4,2)
+          if (print_sink_paths) then
+             write(333,*) itest,i,xyzmh_ptmass(1:4,1),xyzmh_ptmass(1:4,2)
+             if (itest==8) then
+                do j = 1,nptmass
+                   if (xyzmh_ptmass(4,j) > 0.) write(334,*) t,j,xyzmh_ptmass(1:4,j)
+                enddo
+             endif
+          endif
        enddo
        !
        ! check results
+       call get_momenta(nptmass,nsinkF,xyzmh_ptmass,vxyz_ptmass,angmomF,mvF,mtotF,periodic)
        !
        if (xyzmh_ptmass(4,2) < 0.) then
           merged = .true.
        else
           merged = .false.
        endif
-       call checkval(merged,merged_expected,nfailed(itest),'merger')
-       if (merged_expected) then
-          call checkval(xyzmh_ptmass(1,1),0.,epsilon(0.),nfailed(2*itest),'final x-position')
-          call checkval(xyzmh_ptmass(2,1),0.,epsilon(0.),nfailed(3*itest),'final y-position')
-          v2 = dot_product(vxyz_ptmass(1:2,1),vxyz_ptmass(1:2,1))
-          call checkval(sqrt(v2),0.,epsilon(0.),nfailed(4*itest),'final velocity')
+       if (itest==8) then
+          call checkval(nsinkF,41,0,nfailed(itest),'final number of sinks')
+       else
+          call checkval(merged,merged_expected,nfailed(itest),'merger')
+          if (merged_expected) then
+             call checkval(xyzmh_ptmass(1,1),0.,epsilon(0.),nfailed(2*itest),'final x-position')
+             call checkval(xyzmh_ptmass(2,1),0.,epsilon(0.),nfailed(3*itest),'final y-position')
+             v2 = dot_product(vxyz_ptmass(1:2,1),vxyz_ptmass(1:2,1))
+             call checkval(sqrt(v2),0.,epsilon(0.),nfailed(4*itest),'final velocity')
+          endif
        endif
+       call checkval(mvF,    mv0,    1.e-13,nfailed(5*itest),'conservation of linear momentum')
+       call checkval(angmomF,angmom0,1.e-13,nfailed(6*itest),'conservation of angular momentum')
+       call checkval(mtotF,  mtot0,  1.e-13,nfailed(7*itest),'conservation of mass')
     enddo
-    call update_test_scores(ntests,nfailed(1:21),npass)
+    call update_test_scores(ntests,nfailed(1:56),npass)
 
  endif testsinkmerger
 
@@ -740,6 +793,46 @@ subroutine test_ptmass(ntests,npass)
  if (id==master) write(*,"(/,a)") '<-- PTMASS TEST COMPLETE'
 
 end subroutine test_ptmass
+
+subroutine get_momenta(nptmass,nsnk,xyzmh_ptmass,vxyz_ptmass,ang,mv,mtot,periodic)
+ use part, only:ispinx,ispiny,ispinz
+ integer, intent(in)  :: nptmass
+ integer, intent(out) :: nsnk
+ real,    intent(in)  :: xyzmh_ptmass(:,:),vxyz_ptmass(:,:)
+ real,    intent(out) :: ang,mv,mtot
+ logical, intent(in)  :: periodic
+ integer              :: i
+ real                 :: angx,angy,angz,xmom,ymom,zmom
+
+ angx = 0.
+ angy = 0.
+ angz = 0.
+ xmom = 0.
+ ymom = 0.
+ zmom = 0.
+ mv   = 0.
+ mtot = 0.
+ nsnk = 0
+ do i = 1,nptmass
+    if (xyzmh_ptmass(4,i) > 0.) then
+       nsnk = nsnk + 1
+       angx = angx + xyzmh_ptmass(4,i)*(xyzmh_ptmass(2,i)*vxyz_ptmass(3,i) - xyzmh_ptmass(3,i)*vxyz_ptmass(2,i))
+       angy = angy + xyzmh_ptmass(4,i)*(xyzmh_ptmass(3,i)*vxyz_ptmass(1,i) - xyzmh_ptmass(1,i)*vxyz_ptmass(3,i))
+       angz = angz + xyzmh_ptmass(4,i)*(xyzmh_ptmass(1,i)*vxyz_ptmass(2,i) - xyzmh_ptmass(2,i)*vxyz_ptmass(1,i))
+       angx = angx + xyzmh_ptmass(ispinx,i)
+       angy = angy + xyzmh_ptmass(ispiny,i)
+       angz = angz + xyzmh_ptmass(ispinz,i)
+       xmom = xmom + xyzmh_ptmass(4,i)*vxyz_ptmass(1,i)
+       ymom = ymom + xyzmh_ptmass(4,i)*vxyz_ptmass(2,i)
+       zmom = zmom + xyzmh_ptmass(4,i)*vxyz_ptmass(3,i)
+       mtot = mtot + xyzmh_ptmass(4,i)
+    endif
+ enddo
+ mv  = sqrt(xmom*xmom + ymom*ymom + zmom*zmom)
+ ang = sqrt(angx*angx + angy*angy + angz*angz)
+ if (periodic) ang = 0. ! since this will not be conserved with periodic boundaries
+
+end subroutine get_momenta
 
 real function gaussianr(r)
  real, intent(in) :: r

--- a/src/tests/test_ptmass.F90
+++ b/src/tests/test_ptmass.F90
@@ -681,10 +681,6 @@ subroutine test_ptmass(ntests,npass)
           do i = 1,nptmass
              xyzmh_ptmass(1:3,i) = ( (/ran2(iseed),ran2(iseed),ran2(iseed)/) - 0.5) * 2.  ! in range (-1,1)
              vxyz_ptmass(1:3,i)  = ( (/ran2(iseed),ran2(iseed),ran2(iseed)/) - 0.5) * 6.  ! in range (-3,3)
-!             do j = 1,3
-!                xyzmh_ptmass(j,i) = (ran2(iseed) - 0.5) * 2.  ! in range (-3,3)
-!                vxyz_ptmass(j,i)  = (ran2(iseed) - 0.5) * 6.  ! in range (-3,3)
-!             enddo
           enddo
           merged_expected   = .true. ! this logical does not have meaning here
        end select

--- a/src/utils/analysis_clumpfind.F90
+++ b/src/utils/analysis_clumpfind.F90
@@ -527,6 +527,7 @@ subroutine create_sink_clumps(npart,xyzh)
  print'(a,F5.1,a)', 'All particles within ',sinkclumprad,' accretion radii  will be added to sink clumps'
 
  do iptmass=1,nptmass
+    if (xyzmh_ptmass(4,iptmass) < 0.) cycle
     clumpsep = sinkclumprad*xyzmh_ptmass(ihacc,iptmass)
     nclump   = nclump + 1
 

--- a/src/utils/analysis_common_envelope.F90
+++ b/src/utils/analysis_common_envelope.F90
@@ -434,7 +434,7 @@ subroutine calculate_energies(time, num, npart, particlemass, xyzh, vxyzu)
     encomp(ipot_env) = encomp(ipot_env) + phii1 * particlemass
 
     do j=1,nptmass
-       if (xyzmh_ptmass(4,i) > 0.) then
+       if (xyzmh_ptmass(4,j) > 0.) then
           r_ij = separation(xyzmh_ptmass(1:3,j),xyzh(1:3,i))
           if (r_ij < 80.) then
              inearsink = .true.
@@ -1225,7 +1225,7 @@ subroutine sink_properties(time, num, npart, particlemass, xyzh, vxyzu)
  real                         :: fxi, fyi, fzi, phii
  real, dimension(4,maxptmass) :: fssxyz_ptmass
  real, dimension(4,maxptmass) :: fxyz_ptmass
- integer                      :: i, ncols
+ integer                      :: i, ncols, merge_n, merge_ij(nptmass)
 
  ncols = 25
  allocate(columns(ncols))
@@ -1252,7 +1252,7 @@ subroutine sink_properties(time, num, npart, particlemass, xyzh, vxyzu)
              '       kin en'/)
 
  fxyz_ptmass = 0.
- call get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,phitot,dtsinksink,0,0.)
+ call get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,phitot,dtsinksink,0,0.,merge_ij,merge_n)
  fssxyz_ptmass = fxyz_ptmass
  do i=1,npart
     call get_accel_sink_gas(nptmass,xyzh(1,i),xyzh(2,i),xyzh(3,i),xyzh(4,i),xyzmh_ptmass,&
@@ -1392,7 +1392,7 @@ subroutine gravitational_drag(time,num,npart,particlemass,xyzh,vxyzu)
  real,    intent(inout)                :: xyzh(:,:),vxyzu(:,:)
  character(len=17), allocatable        :: columns(:)
  character(len=17)                     :: filename
- integer                               :: i,j,k,iorder(npart),ncols,npart_insphere,sizeRcut
+ integer                               :: i,j,k,iorder(npart),ncols,npart_insphere,sizeRcut,merge_ij(nptmass),merge_n
  real, dimension(:), allocatable, save :: ang_mom_old,time_old
  real, dimension(:,:), allocatable     :: drag_force
  real, dimension(4,maxptmass)          :: fxyz_ptmass
@@ -1520,7 +1520,7 @@ subroutine gravitational_drag(time,num,npart,particlemass,xyzh,vxyzu)
     ! Sum acceleration (fxyz_ptmass) on companion due to gravity of all gas particles
     force_cut_vec = 0.
     fxyz_ptmass = 0.
-    call get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,phitot,dtsinksink,0,0.)
+    call get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,phitot,dtsinksink,0,0.,merge_ij,merge_n)
 
     sizeRcut = 5
     if (i == 1) allocate(Rcut(sizeRcut))

--- a/src/utils/analysis_common_envelope.F90
+++ b/src/utils/analysis_common_envelope.F90
@@ -212,9 +212,11 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
     ang_vel = 0.
 
     do i=1,nptmass
-       xyz_a(1:3) = xyzmh_ptmass(1:3,i) - com_xyz(1:3)
-       vxyz_a(1:3) = vxyz_ptmass(1:3,i) - com_vxyz(1:3)
-       ang_vel = ang_vel + (-xyz_a(2) * vxyz_a(1) + xyz_a(1) * vxyz_a(2)) / dot_product(xyz_a(1:2), xyz_a(1:2))
+       if (xyzmh_ptmass(4,i) > 0.) then
+          xyz_a(1:3) = xyzmh_ptmass(1:3,i) - com_xyz(1:3)
+          vxyz_a(1:3) = vxyz_ptmass(1:3,i) - com_vxyz(1:3)
+          ang_vel = ang_vel + (-xyz_a(2) * vxyz_a(1) + xyz_a(1) * vxyz_a(2)) / dot_product(xyz_a(1:2), xyz_a(1:2))
+       endif
     enddo
 
     ang_vel = ang_vel / 2.
@@ -432,10 +434,11 @@ subroutine calculate_energies(time, num, npart, particlemass, xyzh, vxyzu)
     encomp(ipot_env) = encomp(ipot_env) + phii1 * particlemass
 
     do j=1,nptmass
-       r_ij = separation(xyzmh_ptmass(1:3,j),xyzh(1:3,i))
-
-       if (r_ij < 80.) then
-          inearsink = .true.
+       if (xyzmh_ptmass(4,i) > 0.) then
+          r_ij = separation(xyzmh_ptmass(1:3,j),xyzh(1:3,i))
+          if (r_ij < 80.) then
+             inearsink = .true.
+          endif
        endif
     enddo
 
@@ -463,23 +466,27 @@ subroutine calculate_energies(time, num, npart, particlemass, xyzh, vxyzu)
  enddo
 
  do i=1,nptmass
+    if (xyzmh_ptmass(4,i) > 0.) then
+       call cross(xyzmh_ptmass(1:3,i), xyzmh_ptmass(4,i)*vxyz_ptmass(1:3,i), rcrossmv)
 
-    call cross(xyzmh_ptmass(1:3,i), xyzmh_ptmass(4,i)*vxyz_ptmass(1:3,i), rcrossmv)
-
-    jz = rcrossmv(3)
-    encomp(ijz_tot) = jz + encomp(ijz_tot)
-    encomp(ijz_orb) = jz + encomp(ijz_orb)
-    encomp(ikin_sink) = encomp(ikin_sink) + 0.5 * xyzmh_ptmass(4,i) * distance(vxyz_ptmass(1:3,i))**2
-    if (i==2) encomp(iorb_comp) = encomp(iorb_comp) + 0.5 * xyzmh_ptmass(4,i) * distance(vxyz_ptmass(1:3,i))**2
+       jz = rcrossmv(3)
+       encomp(ijz_tot) = jz + encomp(ijz_tot)
+       encomp(ijz_orb) = jz + encomp(ijz_orb)
+       encomp(ikin_sink) = encomp(ikin_sink) + 0.5 * xyzmh_ptmass(4,i) * distance(vxyz_ptmass(1:3,i))**2
+       if (i==2) encomp(iorb_comp) = encomp(iorb_comp) + 0.5 * xyzmh_ptmass(4,i) * distance(vxyz_ptmass(1:3,i))**2
+    endif
  enddo
 
  do i=1,nptmass-1
-    do j=i+1,nptmass
-       r_ij = separation(xyzmh_ptmass(1:3,i),xyzmh_ptmass(1:3,j))
-
-       encomp(ipot_sink) = encomp(ipot_sink) - xyzmh_ptmass(4,i) * xyzmh_ptmass(4,j) / r_ij
-       if (i==1 .and. j==2) encomp(iorb_comp) = encomp(iorb_comp) - xyzmh_ptmass(4,i) * xyzmh_ptmass(4,j) / r_ij
-    enddo
+    if (xyzmh_ptmass(4,i) > 0.) then
+       do j=i+1,nptmass
+          if (xyzmh_ptmass(4,j) > 0.) then
+             r_ij = separation(xyzmh_ptmass(1:3,i),xyzmh_ptmass(1:3,j))
+             encomp(ipot_sink) = encomp(ipot_sink) - xyzmh_ptmass(4,i) * xyzmh_ptmass(4,j) / r_ij
+             if (i==1 .and. j==2) encomp(iorb_comp) = encomp(iorb_comp) - xyzmh_ptmass(4,i) * xyzmh_ptmass(4,j) / r_ij
+          endif
+       enddo
+    endif
  enddo
 
  ekin = encomp(ikin_bound) + encomp(ikin_unbound) + encomp(ikin_sink)
@@ -907,7 +914,9 @@ subroutine print_simulation_parameters(num, npart, particlemass)
  write(*,"(2(a,es10.3,1x),/)")   '        G: ', gg*umass*utime**2/udist**3,'             c: ',c*utime/udist
 
  do i=1,nptmass
-    write(*,'(A,I2,A,ES10.3,A,ES10.3)') 'Point mass ',i,': M = ',xyzmh_ptmass(4,i),' and h_soft = ',xyzmh_ptmass(ihsoft,i)
+    if (xyzmh_ptmass(4,i) > 0.) then
+       write(*,'(A,I2,A,ES10.3,A,ES10.3)') 'Point mass ',i,': M = ',xyzmh_ptmass(4,i),' and h_soft = ',xyzmh_ptmass(ihsoft,i)
+    endif
  enddo
 
  write(*,'(A,I7,A,ES10.3)') 'Gas particles : ',npart,' particles, each of mass ',particlemass

--- a/src/utils/analysis_protostar_environ.F90
+++ b/src/utils/analysis_protostar_environ.F90
@@ -273,13 +273,14 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
  ! Perform the calculations for each sink; if no sink, reset to the centre of mass
  !
  over_sinks: do isink = isink0,isinkN
+    if (xyzmh_ptmass(4,isink) < 0.) cycle
     calc_rad_prof = .not. ignor_lowrho
     if (isink > 0) calc_rad_prof = .true.
     rsepmin2 = huge(rsepmin2)
     ! Skip 'merged' sinks
     if (isink > 0) then
        do j = 1,isinkN
-          if (j/=isink) then
+          if (j/=isink .and. xyzmh_ptmass(4,j) > 0.) then
              rtmp2    = (xyzmh_ptmass(1,isink)-xyzmh_ptmass(1,j))**2 &
                       + (xyzmh_ptmass(2,isink)-xyzmh_ptmass(2,j))**2
              rsepmin2 = min(rsepmin2,rtmp2)
@@ -288,6 +289,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
        if (imerged(isink) > 0) cycle over_sinks
        ! Determine if two sinks should be merged
        do j = isink+1,isinkN
+          if (xyzmh_ptmass(4,j) < 0.) cycle
           rtmp2 = (xyzmh_ptmass(1,isink)-xyzmh_ptmass(1,j))**2 &
                 + (xyzmh_ptmass(2,isink)-xyzmh_ptmass(2,j))**2 &
                 + (xyzmh_ptmass(3,isink)-xyzmh_ptmass(3,j))**2
@@ -844,6 +846,7 @@ subroutine get_mu(npart,nptmass,nrad,rad_mu,mu,mass,B,xyzh,xyzmh_ptmass,Bxyz,pma
     yi   = xyzmh_ptmass(2,i)
     zi   = xyzmh_ptmass(3,i)
     mi   = xyzmh_ptmass(4,i)
+    if (mi < 0.) cycle
     rad2 = xi*xi + yi*yi + zi*zi  ! Note that we are already centred on the point of interest
     do j = 1,nrad
        if (rad2 < rad2_mu(j)) mass(j) = mass(j) + mi
@@ -1372,8 +1375,8 @@ subroutine adjust_origin(npart,nptmass,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,xyz0,
  vxyz0 = 0.0
  do i = 1,nptmass
     rtmp2 = dot_product(xyzmh_ptmass(1:3,i),xyzmh_ptmass(1:3,i))
-    if (rtmp2 < rcom2) then
-       pmass = xyzmh_ptmass(4,i)
+    pmass = xyzmh_ptmass(4,i)
+    if (rtmp2 < rcom2 .and. pmass > 0.) then
        mcom  =  mcom + pmass
        xyz0  =  xyz0 + xyzmh_ptmass(1:3,i)*pmass
        vxyz0 = vxyz0 +  vxyz_ptmass(1:3,i)*pmass


### PR DESCRIPTION
Added algorithm to permit sink mergers.  They unconditionally merge if they pass with r_merge_uncond of one another, and will merge if they pass within r_merge_cond and they are bound.  By default, both radii are 0 to prevent mergers.  Once a particle as merged, its mass is set to negative; this has been accounted for throughout the code.