### PR TITLE
Disable scheduled actions on forks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,6 +26,7 @@ env:
 jobs:
 
   extract:
+    if: github.repository == 'danieljprice/phantom'
     runs-on: ubuntu-latest
     outputs:
       setups: ${{ steps.extract_step.outputs.setups }}
@@ -48,7 +49,6 @@ jobs:
         setup: ${{fromJson(needs.extract.outputs.setups)}}
 
     name: bench (SETUP=${{ matrix.setup }})
-    if: github.repository == 'danieljprice/phantom'
     runs-on: self-hosted
 
     steps:
@@ -108,7 +108,7 @@ jobs:
   plot:
     runs-on: ubuntu-latest
     needs: bench
-    if: ${{ always() && github.event_name == 'schedule' }}
+    if: ${{ always() && github.event_name == 'schedule' && github.repository == 'danieljprice/phantom' }}
     steps:
 
     - name: "Clone phantom"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ env:
 
 jobs:
   matrix_prep:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'danieljprice/phantom' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -85,11 +86,11 @@ jobs:
         ssh-private-key: ${{ secrets.RUNNER_PRIVATE_KEY }}
 
     - name: "Copy new build logs to web server"
-      if: ${{ (success() || failure()) && github.event_name == 'schedule' && github.repository == 'danieljprice/phantom'}}
+      if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
       run: rsync -vau logs/*.txt ${WEB_USER}@${WEB_SERVER}:${WEB_HTML_DIR}/${BUILD_LOG_DIR}
 
     - name: "Copy HTML files to web server"
-      if: ${{ (success() || failure()) && github.event_name == 'schedule' && github.repository == 'danieljprice/phantom'}}
+      if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
       run: |
         export WEB_BUILD_DIR=${WEB_HTML_DIR}/nightly/build/$(date "+%Y%m%d")
         ssh -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" ${WEB_USER}@${WEB_SERVER} -- mkdir -p ${WEB_BUILD_DIR}

--- a/src/main/checksetup.F90
+++ b/src/main/checksetup.F90
@@ -1,6 +1,6 @@
 !--------------------------------------------------------------------------!
 ! The Phantom Smoothed Particle Hydrodynamics code, by Daniel Price et al. !
-! Copyright (c) 2007-2021 The Authors (see AUTHORS)                        !
+! Copyright (c) 2007-2022 The Authors (see AUTHORS)                        !
 ! See LICENCE file for usage and distribution conditions                   !
 ! http://phantomsph.bitbucket.io/                                          !
 !--------------------------------------------------------------------------!

--- a/src/setup/setup_star.f90
+++ b/src/setup/setup_star.f90
@@ -47,7 +47,6 @@ module setup
 !   - relax_star        : *relax star automatically during setup*
 !   - ui_coef           : *specific internal energy (units of GM/R)*
 !   - use_exactN        : *find closest particle number to np*
-!   - use_variable_comp : *Use variable composition (X, Z, mu)*
 !   - write_rho_to_file : *write density profile to file*
 !
 ! :Dependencies: centreofmass, dim, domain, eos, eos_mesa, eos_piecewise,


### PR DESCRIPTION
**Type of PR:** other

**Description:**
#204 was intended to stop actions that required access to the custom runners from running on forks. All tests passed, but the behaviour of scheduled actions was not covered by the tests run on that PR.

When a scheduled action is run, the benchmark and build data is pushed to the central server, so this continues to fail on forked repos.

There is no need to run scheduled actions on forks - only when commits are made. This PR disables scheduled actions on forks.

**Testing:**
To test the scheduled actions, a test commit that reduced the scheduled interval to 15 minutes (Github's minimum) was pushed to the forked repo to verify that scheduled actions would be skipped.

**Did you run the bots?** yes