### PR TITLE
Copy dustprop and dustproppred between MPI tasks when moving particles

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,31 +25,32 @@ Giovanni Dipierro <giovanni.dipierro@leicester.ac.uk>
 Enrico Ragusa <enr.ragusa@gmail.com>
 Hauke Worpel <hworpel@aip.de>
 Roberto Iaconi <robertoiaconi1@gmail.com>
-Simon Glover <glover@uni-heidelberg.de>
 Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
+Simon Glover <glover@uni-heidelberg.de>
 Martina Toscani <mtoscani94@gmail.com>
 Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
 Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Simone Ceppi <simo.ceppi@gmail.com>
 Christopher Russell <crussell@udel.edu>
-Alex Pettitt <alex@astro1.sci.hokudai.ac.jp>
-Megha Sharma <msha0023@student.monash.edu>
 Alessia Franchini <alessia.franchini@unlv.edu>
-Nicole Rodrigues <nicole.rodrigues@monash.edu>
+Megha Sharma <msha0023@student.monash.edu>
+Alex Pettitt <alex@astro1.sci.hokudai.ac.jp>
 Kieran Hirsh <kieran.hirsh1@monash.edu>
-Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
-Nicolas Cuello <cuellonicolas@gmail.com>
+Nicole Rodrigues <nicole.rodrigues@monash.edu>
 Chris Nixon <cjn@leicester.ac.uk>
-Zachary Pellow <zpel1@student.monash.edu>
-Benoit Commercon <benoit.commercon@gmail.com>
-Cristiano Longarini <cristiano.longarini@unimi.it>
-David Trevascus <dtre10@student.monash.edu>
-Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
-Joe Fisher <jwfis1@student.monash.edu>
+Nicolas Cuello <cuellonicolas@gmail.com>
+Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
 Orsola De Marco <orsola.demarco@mq.edu.au>
+Zachary Pellow <zpel1@student.monash.edu>
+Joe Fisher <jwfis1@student.monash.edu>
+Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
+Benoit Commercon <benoit.commercon@gmail.com>
+David Trevascus <dtre10@student.monash.edu>
+Cristiano Longarini <cristiano.longarini@unimi.it>
+Alison Young <ayoung@astro.ex.ac.uk>
+Cox, Samuel <sc676@leicester.ac.uk>
 Steven Rieder <steven@rieder.nl>
 Stéven Toupin <steven.toupin@gmail.com>
+Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Maxime Lombart <maxime.lombart@ens-lyon.fr>
 Jorge Cuadra <jcuadra@astro.puc.cl>
-Cox, Samuel <sc676@leicester.ac.uk>
-Alison Young <ayoung@astro.ex.ac.uk>

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -28,7 +28,7 @@ module part
                maxptmass,maxdvdx,nsinkproperties,mhd,maxmhd,maxBevol,&
                maxp_h2,nabundances,maxtemp,periodic,&
                maxgrav,ngradh,maxtypes,h2chemistry,gravity,maxp_dustfrac,&
-               use_dust,store_temperature,lightcurve,maxlum,nalpha,maxmhdni, &
+               use_dust,use_dustgrowth,store_temperature,lightcurve,maxlum,nalpha,maxmhdni, &
                maxp_growth,maxdusttypes,maxdustsmall,maxdustlarge, &
                maxphase,maxgradh,maxan,maxdustan,maxmhdan,maxneigh,maxprad,maxsp,&
                maxTdust,store_dust_temperature,use_krome,maxp_krome, &
@@ -317,6 +317,10 @@ module part
    +maxdusttypes                        &  ! dustfrac
    +maxdustsmall                        &  ! dustevol
    +maxdustsmall                        &  ! dustpred
+#ifdef DUSTGROWTH
+   +2                                   &  ! dustprop
+   +2                                   &  ! dustproppred
+#endif
 #endif
 #ifdef H2CHEM
  +nabundances                         &  ! abundance
@@ -1376,6 +1380,10 @@ subroutine fill_sendbuf(i,xtemp)
        call fill_buffer(xtemp, dustfrac(:,i),nbuf)
        call fill_buffer(xtemp, dustevol(:,i),nbuf)
        call fill_buffer(xtemp, dustpred(:,i),nbuf)
+       if (use_dustgrowth) then
+         call fill_buffer(xtemp, dustprop(:,i),nbuf)
+         call fill_buffer(xtemp, dustproppred(:,i),nbuf)
+       endif
     endif
     if (maxp_h2==maxp .or. maxp_krome==maxp) then
        call fill_buffer(xtemp, abundance(:,i),nbuf)
@@ -1445,6 +1453,10 @@ subroutine unfill_buffer(ipart,xbuf)
     dustfrac(:,ipart)   = unfill_buf(xbuf,j,maxdusttypes)
     dustevol(:,ipart)   = unfill_buf(xbuf,j,maxdustsmall)
     dustpred(:,ipart)   = unfill_buf(xbuf,j,maxdustsmall)
+    if (use_dustgrowth) then
+      dustprop(:,ipart)       = unfill_buf(xbuf,j,2)
+      dustproppred(:,ipart)   = unfill_buf(xbuf,j,2)
+    endif
  endif
  if (maxp_h2==maxp .or. maxp_krome==maxp) then
     abundance(:,ipart)  = unfill_buf(xbuf,j,nabundances)


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
#206 fixed a bug introduced by ed59ad73b5744266481219ba9a3e17c80680a7b0 where a feature was incorrectly implemented for MPI causing an error for non-dustgrowth runs by removing the change to the `ipartbufsize` counter. This fixed non-dustgrowth runs, but not dustgrowth runs.

The symptom is incorrectly calculated `dt` due to `graindens` being zero because `dustprop` and `dustproppred` are not transported between MPI tasks. The fix is to communicate those variables using MPI 

Testing:
The `growth` benchmark now runs to completion with MPI, whereas it previously did not. There is still no automated test for dustgrowth + MPI.

Did you run the bots? yes
