### PR TITLE
Allow variable composition (X, Z, mu)

### DIFF
--- a/src/main/cons2prim.f90
+++ b/src/main/cons2prim.f90
@@ -154,17 +154,17 @@ end subroutine cons2primall
 
 subroutine cons2prim_everything(npart,xyzh,vxyzu,dvdx,rad,eos_vars,radprop,&
                                 gamma_chem,Bevol,Bxyz,dustevol,dustfrac,alphaind)
- use part,              only:isdead_or_accreted,massoftype,igas,rhoh,igasP,iradP,iradxi,ics,&
+ use part,              only:isdead_or_accreted,massoftype,igas,rhoh,igasP,iradP,iradxi,ics,imu,&
                              iohm,ihall,nden_nimhd,eta_nimhd,iambi,get_partinfo,iphase,this_is_a_test,&
                              ndustsmall,itemp,ikappa
- use eos,               only:equationofstate,ieos,get_temperature,done_init_eos,init_eos
+ use eos,               only:equationofstate,ieos,get_temperature,done_init_eos,init_eos,gmw
  use radiation_utils,   only:radiation_equation_of_state,get_opacity
  use dim,               only:store_temperature,store_gamma,mhd,maxvxyzu,maxphase,maxp,use_dustgrowth,&
                              do_radiation,nalpha,mhd_nonideal
  use nicil,             only:nicil_update_nimhd,nicil_translate_error,n_warn
  use io,                only:fatal,real4,warning
  use cullendehnen,      only:get_alphaloc,xi_limiter
- use options,           only:alpha,alphamax,use_dustfrac,iopacity_type
+ use options,           only:alpha,alphamax,use_dustfrac,iopacity_type,use_variable_composition
  integer,      intent(in)    :: npart
  real,         intent(in)    :: xyzh(:,:),rad(:,:),gamma_chem(:),Bevol(:,:),dustevol(:,:)
  real(kind=4), intent(in)    :: dvdx(:,:)
@@ -174,7 +174,7 @@ subroutine cons2prim_everything(npart,xyzh,vxyzu,dvdx,rad,eos_vars,radprop,&
  integer      :: i,iamtypei,ierr
  integer      :: ierrlist(n_warn)
  real         :: rhoi,spsound,p_on_rhogas,rhogas,gasfrac,pmassi
- real         :: Bxi,Byi,Bzi,psii,xi_limiteri,Bi,temperaturei
+ real         :: Bxi,Byi,Bzi,psii,xi_limiteri,Bi,temperaturei,mui
  real         :: xi,yi,zi,hi
  logical      :: iactivei,iamgasi,iamdusti
 
@@ -187,17 +187,18 @@ subroutine cons2prim_everything(npart,xyzh,vxyzu,dvdx,rad,eos_vars,radprop,&
     call init_eos(ieos,ierr)
     if (ierr /= 0) call fatal('eos','could not initialise equation of state')
  endif
+ mui = gmw
 
 !$omp parallel do default (none) &
 !$omp shared(xyzh,vxyzu,npart,rad,eos_vars,radprop,Bevol,Bxyz) &
 !$omp shared(ieos,gamma_chem,nden_nimhd,eta_nimhd) &
 !$omp shared(alpha,alphamax,iphase,maxphase,maxp,massoftype) &
 !$omp shared(use_dustfrac,dustfrac,dustevol,this_is_a_test,ndustsmall,alphaind,dvdx) &
-!$omp shared(iopacity_type) &
+!$omp shared(iopacity_type,use_variable_composition) &
 !$omp private(i,spsound,rhoi,p_on_rhogas,rhogas,gasfrac) &
 !$omp private(Bxi,Byi,Bzi,psii,xi_limiteri,Bi,temperaturei,ierr,pmassi) &
 !$omp private(xi,yi,zi,hi) &
-!$omp firstprivate(iactivei,iamtypei,iamgasi,iamdusti) &
+!$omp firstprivate(iactivei,iamtypei,iamgasi,iamdusti,mui) &
 !$omp reduction(+:ierrlist)
  do i=1,npart
     if (.not.isdead_or_accreted(xyzh(4,i))) then
@@ -231,17 +232,18 @@ subroutine cons2prim_everything(npart,xyzh,vxyzu,dvdx,rad,eos_vars,radprop,&
        !--Calling Equation of state
        !
        temperaturei = eos_vars(itemp,i) ! needed for initial guess for idealplusrad
+       if (use_variable_composition) mui = eos_vars(imu,i)
        if (maxvxyzu >= 4) then
           if (vxyzu(4,i) < 0.) call warning('cons2prim','Internal energy < 0',i,'u',vxyzu(4,i))
           if (store_gamma) then
              call equationofstate(ieos,p_on_rhogas,spsound,rhogas,xi,yi,zi,eni=vxyzu(4,i),gamma_local=gamma_chem(i),&
-                                  tempi=temperaturei)
+                                  tempi=temperaturei,mu_local=mui)
           else
-             call equationofstate(ieos,p_on_rhogas,spsound,rhogas,xi,yi,zi,eni=vxyzu(4,i),tempi=temperaturei)
+             call equationofstate(ieos,p_on_rhogas,spsound,rhogas,xi,yi,zi,eni=vxyzu(4,i),tempi=temperaturei,mu_local=mui)
           endif
        else
           !isothermal
-          call equationofstate(ieos,p_on_rhogas,spsound,rhogas,xi,yi,zi,tempi=temperaturei)
+          call equationofstate(ieos,p_on_rhogas,spsound,rhogas,xi,yi,zi,tempi=temperaturei,mu_local=mui)
        endif
 
        eos_vars(igasP,i)  = p_on_rhogas*rhogas

--- a/src/main/energies.F90
+++ b/src/main/energies.F90
@@ -66,7 +66,7 @@ subroutine compute_energies(t)
                           igas,idust,iboundary,istar,idarkmatter,ibulge,&
                           nptmass,xyzmh_ptmass,vxyz_ptmass,isdeadh,&
                           isdead_or_accreted,epot_sinksink,imacc,ispinx,ispiny,&
-                          ispinz,mhd,gravity,poten,dustfrac,eos_vars,itemp,&
+                          ispinz,mhd,gravity,poten,dustfrac,eos_vars,itemp,igasP,ics,&
                           nden_nimhd,eta_nimhd,iion,ndustsmall,graindens,grainsize,&
                           iamdust,ndusttypes,rad,iradxi
  use part,           only:pxyzu,fxyzu,fext
@@ -373,16 +373,10 @@ subroutine compute_energies(t)
              ethermi = (alpha_gr/lorentzi)*ethermi
 #endif
              etherm = etherm + ethermi
-#ifdef KROME
-             call equationofstate(ieos,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni=vxyzu(iu,i),&
-                                   gamma_local=gamma_chem(i))
-#else
-             if (store_temperature) then
-                call equationofstate(ieos,ponrhoi,spsoundi,rhoi,xi,yi,zi,vxyzu(iu,i),tempi=eos_vars(itemp,i))
-             else
-                call equationofstate(ieos,ponrhoi,spsoundi,rhoi,xi,yi,zi,vxyzu(iu,i))
-             endif
-#endif
+
+             ponrhoi = eos_vars(igasP,i)/rhoi
+             spsoundi = eos_vars(ics,i)
+
              if (vxyzu(iu,i) < tiny(vxyzu(iu,i))) np_e_eq_0 = np_e_eq_0 + 1
              if (spsoundi < tiny(spsoundi) .and. vxyzu(iu,i) > 0. ) np_cs_eq_0 = np_cs_eq_0 + 1
           else

--- a/src/main/eos.F90
+++ b/src/main/eos.F90
@@ -1239,11 +1239,11 @@ subroutine calc_temp_and_ene(rho,pres,ene,temp,ierr,guesseint,mu_local)
  if (present(mu_local)) mu = mu_local
  select case(ieos)
  case(2) ! Adiabatic/polytropic EoS
-    temp = pres / (rho * kb_on_mh) * mu_local
+    temp = pres / (rho * kb_on_mh) * mu
     ene = pres / ( (gamma-1.) * rho)
  case(12) ! Ideal plus rad. EoS
-    call get_idealgasplusrad_tempfrompres(pres,rho,mu_local,temp)
-    call get_idealplusrad_enfromtemp(rho,temp,mu_local,ene)
+    call get_idealgasplusrad_tempfrompres(pres,rho,mu,temp)
+    call get_idealplusrad_enfromtemp(rho,temp,mu,ene)
  case(10) ! MESA-like EoS
     call get_eos_eT_from_rhop_mesa(rho,pres,ene,temp,guesseint)
  case default

--- a/src/main/eos.F90
+++ b/src/main/eos.F90
@@ -64,7 +64,7 @@ module eos
 
  data qfacdisc /0.75/
 
- public  :: equationofstate,setpolyk,eosinfo,utherm,en_from_utherm
+ public  :: equationofstate,setpolyk,eosinfo,utherm,en_from_utherm,get_mean_molecular_weight
  public  :: get_spsound,get_temperature,get_temperature_from_ponrho,eos_is_non_ideal
 #ifdef KROME
  public  :: get_local_temperature, get_local_u_internal
@@ -123,7 +123,7 @@ contains
 !  (and position in the case of the isothermal disc)
 !+
 !----------------------------------------------------------------
-subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gamma_local)
+subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gamma_local,mu_local)
  use io,            only:fatal,error,warning
  use part,          only:xyzmh_ptmass
  use units,         only:unit_density,unit_pressure,unit_ergg,unit_velocity
@@ -137,9 +137,9 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
  real,    intent(out) :: ponrhoi,spsoundi
  real,    intent(inout), optional :: eni
  real,    intent(inout), optional :: tempi
- real,    intent(in)   , optional :: gamma_local
+ real,    intent(in)   , optional :: gamma_local,mu_local
  real :: r,omega,bigH,polyk_new,r1,r2
- real :: gammai,temperaturei
+ real :: gammai,temperaturei,mui
  real :: cgsrhoi,cgseni,cgspresi,presi,gam1,cgsspsoundi
  integer :: ierr
  real :: uthermconst
@@ -151,6 +151,9 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
  var='eos_type',val=real(eos_type))
 #endif
 
+ mui = gmw
+ if (present(mu_local)) mui = mu_local
+
  select case(eos_type)
  case(1)
 !
@@ -158,7 +161,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
 !
     ponrhoi  = polyk
     spsoundi = sqrt(ponrhoi)
-    if (present(tempi)) tempi = temperature_coef*gmw*ponrhoi
+    if (present(tempi)) tempi = temperature_coef*mui*ponrhoi
 
  case(2)
 !
@@ -194,7 +197,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
     spsoundi = sqrt(gamma*ponrhoi)
 #endif
 
-    if (present(tempi)) tempi = temperature_coef*gmw*ponrhoi
+    if (present(tempi)) tempi = temperature_coef*mui*ponrhoi
 
  case(3)
 !
@@ -203,7 +206,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
 !
     ponrhoi  = polyk*(xi**2 + yi**2 + zi**2)**(-qfacdisc)
     spsoundi = sqrt(ponrhoi)
-    if (present(tempi)) tempi = temperature_coef*gmw*ponrhoi
+    if (present(tempi)) tempi = temperature_coef*mui*ponrhoi
 
 !
 !--GR isothermal
@@ -212,7 +215,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
     uthermconst = polyk
     ponrhoi = (gamma-1.)*uthermconst
     spsoundi = sqrt(ponrhoi/(1.+uthermconst))
-    if (present(tempi)) tempi = temperature_coef*gmw*ponrhoi
+    if (present(tempi)) tempi = temperature_coef*mui*ponrhoi
 
  case(6)
 !
@@ -221,7 +224,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
     ponrhoi  = polyk*((xi-xyzmh_ptmass(1,isink))**2 + (yi-xyzmh_ptmass(2,isink))**2 + &
                       (zi-xyzmh_ptmass(3,isink))**2)**(-qfacdisc)
     spsoundi = sqrt(ponrhoi)
-    if (present(tempi)) tempi = temperature_coef*gmw*ponrhoi
+    if (present(tempi)) tempi = temperature_coef*mui*ponrhoi
 
  case(7)
 !
@@ -241,7 +244,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
 
     ponrhoi = polyk_new*(xi**2 + yi**2 + zi**2)**(-qfacdisc)
     spsoundi = sqrt(ponrhoi)
-    if (present(tempi)) tempi = temperature_coef*gmw*ponrhoi
+    if (present(tempi)) tempi = temperature_coef*mui*ponrhoi
 
  case(8)
 !
@@ -273,7 +276,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
        ponrhoi = fac3*(rhoi/rhocrit3)**(gamma3-1.)
     endif
     spsoundi = sqrt(gammai*ponrhoi)
-    if (present(tempi)) tempi = temperature_coef*gmw*ponrhoi
+    if (present(tempi)) tempi = temperature_coef*mui*ponrhoi
 
  case(9)
 !
@@ -293,7 +296,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
        ponrhoi = k3pwp*rhoi**(gamma3pwp-1.)
     endif
     spsoundi = sqrt(gammai*ponrhoi)
-    if (present(tempi)) tempi = temperature_coef*gmw*ponrhoi
+    if (present(tempi)) tempi = temperature_coef*mui*ponrhoi
 
  case(10)
 !
@@ -315,7 +318,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
 !
     ponrhoi  = 0.
     spsoundi = sqrt(polyk)
-    if (present(tempi)) tempi = temperature_coef*gmw*ponrhoi
+    if (present(tempi)) tempi = temperature_coef*mui*ponrhoi
 
  case(12)
 !
@@ -328,8 +331,8 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
     endif
     cgsrhoi = rhoi * unit_density
     cgseni  = eni * unit_ergg
-    call get_idealplusrad_temp(cgsrhoi,cgseni,gmw,temperaturei,ierr)
-    call get_idealplusrad_pres(cgsrhoi,temperaturei,gmw,cgspresi)
+    call get_idealplusrad_temp(cgsrhoi,cgseni,mui,temperaturei,ierr)
+    call get_idealplusrad_pres(cgsrhoi,temperaturei,mui,cgspresi)
     call get_idealplusrad_spsoundi(cgsrhoi,cgspresi,cgseni,spsoundi)
     spsoundi = spsoundi / unit_velocity
     presi = cgspresi / unit_pressure
@@ -346,7 +349,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
 !  ponrhoi=polyk*(xyzmh_ptmass(4,1)/r1+xyzmh_ptmass(4,2)/r2)**(2*qfacdisc)/(xyzmh_ptmass(4,1)+xyzmh_ptmass(4,2))**(2*qfacdisc)
     ponrhoi=polyk*(xyzmh_ptmass(4,1)/r1+xyzmh_ptmass(4,2)/r2)**(2*qfacdisc)/(xyzmh_ptmass(4,1))**(2*qfacdisc)
     spsoundi=sqrt(ponrhoi)
-    if (present(tempi)) tempi = temperature_coef*gmw*ponrhoi
+    if (present(tempi)) tempi = temperature_coef*mui*ponrhoi
 
  case(15)
 !
@@ -383,7 +386,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
     if (present(gamma_local)) then
        ponrhoi  = (gamma_local-1.)*eni
        spsoundi = sqrt(gamma_local*ponrhoi)
-       if (present(tempi)) tempi = temperature_coef*gmw*ponrhoi
+       if (present(tempi)) tempi = temperature_coef*mui*ponrhoi
     else
        ponrhoi = 0.
        spsoundi = 0.
@@ -393,7 +396,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni,tempi,gam
  case default
     spsoundi = 0. ! avoids compiler warnings
     ponrhoi  = 0.
-    if (present(tempi)) tempi = temperature_coef*gmw*ponrhoi
+    if (present(tempi)) tempi = temperature_coef*mui*ponrhoi
     call fatal('eos','unknown equation of state')
  end select
 
@@ -423,25 +426,28 @@ end function eos_is_non_ideal
 !  (called from step for decay timescale in alpha switches)
 !+
 !----------------------------------------------------------------
-real function get_spsound(eos_type,xyzi,rhoi,vxyzui,tempi,gammai)
+real function get_spsound(eos_type,xyzi,rhoi,vxyzui,tempi,gammai,mui)
  use dim, only:maxvxyzu
  integer,      intent(in)      :: eos_type
  real,         intent(in)      :: xyzi(:),rhoi
  real,         intent(inout)   :: vxyzui(:)
  real, intent(inout)   , optional    :: tempi
- real, intent(in)      , optional    :: gammai
- real :: spsoundi,ponrhoi
+ real, intent(in)      , optional    :: gammai,mui
+ real :: spsoundi,ponrhoi,mu
+
+ mu = gmw
+ if (present(mui)) mu = mui
 
  if (maxvxyzu==4) then
     if (present(gammai)) then
-       call equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xyzi(1),xyzi(2),xyzi(3),vxyzui(4),gamma_local=gammai)
+       call equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xyzi(1),xyzi(2),xyzi(3),vxyzui(4),gamma_local=gammai,mu_local=mu)
     elseif (present(tempi)) then
-       call equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xyzi(1),xyzi(2),xyzi(3),vxyzui(4),tempi=tempi)
+       call equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xyzi(1),xyzi(2),xyzi(3),vxyzui(4),tempi=tempi,mu_local=mu)
     else
-       call equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xyzi(1),xyzi(2),xyzi(3),vxyzui(4))
+       call equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xyzi(1),xyzi(2),xyzi(3),vxyzui(4),mu_local=mu)
     endif
  else
-    call equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xyzi(1),xyzi(2),xyzi(3))
+    call equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xyzi(1),xyzi(2),xyzi(3),mu_local=mu)
  endif
  get_spsound = spsoundi
 
@@ -453,52 +459,31 @@ end function get_spsound
 !  position and/or thermal energy
 !+
 !-----------------------------------------------------------------------
-real function get_temperature(eos_type,xyzi,rhoi,vxyzui,gammai)
+real function get_temperature(eos_type,xyzi,rhoi,vxyzui,gammai,mui) result(tempi)
  use dim, only:maxvxyzu
  integer,      intent(in)    :: eos_type
  real,         intent(in)    :: xyzi(:),rhoi
  real,         intent(inout) :: vxyzui(:)
- real, intent(in), optional  :: gammai
- real :: spsoundi,ponrhoi
+ real, intent(in), optional  :: gammai,mui
+ real :: spsoundi,ponrhoi,mu
 
+ mu = gmw
+ if (present(mui)) mu = mui
  if (maxvxyzu==4) then
     if (present(gammai)) then
-       call equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xyzi(1),xyzi(2),xyzi(3),vxyzui(4),gamma_local=gammai)
+       call equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xyzi(1),xyzi(2),xyzi(3),vxyzui(4),&
+                            gamma_local=gammai,mu_local=mui,tempi=tempi)
     else
-       call equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xyzi(1),xyzi(2),xyzi(3),vxyzui(4))
+       call equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xyzi(1),xyzi(2),xyzi(3),vxyzui(4),&
+                            mu_local=mui,tempi=tempi)
     endif
  else
-    call equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xyzi(1),xyzi(2),xyzi(3))
+    call equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xyzi(1),xyzi(2),xyzi(3),mu_local=mui,tempi=tempi)
  endif
-
- get_temperature = temperature_coef*gmw*ponrhoi
 
 end function get_temperature
 
 #ifdef KROME
-!-----------------------------------------------------------------------
-!+
-!  query function to return the temperature for calculations with a local
-!  mean molecular weight and local adiabatic index
-!+
-!-----------------------------------------------------------------------
-subroutine get_local_temperature(eos_type,xi,yi,zi,rhoi,gmwi,intenerg,gammai,local_temperature)
- use dim, only:maxvxyzu
- integer,      intent(in)    :: eos_type
- real,         intent(in)    :: xi,yi,zi,rhoi,gmwi,gammai
- real,         intent(inout) :: intenerg
- real,         intent(out)   :: local_temperature
- real :: spsoundi,ponrhoi
-
- if (maxvxyzu==4) then
-    call equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,eni=intenerg,gamma_local=gammai)
- else
-    print *, "CHEMISTRY PROBLEM: ISOTHERMAL SETUP USED, INTERNAL ENERGY NOT STORED"
- endif
- local_temperature = temperature_coef*gmwi*ponrhoi
-
-end subroutine get_local_temperature
-
 !----------------------------------------------------------------------------
 !+
 !  query function to return the internal energyfor calculations with a local
@@ -671,7 +656,7 @@ subroutine init_eos(eos_type,ierr)
     !
     ! ideal plus radiation
     !
-    write(*,'(1x,a,f7.5)') 'Initialising ideal plus radiation EoS with mu = ',gmw
+    write(*,'(1x,a,f7.5)') 'Using ideal plus radiation EoS with mu = ',gmw
     if (do_radiation) then
        call error('eos','ieos=12, cannot use eos with radiation, will double count radiation pressure')
        ierr = ierr_option_conflict
@@ -1239,23 +1224,26 @@ end subroutine calc_rec_ene
 !  pressure and density, assuming inputs are in cgs units
 !+
 !----------------------------------------------------------------
-subroutine calc_temp_and_ene(rho,pres,ene,temp,ierr,guesseint)
+subroutine calc_temp_and_ene(rho,pres,ene,temp,ierr,guesseint,mu_local)
  use physcon,          only:kb_on_mh
  use eos_idealplusrad, only:get_idealgasplusrad_tempfrompres,get_idealplusrad_enfromtemp
  use eos_mesa,         only:get_eos_eT_from_rhop_mesa
  real, intent(in)           :: rho,pres
  real, intent(inout)        :: ene,temp
- real, intent(in), optional :: guesseint
+ real, intent(in), optional :: guesseint,mu_local
  integer, intent(out)       :: ierr
+ real                       :: mu
 
  ierr = 0
+ mu = gmw
+ if (present(mu_local)) mu = mu_local
  select case(ieos)
  case(2) ! Adiabatic/polytropic EoS
-    temp = pres / (rho * kb_on_mh) * gmw
+    temp = pres / (rho * kb_on_mh) * mu_local
     ene = pres / ( (gamma-1.) * rho)
  case(12) ! Ideal plus rad. EoS
-    call get_idealgasplusrad_tempfrompres(pres,rho,gmw,temp)
-    call get_idealplusrad_enfromtemp(rho,temp,gmw,ene)
+    call get_idealgasplusrad_tempfrompres(pres,rho,mu_local,temp)
+    call get_idealplusrad_enfromtemp(rho,temp,mu_local,ene)
  case(10) ! MESA-like EoS
     call get_eos_eT_from_rhop_mesa(rho,pres,ene,temp,guesseint)
  case default
@@ -1270,7 +1258,7 @@ end subroutine calc_temp_and_ene
 !  up to an additive integration constant, from density and pressure.
 !+
 !-----------------------------------------------------------------------
-function entropy(rho,pres,ientropy,ierr)
+function entropy(rho,pres,mu,ientropy,ierr)
  use io,                only:fatal
  use physcon,           only:radconst,kb_on_mh
  use eos_idealplusrad,  only:get_idealgasplusrad_tempfrompres
@@ -1279,20 +1267,19 @@ function entropy(rho,pres,ientropy,ierr)
  real, intent(in)               :: rho,pres
  integer, intent(in)            :: ientropy
  integer, intent(out), optional :: ierr
- real                           :: inv_mu,entropy,logentropy,temp,eint
+ real                           :: mu,entropy,logentropy,temp,eint
 
  if (present(ierr)) ierr=0
- inv_mu = 1/gmw
 
  select case(ientropy)
  case(1) ! Include only gas entropy (up to additive constants)
-    temp = pres * gmw / (rho * kb_on_mh)
-    entropy = kb_on_mh * inv_mu * log(temp**1.5/rho)
+    temp = pres * mu / (rho * kb_on_mh)
+    entropy = kb_on_mh / mu * log(temp**1.5/rho)
 
  case(2) ! Include both gas and radiation entropy (up to additive constants)
-    temp = pres * gmw / (rho * kb_on_mh) ! Guess for temp
-    call get_idealgasplusrad_tempfrompres(pres,rho,gmw,temp) ! First solve for temp from rho and pres
-    entropy = kb_on_mh * inv_mu * log(temp**1.5/rho) + 4.*radconst*temp**3 / (3.*rho)
+    temp = pres * mu / (rho * kb_on_mh) ! Guess for temp
+    call get_idealgasplusrad_tempfrompres(pres,rho,mu,temp) ! First solve for temp from rho and pres
+    entropy = kb_on_mh / mu * log(temp**1.5/rho) + 4.*radconst*temp**3 / (3.*rho)
 
  case(3) ! Get entropy from MESA tables if using MESA EoS
     if (ieos /= 10) call fatal('eos','Using MESA tables to calculate S from rho and pres, but not using MESA EoS')
@@ -1320,9 +1307,9 @@ end function entropy
 !  method
 !+
 !-----------------------------------------------------------------------
-subroutine get_rho_from_p_s(pres,S,rho,rhoguess,ientropy)
+subroutine get_rho_from_p_s(pres,S,rho,mu,rhoguess,ientropy)
  use physcon, only:kb_on_mh
- real, intent(in)    :: pres,S,rhoguess
+ real, intent(in)    :: pres,S,mu,rhoguess
  real, intent(inout) :: rho
  real                :: srho,srho_plus_dsrho,S_plus_dS,dSdsrho
  real(kind=8)        :: corr
@@ -1335,13 +1322,26 @@ subroutine get_rho_from_p_s(pres,S,rho,rhoguess,ientropy)
  do while (abs(corr) > eoserr*abs(srho))
     ! First calculate dS/dsrho
     srho_plus_dsrho = srho * (1. + dfac)
-    S_plus_dS = entropy(srho_plus_dsrho**2, pres, ientropy)
-    dSdsrho = (S_plus_dS - entropy(srho**2,pres,ientropy)) / (srho_plus_dsrho - srho)
-    corr = ( entropy(srho**2,pres,ientropy) - S ) / dSdsrho
+    S_plus_dS = entropy(srho_plus_dsrho**2,pres,mu,ientropy)
+    dSdsrho = (S_plus_dS - entropy(srho**2,pres,mu,ientropy)) / (srho_plus_dsrho - srho)
+    corr = ( entropy(srho**2,pres,mu,ientropy) - S ) / dSdsrho
     srho = srho - corr
  enddo
  rho = srho**2
  return
 end subroutine get_rho_from_p_s
+
+!-----------------------------------------------------------------------
+!+
+!  Calculate mean molecular weight from X and Z, assumming complete
+!  ionisation
+!+
+!-----------------------------------------------------------------------
+real function get_mean_molecular_weight(XX,ZZ) result(mu)
+ real, intent(in) :: XX,ZZ
+ real :: YY
+ YY = 1.-XX-ZZ
+ mu = 1./(2.*XX + 0.75*YY + 0.5*ZZ)
+end function  get_mean_molecular_weight
 
 end module eos

--- a/src/main/krome.f90
+++ b/src/main/krome.f90
@@ -108,7 +108,7 @@ subroutine update_krome(dt,xyzh,u,rho,xchem,gamma_chem,mu_chem,T_chem)
  use krome_main, only: krome
  use krome_user,    only:krome_consistent_x,krome_get_mu_x,krome_get_gamma_x
  use units,         only:unit_density,utime
- use eos,           only:ieos,get_local_temperature,get_local_u_internal!equationofstate
+ use eos,           only:ieos,get_temperature,get_local_u_internal!equationofstate
 
  real, intent(in)    :: dt,xyzh(4),rho
  real, intent(inout) :: u,gamma_chem,mu_chem,xchem(:)
@@ -117,7 +117,7 @@ subroutine update_krome(dt,xyzh,u,rho,xchem,gamma_chem,mu_chem,T_chem)
 
  dt_cgs = dt*utime
  rho_cgs = rho*unit_density
- call get_local_temperature(ieos,xyzh(1),xyzh(2),xyzh(3),rho,mu_chem,u,gamma_chem,T_local)
+ T_local = get_temperature(ieos,xyzh(1:3),rho,(/0.,0.,0.,u/),gammai=gamma_chem,mui=mu_chem)
  T_local=max(T_local,20.0d0)
 ! normalise abudances and balance charge conservation with e-
  call krome_consistent_x(xchem)

--- a/src/main/options.f90
+++ b/src/main/options.f90
@@ -53,6 +53,9 @@ module options
  ! radiation
  logical,public :: exchange_radiation_energy, limit_radiation_flux
 
+ ! variable composition
+ logical,public :: use_variable_composition
+
  public :: set_default_options
  public :: ieos
  public :: iopacity_type
@@ -153,6 +156,9 @@ subroutine set_default_options
     limit_radiation_flux = .false.
     iopacity_type = 0
  endif
+
+ ! variable composition
+ use_variable_composition = .false.
 
 end subroutine set_default_options
 

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -127,9 +127,11 @@ module part
                        ics   = 2, &
                        itemp = 3, &
                        imu   = 4, &
-                       maxeosvars = 4
+                       iX    = 5, &
+                       iZ    = 6, &
+                       maxeosvars = 6
  character(len=*), parameter :: eos_vars_label(maxeosvars) = &
-    (/'pressure   ','sound speed', 'temperature', 'mu         '/)
+    (/'pressure   ','sound speed','temperature','mu         ','H fraction ','metallicity'/)
 !
 !--one-fluid dust (small grains)
 !

--- a/src/main/readwrite_dumps_common.F90
+++ b/src/main/readwrite_dumps_common.F90
@@ -120,7 +120,7 @@ end subroutine get_options_from_fileid
 !---------------------------------------------------------------
 subroutine check_arrays(i1,i2,npartoftype,npartread,nptmass,nsinkproperties,massoftype,&
                         alphafile,tfile,phantomdump,got_iphase,got_xyzh,got_vxyzu,got_alpha, &
-                        got_krome_mols,got_krome_gamma,got_krome_mu,got_krome_T, &
+                        got_krome_mols,got_krome_gamma,got_krome_mu,got_krome_T,got_x,got_z,got_mu, &
                         got_abund,got_dustfrac,got_sink_data,got_sink_vels,got_Bxyz,got_psi,got_dustprop,got_pxyzu,got_VrelVf, &
                         got_dustgasprop,got_temp,got_raden,got_kappa,got_Tdust,got_iorig,iphase,&
                         xyzh,vxyzu,pxyzu,alphaind,xyzmh_ptmass,Bevol,iorig,iprint,ierr)
@@ -130,12 +130,12 @@ subroutine check_arrays(i1,i2,npartoftype,npartread,nptmass,nsinkproperties,mass
  use part, only:maxphase,isetphase,set_particle_type,igas,ihacc,ihsoft,imacc,&
                 xyzmh_ptmass_label,vxyz_ptmass_label,get_pmass,rhoh,dustfrac,ndusttypes,norig
  use io,   only:warning,id,master
- use options,    only:alpha,use_dustfrac
+ use options,    only:alpha,use_dustfrac,use_variable_composition
  use sphNGutils, only:itype_from_sphNG_iphase,isphNG_accreted
  integer,         intent(in)    :: i1,i2,npartoftype(:),npartread,nptmass,nsinkproperties
  real,            intent(in)    :: massoftype(:),alphafile,tfile
  logical,         intent(in)    :: phantomdump,got_iphase,got_xyzh(:),got_vxyzu(:),got_alpha,got_dustprop(:)
- logical,         intent(in)    :: got_VrelVf,got_dustgasprop(:)
+ logical,         intent(in)    :: got_VrelVf,got_dustgasprop(:),got_x,got_z,got_mu
  logical,         intent(in)    :: got_abund(:),got_dustfrac(:),got_sink_data(:),got_sink_vels(:),got_Bxyz(:)
  logical,         intent(in)    :: got_krome_mols(:),got_krome_gamma,got_krome_mu,got_krome_T
  logical,         intent(in)    :: got_psi,got_temp,got_Tdust,got_pxyzu(:),got_raden(:),got_kappa,got_iorig
@@ -250,6 +250,7 @@ subroutine check_arrays(i1,i2,npartoftype,npartread,nptmass,nsinkproperties,mass
  if (store_temperature .and. .not.got_temp) then
     if (id==master .and. i1==1) write(*,*) 'WARNING: missing temperature information from file'
  endif
+ use_variable_composition = (got_x .and. got_z .and. got_mu)
  if (store_dust_temperature .and. .not.got_Tdust) then
     if (id==master .and. i1==1) write(*,*) 'WARNING: missing dust temperature information from file'
  endif

--- a/src/main/readwrite_dumps_fortran.F90
+++ b/src/main/readwrite_dumps_fortran.F90
@@ -218,8 +218,8 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
                  divcurlv,divcurlv_label,divcurlB,divcurlB_label,poten,dustfrac,deltav,deltav_label,tstop,&
                  dustfrac_label,tstop_label,dustprop,dustprop_label,eos_vars,eos_vars_label,ndusttypes,ndustsmall,VrelVf,&
                  VrelVf_label,dustgasprop,dustgasprop_label,dust_temp,pxyzu,pxyzu_label,dens,& !,dvdx,dvdx_label
-                 rad,rad_label,radprop,radprop_label,do_radiation,maxirad,maxradprop,itemp,igasP,iorig
- use options,    only:use_dustfrac
+                 rad,rad_label,radprop,radprop_label,do_radiation,maxirad,maxradprop,itemp,igasP,iorig,iX,iZ,imu
+ use options,    only:use_dustfrac,use_variable_composition
  use dump_utils, only:tag,open_dumpfile_w,allocate_header,&
                  free_header,write_header,write_array,write_block_header
  use mpiutils,   only:reduce_mpi,reduceall_mpi
@@ -379,6 +379,12 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
        ! write pressure to file
        if ((ieos==8 .or. ieos==9 .or. ieos==10 .or. ieos==15 .or. eos_is_non_ideal(ieos)) .and. k==i_real) then
           call write_array(1,eos_vars,eos_vars_label,1,npart,k,ipass,idump,nums,ierrs(13),index=igasP)
+       endif
+       ! write X, Z, mu to file
+       if (use_variable_composition) then
+          call write_array(1,eos_vars,eos_vars_label,1,npart,k,ipass,idump,nums,ierrs(13),index=iX)
+          call write_array(1,eos_vars,eos_vars_label,1,npart,k,ipass,idump,nums,ierrs(13),index=iZ)
+          call write_array(1,eos_vars,eos_vars_label,1,npart,k,ipass,idump,nums,ierrs(13),index=imu)
        endif
 
        ! smoothing length written as real*4 to save disk space
@@ -1097,7 +1103,7 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
  use part,       only:xyzh,xyzh_label,vxyzu,vxyzu_label,dustfrac,abundance,abundance_label, &
                       alphaind,poten,xyzmh_ptmass,xyzmh_ptmass_label,vxyz_ptmass,vxyz_ptmass_label, &
                       Bevol,Bxyz,Bxyz_label,nabundances,iphase,idust,dustfrac_label, &
-                      eos_vars,eos_vars_label,dustprop,dustprop_label,divcurlv,divcurlv_label,&
+                      eos_vars,eos_vars_label,dustprop,dustprop_label,divcurlv,divcurlv_label,iX,iZ,imu, &
                       VrelVf,VrelVf_label,dustgasprop,dustgasprop_label,pxyzu,pxyzu_label,dust_temp, &
                       rad,rad_label,radprop,radprop_label,do_radiation,maxirad,maxradprop,ikappa,ithick,itemp,iorig
 #ifdef IND_TIMESTEPS
@@ -1125,7 +1131,7 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
  logical               :: match
  logical               :: got_iphase,got_xyzh(4),got_vxyzu(4),got_abund(nabundances),got_alpha,got_poten
  logical               :: got_sink_data(nsinkproperties),got_sink_vels(3),got_Bxyz(3)
- logical               :: got_krome_mols(krome_nmols),got_krome_T,got_krome_gamma,got_krome_mu
+ logical               :: got_krome_mols(krome_nmols),got_krome_T,got_krome_gamma,got_krome_mu,got_x,got_z,got_mu
  logical               :: got_nucleation(n_nucleation)
  logical               :: got_psi,got_temp,got_Tdust,got_dustprop(2),got_VrelVf,got_dustgasprop(4), &
                           got_divcurlv(4),got_raden(maxirad),got_kappa,got_pxyzu(4),got_iorig
@@ -1156,6 +1162,9 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
  got_krome_gamma = .false.
  got_krome_mu    = .false.
  got_krome_T     = .false.
+ got_x           = .false.
+ got_z           = .false.
+ got_mu          = .false.
  got_nucleation  = .false.
  got_raden       = .false.
  got_kappa       = .false.
@@ -1213,6 +1222,9 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
              if (store_temperature) then
                 call read_array(eos_vars(itemp,:),eos_vars_label(itemp),got_temp,ik,i1,i2,noffset,idisk1,tag,match,ierr)
              endif
+             call read_array(eos_vars(iX,:),eos_vars_label(iX),got_x,ik,i1,i2,noffset,idisk1,tag,match,ierr)
+             call read_array(eos_vars(iZ,:),eos_vars_label(iZ),got_z,ik,i1,i2,noffset,idisk1,tag,match,ierr)
+             call read_array(eos_vars(imu,:),eos_vars_label(imu),got_mu,ik,i1,i2,noffset,idisk1,tag,match,ierr)
              if (maxalpha==maxp) call read_array(alphaind(1,:),'alpha',got_alpha,ik,i1,i2,noffset,idisk1,tag,match,ierr)
              !
              ! read divcurlv if it is in the file
@@ -1256,7 +1268,7 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
  !
  call check_arrays(i1,i2,npartoftype,npartread,nptmass,nsinkproperties,massoftype,&
                    alphafile,tfile,phantomdump,got_iphase,got_xyzh,got_vxyzu,got_alpha, &
-                   got_krome_mols,got_krome_gamma,got_krome_mu,got_krome_T, &
+                   got_krome_mols,got_krome_gamma,got_krome_mu,got_krome_T,got_x,got_z,got_mu, &
                    got_abund,got_dustfrac,got_sink_data,got_sink_vels,got_Bxyz,got_psi,got_dustprop,got_pxyzu,got_VrelVf, &
                    got_dustgasprop,got_temp,got_raden,got_kappa,got_Tdust,got_iorig,iphase,&
                    xyzh,vxyzu,pxyzu,alphaind,xyzmh_ptmass,Bevol,iorig,iprint,ierr)

--- a/src/main/utils_tables.f90
+++ b/src/main/utils_tables.f90
@@ -115,7 +115,7 @@ end subroutine logspace
 !  ordered array
 !+
 !----------------------------------------------------------------
-subroutine interpolator(array, value, valueidx)
+subroutine interpolator(array,value,valueidx)
  real, intent(in)     :: array(:)
  real, intent(in)     :: value
  integer, intent(out) :: valueidx

--- a/src/setup/density_profiles.f90
+++ b/src/setup/density_profiles.f90
@@ -29,7 +29,7 @@ module rho_profile
  public  :: rho_uniform,rho_polytrope,rho_piecewise_polytrope, &
             rho_evrard,read_mesa,read_kepler_file, &
             rho_bonnorebert,prompt_BEparameters
- public  :: write_softened_profile,calc_mass_enc
+ public  :: write_profile,calc_mass_enc
  private :: integrate_rho_profile,get_dPdrho
 
 contains
@@ -408,7 +408,6 @@ subroutine read_mesa(filepath,rho,r,pres,m,ene,temp,Xfrac,Yfrac,Mstar,ierr,cgsun
  allocate(header(rows),dat(lines,rows))
  header(1:rows) = dum(1:rows)
  deallocate(dum)
-
  do i = 1,lines
     read(40,*) dat(lines-i+1,1:rows)
  enddo
@@ -417,11 +416,10 @@ subroutine read_mesa(filepath,rho,r,pres,m,ene,temp,Xfrac,Yfrac,Mstar,ierr,cgsun
              temp(lines),Xfrac(lines),Yfrac(lines))
 
  close(40)
-
  ! Set mass fractions to default in eos module if not in file
  Xfrac = X_in
  Yfrac = 1. - X_in - Z_in
- do i = 1, rows
+ do i = 1,rows
     select case(trim(lcase(header(i))))
     case('mass_grams')
        m = dat(1:lines,i)
@@ -438,9 +436,9 @@ subroutine read_mesa(filepath,rho,r,pres,m,ene,temp,Xfrac,Yfrac,Mstar,ierr,cgsun
        pres = dat(1:lines,i)
     case('temperature')
        temp = dat(1:lines,i)
-    case('x_mass_fraction_h')
+    case('x_mass_fraction_h','xfrac')
        Xfrac = dat(1:lines,i)
-    case('y_mass_fraction_he')
+    case('y_mass_fraction_he','yfrac')
        Yfrac = dat(1:lines,i)
     end select
  enddo
@@ -460,7 +458,7 @@ end subroutine read_mesa
 !  Write stellar profile in format readable by read_mesa;
 !  used in star setup to write softened stellar profile.
 !----------------------------------------------------------------
-subroutine write_softened_profile(outputpath, m, pres, temp, r, rho, ene, Xfrac, Yfrac, csound)
+subroutine write_profile(outputpath,m,pres,temp,r,rho,ene,Xfrac,Yfrac,csound)
  real, intent(in)                :: m(:),rho(:),pres(:),r(:),ene(:),temp(:)
  real, intent(in), optional      :: Xfrac(:),Yfrac(:),csound(:)
  character(len=120), intent(in)  :: outputpath
@@ -491,7 +489,7 @@ subroutine write_softened_profile(outputpath, m, pres, temp, r, rho, ene, Xfrac,
 
  close(1, status = 'keep')
 
-end subroutine write_softened_profile
+end subroutine write_profile
 
 !-----------------------------------------------------------------------
 !+

--- a/src/setup/set_fixedentropycore.f90
+++ b/src/setup/set_fixedentropycore.f90
@@ -28,28 +28,24 @@ contains
 !  Main subroutine that calculates the constant entropy softened profile
 !+
 !-----------------------------------------------------------------------
-subroutine set_fixedS_softened_core(mcore,rcore,rho,r,pres,m,ene,temp,ierr)
- use eos,         only:calc_temp_and_ene,ieos
+subroutine set_fixedS_softened_core(mcore,rcore,rho,r,pres,m,Xcore,Ycore,ierr)
+ use eos,         only:ieos
  use physcon,     only:pi,gg,solarm,solarr,kb_on_mh
- use table_utils, only:interpolator,flip_array
+ use table_utils, only:interpolator
  use io,          only:fatal
- real, intent(inout)        :: r(:),rho(:),m(:),pres(:),ene(:),temp(:),mcore
- real, allocatable          :: r_alloc(:),rho_alloc(:),pres_alloc(:)
- real, intent(in)           :: rcore
- integer, intent(out)       :: ierr
- real                       :: mc,msoft,rc,eneguess
- logical                    :: isort_decreasing,iexclude_core_mass
- integer                    :: i,icore
+ real, intent(inout)  :: r(:),rho(:),m(:),pres(:),mcore
+ real, allocatable    :: r_alloc(:),rho_alloc(:),pres_alloc(:)
+ real, intent(in)     :: rcore,Xcore,Ycore
+ integer, intent(out) :: ierr
+ real                 :: mc,msoft,rc
+ integer              :: icore
 
- ! Output data to be sorted from stellar surface to interior?
- isort_decreasing = .true.     ! Needs to be true if to be read by Phantom
- ! Exclude core mass in output mass coordinate?
- iexclude_core_mass = .true.   ! Needs to be true if to be read by Phantom
-
- rc = rcore * solarr     ! Convert to cm
- mc = mcore * solarm     ! Convert to g
- call interpolator(r,rc,icore)   ! Find index in r closest to rc
+ ierr = 0
+ rc = rcore*solarr  ! convert to cm
+ mc = mcore*solarm  ! convert to g
+ call interpolator(r,rc,icore)  ! find index in r closest to rc
  msoft = m(icore) - mc
+ if (msoft<0.) call fatal('setup','mcore cannot exceed m(r=h)')
 
  select case(ieos)
  case(2)
@@ -70,38 +66,14 @@ subroutine set_fixedS_softened_core(mcore,rcore,rho,r,pres,m,ene,temp,ierr)
  rho_alloc(icore) = rho(icore)
  allocate(pres_alloc(0:icore+1))
  pres_alloc(icore:icore+1) = pres(icore:icore+1)
- call calc_rho_and_pres(r_alloc,mc,m(icore),rho_alloc,pres_alloc)
+ call calc_rho_and_pres(r_alloc,mc,m(icore),rho_alloc,pres_alloc,Xcore,Ycore)
  mcore = mc / solarm
  write(*,'(1x,a,f12.5,a)') 'Obtained core mass of ',mcore,' Msun'
  write(*,'(1x,a,f12.5,a)') 'Softened mass is ',m(icore)/solarm-mcore,' Msun'
  rho(1:icore)  = rho_alloc(1:icore)
  pres(1:icore) = pres_alloc(1:icore)
-
  call calc_mass_from_rho(r(1:icore),rho(1:icore),m(1:icore))
  m(1:icore) = m(1:icore) + mc
-
- call calc_temp_and_ene(rho(1),pres(1),ene(1),temp(1),ierr)
- if (ierr /= 0) call fatal('setfixedentropycore','EoS not one of: adiabatic, ideal gas plus radiation, MESA in set_softened_core')
- do i = 2,size(rho)-1
-    eneguess = ene(i-1)
-    call calc_temp_and_ene(rho(i),pres(i),ene(i),temp(i),ierr,eneguess)
- enddo
- ene(size(rho))  = 0. ! Zero surface internal energy
- temp(size(rho)) = 0. ! Zero surface temperature
-
- ! Reverse arrays so that data is sorted from stellar surface to stellar centre.
- if (isort_decreasing) then
-    call flip_array(m)
-    call flip_array(pres)
-    call flip_array(temp)
-    call flip_array(r)
-    call flip_array(rho)
-    call flip_array(ene)
- endif
-
- if (iexclude_core_mass) then
-    m = m - mc
- endif
 
 end subroutine set_fixedS_softened_core
 
@@ -111,14 +83,14 @@ end subroutine set_fixedS_softened_core
 !  Returns softened core profile with fixed entropy
 !+
 !-----------------------------------------------------------------------
-subroutine calc_rho_and_pres(r,mcore,mh,rho,pres)
- use eos, only:entropy
+subroutine calc_rho_and_pres(r,mcore,mh,rho,pres,Xcore,Ycore)
+ use eos, only:entropy,get_mean_molecular_weight
  real, allocatable, dimension(:), intent(in)    :: r
- real, intent(in)                               :: mh
+ real, intent(in)                               :: mh,Xcore,Ycore
  real, intent(inout)                            :: mcore
  real, allocatable, dimension(:), intent(inout) :: rho,pres
  integer                                        :: Nmax
- real                                           :: Sc,mass,mold,msoft,fac
+ real                                           :: Sc,mass,mold,msoft,fac,mu
 
 ! INSTRUCTIONS
 
@@ -132,7 +104,8 @@ subroutine calc_rho_and_pres(r,mcore,mh,rho,pres)
 
  msoft = mh - mcore
  Nmax  = size(rho)-1 ! Index corresponding to r = h
- Sc = entropy(rho(Nmax),pres(Nmax),ientropy)
+ mu = get_mean_molecular_weight(Xcore,1.-Xcore-Ycore)
+ Sc = entropy(rho(Nmax),pres(Nmax),mu,ientropy)
 
  ! Start shooting method
  fac  = 0.05
@@ -140,7 +113,7 @@ subroutine calc_rho_and_pres(r,mcore,mh,rho,pres)
 
  do
     mold = mass
-    call one_shot(Sc,r,mcore,msoft,rho,pres,mass) ! returned mass is m(r=0)
+    call one_shot(Sc,r,mcore,msoft,mu,rho,pres,mass) ! returned mass is m(r=0)
     if (mass < 0.) then
        mcore = mcore * (1. - fac)
        msoft = mh - mcore
@@ -167,9 +140,10 @@ end subroutine calc_rho_and_pres
 !  Calculate a hydrostatic structure for a given entropy
 !+
 !-----------------------------------------------------------------------
-subroutine one_shot(Sc,r,mcore,msoft,rho,pres,mass)
+subroutine one_shot(Sc,r,mcore,msoft,mu,rho,pres,mass)
  use physcon, only:gg,pi
- real, intent(in)                               :: Sc,mcore,msoft
+ use eos, only:get_rho_from_p_s
+ real, intent(in)                               :: Sc,mcore,msoft,mu
  real, allocatable, dimension(:), intent(in)    :: r
  real, allocatable, dimension(:), intent(inout) :: rho,pres
  real, intent(out)                              :: mass
@@ -193,12 +167,8 @@ subroutine one_shot(Sc,r,mcore,msoft,rho,pres,mass)
                 * rho(i) * gg * (mass/r(i)**2 + mcore * gcore(r(i),rcore)) &
                 + dr(i)**2 * pres(i+1) &
                 + ( dr(i+1)**2 - dr(i)**2) * pres(i) ) / dr(i+1)**2
-    if (i == Nmax) then
-       rhoguess = 1.e8
-    else
-       rhoguess = rho(i)
-    endif
-    call get_rho_from_p_s(pres(i-1),Sc,rho(i-1))
+    rhoguess = rho(i)
+    call get_rho_from_p_s(pres(i-1),Sc,rho(i-1),mu,rhoguess,ientropy)
     mass = mass - 0.5*(rho(i)+rho(i-1)) * dvol(i)
     if (mass < 0.) return ! m(r) < 0 encountered, exit and decrease mcore
  enddo
@@ -206,37 +176,6 @@ subroutine one_shot(Sc,r,mcore,msoft,rho,pres,mass)
  return
 
 end subroutine one_shot
-
-
-!-----------------------------------------------------------------------
-!+
-!  Calculate density given pressure and entropy using Newton-Raphson
-!  method
-!+
-!-----------------------------------------------------------------------
-subroutine get_rho_from_p_s(pres,S,rho)
- use eos, only:entropy
- real, intent(in)  :: pres,S
- real, intent(out) :: rho
- real              :: corr,dSdrho,S_plus_dS,rho_plus_drho
- real, parameter   :: eoserr=1d-9,dfac=1d-12
-
- rho = 1d-8 ! Initial guess
- corr = huge(corr)
-
- do while (abs(corr) > eoserr*rho)
-    ! First calculate dS/drho
-    rho_plus_drho = rho * (1. + dfac)
-    S_plus_dS = entropy(rho_plus_drho, pres, ientropy)
-    dSdrho = (S_plus_dS - entropy(rho,pres,ientropy)) / (rho_plus_drho - rho)
-    corr = ( entropy(rho,pres,ientropy) - S ) / dSdrho
-    rho = rho - corr
- enddo
-
- return
-
-end subroutine get_rho_from_p_s
-
 
 !-----------------------------------------------------------------------
 !+

--- a/src/setup/set_softened_core.f90
+++ b/src/setup/set_softened_core.f90
@@ -72,7 +72,8 @@ subroutine set_softened_core(isoftcore,isofteningopt,r,den,pres,m,X,Y,ierr)
  Xcore = yinterp(X,r,rcore*solarr)
  Zcore = 1.-Xcore-yinterp(Y,r,rcore*solarr)
  
- write(*,'(1x,a,f7.5,a,f7.5,a,f7.5)') 'Using composition at core boundary: X = ',Xcore,', Z = ',Zcore,', mu = ',get_mean_molecular_weight(Xcore,Zcore)
+ write(*,'(1x,a,f7.5,a,f7.5,a,f7.5)') 'Using composition at core boundary: X = ',Xcore,', Z = ',Zcore,&
+                                      ', mu = ',get_mean_molecular_weight(Xcore,Zcore)
  call interpolator(r,rcore*solarr,core_index)  ! find index of core
  X(1:core_index) = Xcore
  Y(1:core_index) = yinterp(Y,r,rcore*solarr)

--- a/src/setup/set_softened_core.f90
+++ b/src/setup/set_softened_core.f90
@@ -42,7 +42,7 @@ subroutine set_softened_core(isoftcore,isofteningopt,r,den,pres,m,X,Y,ierr)
  integer, intent(in) :: isoftcore,isofteningopt
  real, intent(inout) :: r(:),den(:),m(:),pres(:),X(:),Y(:)
  integer             :: core_index,ierr
- real                :: Xcore,Zcore
+ real                :: Xcore,Zcore,rc
  logical             :: isort_decreasing,iexclude_core_mass
 
  ! Output data to be sorted from stellar surface to interior?
@@ -69,14 +69,15 @@ subroutine set_softened_core(isoftcore,isofteningopt,r,den,pres,m,X,Y,ierr)
  endif
 
  ! set fixed composition (X, Z, mu) of softened region (take on values at the core boundary)
- Xcore = yinterp(X,r,rcore*solarr)
- Zcore = 1.-Xcore-yinterp(Y,r,rcore*solarr)
+ rc = rcore*solarr
+ Xcore = yinterp(X,r,rc)
+ Zcore = 1.-Xcore-yinterp(Y,r,rc)
  
  write(*,'(1x,a,f7.5,a,f7.5,a,f7.5)') 'Using composition at core boundary: X = ',Xcore,', Z = ',Zcore,&
                                       ', mu = ',get_mean_molecular_weight(Xcore,Zcore)
- call interpolator(r,rcore*solarr,core_index)  ! find index of core
+ call interpolator(r,rc,core_index)  ! find index of core
  X(1:core_index) = Xcore
- Y(1:core_index) = yinterp(Y,r,rcore*solarr)
+ Y(1:core_index) = yinterp(Y,r,rc)
  if (ieos==10) then
     X_in = Xcore
     Z_in = Zcore

--- a/src/setup/set_softened_core.f90
+++ b/src/setup/set_softened_core.f90
@@ -6,8 +6,8 @@
 !--------------------------------------------------------------------------!
 module setsoftenedcore
 !
-! This module softens the core of a MESA stellar profile given a softening
-! radius
+! This module solves for a softened density and pressure profile below 
+! a softening radius, rcore, of a stellar profile
 !
 ! :References:
 !
@@ -21,9 +21,9 @@ module setsoftenedcore
  implicit none
  real :: rcore,mcore
 
- ! rcore: Radius below which we replace the original profile with a
+ ! rcore: Radius / Rsun below which we replace the original profile with a
  !        softened profile.
- ! mcore: Mass of core particle
+ ! mcore: Mass / Msun of core particle
 
 contains
 
@@ -32,72 +32,81 @@ contains
 !  Main subroutine that sets a softened core profile
 !+
 !-----------------------------------------------------------------------
-subroutine set_softened_core(isoftcore,isofteningopt,r,den,pres,m,ene,temp,X,Y,rcore,mcore,ierr)
- use eos,         only:ieos,X_in,Z_in,gmw,init_eos
+subroutine set_softened_core(isoftcore,isofteningopt,r,den,pres,m,X,Y,ierr)
+ use eos,         only:ieos,X_in,Z_in,init_eos,get_mean_molecular_weight
  use io,          only:fatal
+ use table_utils, only:interpolator,yinterp,flip_array
  use setcubiccore,only:set_cubic_core,find_mcore_given_rcore,find_rcore_given_mcore,check_rcore_and_mcore
  use setfixedentropycore,only:set_fixedS_softened_core
- integer, intent(in)        :: isoftcore,isofteningopt
- real, intent(inout)        :: r(:),den(:),m(:),pres(:),ene(:),temp(:),X(:),Y(:),rcore,mcore
- integer                    :: ierr
+ use physcon, only:solarr,solarm
+ integer, intent(in) :: isoftcore,isofteningopt
+ real, intent(inout) :: r(:),den(:),m(:),pres(:),X(:),Y(:)
+ integer             :: core_index,ierr
+ real                :: Xcore,Zcore
+ logical             :: isort_decreasing,iexclude_core_mass
 
- ! set mu, X, Z mass fractions to be their values at R/2
- if ((ieos == 10) .or. (ieos == 12)) then
-    call get_composition(r,den,pres,temp,X,Y,X_in,Z_in,gmw)
-    write(*,'(1x,a,f7.5,a,f7.5,a,f7.5)') 'Using composition at R/2: X = ',X_in,', Z = ',Z_in,', mu = ',gmw
+ ! Output data to be sorted from stellar surface to interior?
+ isort_decreasing = .true.     ! Needs to be true if to be read by Phantom
+ !
+ ! Exclude core mass in output mass coordinate?
+ iexclude_core_mass = .true.   ! Needs to be true if to be read by Phantom
+
+ ! get values of rcore and mcore
+ if (isoftcore == 1) then
+    select case (isofteningopt)
+    case(1)
+       call find_mcore_given_rcore(rcore,r,den,m,mcore,ierr)
+       if (ierr==1) call fatal('setup','Cannot find mcore that produces nice profile (mcore/m(h) > 0.98 reached)')
+    case(2)
+       call find_rcore_given_mcore(mcore,r,den,m,rcore,ierr)
+       if (ierr==1) call fatal('setup','Cannot find softening length that produces nice profile (h/r(mcore) < 1.02 reached)')
+    case(3) ! Both rcore and mcore are specified, check if values are sensible
+        call check_rcore_and_mcore(rcore,mcore,r,den,m,ierr)
+        if (ierr==1) call fatal('setup','mcore cannot exceed m(r=h)')
+        if (ierr==2) call fatal('setup','softenedrho/rho > tolerance')
+        if (ierr==3) call fatal('setup','drho/dr > 0 found in softened profile')
+    end select
  endif
+
+ ! set fixed composition (X, Z, mu) of softened region (take on values at the core boundary)
+ Xcore = yinterp(X,r,rcore*solarr)
+ Zcore = 1.-Xcore-yinterp(Y,r,rcore*solarr)
+ 
+ write(*,'(1x,a,f7.5,a,f7.5,a,f7.5)') 'Using composition at core boundary: X = ',Xcore,', Z = ',Zcore,', mu = ',get_mean_molecular_weight(Xcore,Zcore)
+ call interpolator(r,rcore*solarr,core_index)  ! find index of core
+ X(1:core_index) = Xcore
+ Y(1:core_index) = yinterp(Y,r,rcore*solarr)
+ if (ieos==10) then
+    X_in = Xcore
+    Z_in = Zcore
+ endif
+
  call init_eos(ieos,ierr)
  if (ierr /= 0) call fatal('set_softened_core','could not initialise equation of state')
 
- ! get values of rcore and mcore
- select case (isofteningopt)
- case(1)
-    call find_mcore_given_rcore(rcore,r,den,m,mcore,ierr)
-    if (ierr==1) call fatal('setup','Cannot find mcore that produces nice profile (mcore/m(h) > 0.98 reached)')
- case(2)
-    call find_rcore_given_mcore(mcore,r,den,m,rcore,ierr)
-    if (ierr==1) call fatal('setup','Cannot find softening length that produces nice profile (h/r(mcore) < 1.02 reached)')
- case(3) ! Both rcore and mcore are specified, check if values are sensible
-    call check_rcore_and_mcore(rcore,mcore,r,den,m,ierr)
-    if (ierr==1) call fatal('setup','mcore cannot exceed m(r=h)')
-    if (ierr==2) call fatal('setup','softenedrho/rho > tolerance')
-    if (ierr==3) call fatal('setup','drho/dr > 0 found in softened profile')
- end select
-
  ! call core-softening subroutines
- select case(isoftcore) ! choose type of core-softneing
+ select case(isoftcore) ! choose type of core-softening
  case(1)
-    call set_cubic_core(mcore,rcore,den,r,pres,m,ene,temp,ierr)
-    if (ierr /= 0) call fatal('setup','could not set softened core')
+    call set_cubic_core(mcore,rcore,den,r,pres,m)
  case(2)
-    call set_fixedS_softened_core(mcore,rcore,den,r,pres,m,ene,temp,ierr)
+    call set_fixedS_softened_core(mcore,rcore,den,r,pres,m,Xcore,1.-Xcore-Zcore,ierr)
     if (ierr /= 0) call fatal('setup','could not set fixed entropy softened core')
  end select
 
+ ! Reverse arrays so that data is sorted from stellar surface to stellar centre.
+ if (isort_decreasing) then
+   call flip_array(m)
+   call flip_array(pres)
+   call flip_array(r)
+   call flip_array(den)
+   call flip_array(X)
+   call flip_array(Y)
+ endif
+
+ if (iexclude_core_mass) then
+    m = m - mcore*solarm
+ endif
+
 end subroutine set_softened_core
-
-
-!-----------------------------------------------------------------------
-!+
-!  Get composition (mean molecular weight, X, Z mass fractions) to be
-!  their values at R/2
-!+
-!-----------------------------------------------------------------------
-subroutine get_composition(r,den,pres,temp,X,Y,Xfixed,Zfixed,mu)
- use table_utils, only:interpolator
- use physcon,     only:radconst,kb_on_mh
- real, intent(in)     :: r(:),den(:),pres(:),temp(:),X(:),Y(:)
- real, intent(out)    :: mu,Xfixed,Zfixed
- real                 :: Rstar,pgas
- integer              :: i
-
- Rstar = r(size(r))
- call interpolator(r, 0.5*Rstar, i)
- pgas = pres(i) - radconst*temp(i)**4/3. ! Assuming pressure due to ideal gas + radiation
- mu = (den(i) * kb_on_mh * temp(i)) / pgas
- Xfixed = X(i)
- Zfixed = 1. - Xfixed - Y(i)
-
-end subroutine get_composition
 
 end module setsoftenedcore

--- a/src/tests/test_nonidealmhd.F90
+++ b/src/tests/test_nonidealmhd.F90
@@ -527,10 +527,10 @@ subroutine test_etaval(ntests,npass)
  use boundary,       only:set_boundary,xmin,xmax,ymin,ymax,zmin,zmax,dxbound,dybound,dzbound
  use kernel,         only:hfact_default
  use part,           only:init_part,npart,xyzh,vxyzu,Bxyz,npartoftype,massoftype,set_particle_type,&
-                          Bevol,igas,alphaind,nden_nimhd,rhoh,eta_nimhd,iohm,ihall,iambi
+                          Bevol,igas,alphaind,nden_nimhd,rhoh,eta_nimhd,iohm,ihall,iambi,eos_vars,itemp
  use deriv,          only:get_derivs_global
  use testutils,      only:checkval
- use eos,            only:ieos,init_eos,polyk,polyk2,gamma,get_temperature
+ use eos,            only:ieos,init_eos,polyk,polyk2,gamma
  use options,        only:alphaB,alpha,alphamax
  use unifdis,        only:set_unifdis
  use dim,            only:periodic
@@ -638,7 +638,7 @@ subroutine test_etaval(ntests,npass)
     !
     rhoi  = rhoh(xyzh(4,itmp),massoftype(igas))
     Bi    = sqrt(dot_product(Bevol(1:3,itmp),Bevol(1:3,itmp)))*rhoi
-    tempi = get_temperature(ieos,xyzh(1:3,itmp),rhoi,vxyzu(:,itmp))
+    tempi = eos_vars(itemp,itmp)
 
     if (id==master) then
        write(*,*) ' '


### PR DESCRIPTION
- `eos_vars` can now store X, Z, and mu
- New option `use_variable_composition`
- `equationofstate` subroutine and certain eos-related subroutines now take mu as an optional input argument. If mu is not present, use the global variable `gmw` from the `eos` module instead.
- Can now set up a (core-softened) star with variable composition by reading X and Y from a MESA profile.
- Clean up modules related to softening stellar core profiles.
