### PR TITLE
Fix ipartbufsize for dustgrowth

### DIFF
--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -314,13 +314,9 @@ module part
  +1                                   &  ! iphase
 #endif
 #ifdef DUST
- +maxdusttypes                        &  ! dustfrac
- +maxdustsmall                        &  ! dustevol
- +maxdustsmall                        &  ! dustpred
-#ifdef DUSTGROWTH
- +1                                   &  ! dustproppred
- +1                                   &  ! ddustprop
-#endif
+   +maxdusttypes                        &  ! dustfrac
+   +maxdustsmall                        &  ! dustevol
+   +maxdustsmall                        &  ! dustpred
 #endif
 #ifdef H2CHEM
  +nabundances                         &  ! abundance


### PR DESCRIPTION
The allocation size for particle data `ipartbufsize` was increased by 2 in ed59ad73b5744266481219ba9a3e17c80680a7b0. This does not appear to do anything because the functions to fill and unfill the buffer were not updated. The arrays that this change accounts for (`dustproppred` and `ddustprop`) have size 2 each, totalling 4, so it was implemented incorrectly anyway.

Due to the mismatch, the code crashes when using MPI or reordering particles, due to the check `nbuf /= ipartbufsize`. This PR removes the change to `ipartbufsize`.