### PR TITLE
Use npartoftypetot instead of npartoftype

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,31 +25,32 @@ Giovanni Dipierro <giovanni.dipierro@leicester.ac.uk>
 Enrico Ragusa <enr.ragusa@gmail.com>
 Hauke Worpel <hworpel@aip.de>
 Roberto Iaconi <robertoiaconi1@gmail.com>
-Simon Glover <glover@uni-heidelberg.de>
 Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
+Simon Glover <glover@uni-heidelberg.de>
 Martina Toscani <mtoscani94@gmail.com>
 Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
 Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Simone Ceppi <simo.ceppi@gmail.com>
 Christopher Russell <crussell@udel.edu>
-Alex Pettitt <alex@astro1.sci.hokudai.ac.jp>
-Megha Sharma <msha0023@student.monash.edu>
 Alessia Franchini <alessia.franchini@unlv.edu>
-Nicole Rodrigues <nicole.rodrigues@monash.edu>
+Megha Sharma <msha0023@student.monash.edu>
+Alex Pettitt <alex@astro1.sci.hokudai.ac.jp>
 Kieran Hirsh <kieran.hirsh1@monash.edu>
-Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
-Nicolas Cuello <cuellonicolas@gmail.com>
+Nicole Rodrigues <nicole.rodrigues@monash.edu>
 Chris Nixon <cjn@leicester.ac.uk>
-Zachary Pellow <zpel1@student.monash.edu>
-Benoit Commercon <benoit.commercon@gmail.com>
-Cristiano Longarini <cristiano.longarini@unimi.it>
-David Trevascus <dtre10@student.monash.edu>
-Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
-Joe Fisher <jwfis1@student.monash.edu>
+Nicolas Cuello <cuellonicolas@gmail.com>
+Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
 Orsola De Marco <orsola.demarco@mq.edu.au>
+Zachary Pellow <zpel1@student.monash.edu>
+Joe Fisher <jwfis1@student.monash.edu>
+Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
+Benoit Commercon <benoit.commercon@gmail.com>
+David Trevascus <dtre10@student.monash.edu>
+Cristiano Longarini <cristiano.longarini@unimi.it>
+Alison Young <ayoung@astro.ex.ac.uk>
+Cox, Samuel <sc676@leicester.ac.uk>
 Steven Rieder <steven@rieder.nl>
 Stéven Toupin <steven.toupin@gmail.com>
+Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Maxime Lombart <maxime.lombart@ens-lyon.fr>
 Jorge Cuadra <jcuadra@astro.puc.cl>
-Cox, Samuel <sc676@leicester.ac.uk>
-Alison Young <ayoung@astro.ex.ac.uk>

--- a/src/main/evwrite.F90
+++ b/src/main/evwrite.F90
@@ -78,19 +78,22 @@ subroutine init_evfile(iunit,evfile,open_file)
  use dim,       only:maxtypes,maxalpha,maxp,mhd,mhd_nonideal,lightcurve
  use options,   only:calc_erot,ishock_heating,ipdv_heating,use_dustfrac
  use units,     only:c_is_unity
- use part,      only:igas,idust,iboundary,istar,idarkmatter,ibulge,npartoftypetot,ndusttypes
+ use part,      only:igas,idust,iboundary,istar,idarkmatter,ibulge,npartoftype,ndusttypes,maxtypes
  use nicil,     only:use_ohm,use_hall,use_ambi
  use viscosity, only:irealvisc
  use gravwaveutils, only:calc_gravitwaves
+ use mpiutils,  only:reduceall_mpi
  integer,            intent(in) :: iunit
  character(len=  *), intent(in) :: evfile
  logical,            intent(in) :: open_file
  character(len= 27)             :: ev_fmt
  character(len= 11)             :: dustname
  integer                        :: i,j,k
+ integer(kind=8)                :: npartoftypetot(maxtypes)
  !
  !--Initialise additional variables
  !
+ npartoftypetot = reduceall_mpi('+', npartoftype)
  gas_only  = .true.
  do i = 2,maxtypes
     if (npartoftypetot(i) > 0) gas_only = .false.

--- a/src/main/evwrite.F90
+++ b/src/main/evwrite.F90
@@ -78,7 +78,7 @@ subroutine init_evfile(iunit,evfile,open_file)
  use dim,       only:maxtypes,maxalpha,maxp,mhd,mhd_nonideal,lightcurve
  use options,   only:calc_erot,ishock_heating,ipdv_heating,use_dustfrac
  use units,     only:c_is_unity
- use part,      only:igas,idust,iboundary,istar,idarkmatter,ibulge,npartoftype,ndusttypes
+ use part,      only:igas,idust,iboundary,istar,idarkmatter,ibulge,npartoftypetot,ndusttypes
  use nicil,     only:use_ohm,use_hall,use_ambi
  use viscosity, only:irealvisc
  use gravwaveutils, only:calc_gravitwaves
@@ -93,7 +93,7 @@ subroutine init_evfile(iunit,evfile,open_file)
  !
  gas_only  = .true.
  do i = 2,maxtypes
-    if (npartoftype(i) > 0) gas_only = .false.
+    if (npartoftypetot(i) > 0) gas_only = .false.
  enddo
  write(ev_fmt,'(a)') "(1x,'[',i2.2,1x,a11,']',2x)"
  !
@@ -122,12 +122,12 @@ subroutine init_evfile(iunit,evfile,open_file)
  call fill_ev_tag(ev_fmt,iev_com(2), 'ycom',     '0', i,j)
  call fill_ev_tag(ev_fmt,iev_com(3), 'zcom',     '0', i,j)
  if (.not. gas_only) then
-    if (npartoftype(igas)        > 0) call fill_ev_tag(ev_fmt,iev_rhop(1),'rho gas', 'xa',i,j)
-    if (npartoftype(idust)       > 0) call fill_ev_tag(ev_fmt,iev_rhop(2),'rho dust','xa',i,j)
-    if (npartoftype(iboundary)   > 0) call fill_ev_tag(ev_fmt,iev_rhop(3),'rho bdy', 'xa',i,j)
-    if (npartoftype(istar)       > 0) call fill_ev_tag(ev_fmt,iev_rhop(4),'rho star','xa',i,j)
-    if (npartoftype(idarkmatter) > 0) call fill_ev_tag(ev_fmt,iev_rhop(5),'rho dm',  'xa',i,j)
-    if (npartoftype(ibulge)      > 0) call fill_ev_tag(ev_fmt,iev_rhop(6),'rho blg', 'xa',i,j)
+    if (npartoftypetot(igas)        > 0) call fill_ev_tag(ev_fmt,iev_rhop(1),'rho gas', 'xa',i,j)
+    if (npartoftypetot(idust)       > 0) call fill_ev_tag(ev_fmt,iev_rhop(2),'rho dust','xa',i,j)
+    if (npartoftypetot(iboundary)   > 0) call fill_ev_tag(ev_fmt,iev_rhop(3),'rho bdy', 'xa',i,j)
+    if (npartoftypetot(istar)       > 0) call fill_ev_tag(ev_fmt,iev_rhop(4),'rho star','xa',i,j)
+    if (npartoftypetot(idarkmatter) > 0) call fill_ev_tag(ev_fmt,iev_rhop(5),'rho dm',  'xa',i,j)
+    if (npartoftypetot(ibulge)      > 0) call fill_ev_tag(ev_fmt,iev_rhop(6),'rho blg', 'xa',i,j)
  endif
  if (maxalpha==maxp)                  call fill_ev_tag(ev_fmt,iev_alpha,  'alpha',   'x' ,i,j)
  if ( mhd ) then

--- a/src/main/evwrite.F90
+++ b/src/main/evwrite.F90
@@ -38,8 +38,8 @@ module evwrite
 ! :Runtime parameters: None
 !
 ! :Dependencies: boundary, dim, energies, extern_binary, externalforces,
-!   fileutils, gravwaveutils, io, nicil, options, part, ptmass, timestep,
-!   units, viscosity
+!   fileutils, gravwaveutils, io, mpiutils, nicil, options, part, ptmass,
+!   timestep, units, viscosity
 !
  use io,             only:fatal,iverbose
  use options,        only:iexternalforce

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -389,9 +389,12 @@ module part
  interface hrho
   module procedure hrho4,hrho8,hrho4_pmass,hrho8_pmass,hrhomixed_pmass
  end interface hrho
+ interface get_ntypes
+  module procedure get_ntypes_i4, get_ntypes_i8
+ end interface get_ntypes
 
  private :: hrho4,hrho8,hrho4_pmass,hrho8_pmass,hrhomixed_pmass
-
+ private :: get_ntypes_i4,get_ntypes_i8
 contains
 
 subroutine allocate_part
@@ -984,8 +987,9 @@ pure elemental integer function idusttype(iphasei)
 
 end function idusttype
 
-pure integer function get_ntypes(noftype)
+pure function get_ntypes_i4(noftype) result(get_ntypes)
  integer, intent(in) :: noftype(:)
+ integer :: get_ntypes
  integer :: i
 
  get_ntypes = 0
@@ -993,7 +997,19 @@ pure integer function get_ntypes(noftype)
     if (noftype(i) > 0) get_ntypes = i
  enddo
 
-end function get_ntypes
+end function get_ntypes_i4
+
+pure function get_ntypes_i8(noftype) result(get_ntypes)
+ integer(kind=8), intent(in) :: noftype(:)
+ integer :: get_ntypes
+ integer :: i
+
+ get_ntypes = 0
+ do i=1,size(noftype)
+    if (noftype(i) > 0) get_ntypes = i
+ enddo
+
+end function get_ntypes_i8
 
 !-----------------------------------------------------------------------
 !+

--- a/src/main/step_leapfrog.F90
+++ b/src/main/step_leapfrog.F90
@@ -171,7 +171,7 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
 ! velocity predictor step, using dtsph
 !--------------------------------------
  itype   = igas
- ntypes  = get_ntypes(npartoftype)
+ ntypes  = get_ntypes(reduceall_mpi('+',npartoftype))
  pmassi  = massoftype(itype)
  store_itype = (maxphase==maxp .and. ntypes > 1)
  ialphaloc = 2


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
`npartoftype` is used in some places, instead of `npartoftypetot`.

In `init_evfile`, the count of particle types is used to set `iquantities`. This variable is then used to loop over variables to perform `reduceall_mpi` on. If `iquantities` is not the same on each MPI task, some tasks perform an additional `reduceall_mpi` call, causing them to be mismatched and then hang when the last call is left waiting. Symptom: the code hung at a reduction call.

In `step`, `npartoftype` is used to calculate `ntypes`, which is used to set the switch `store_itype`. If some particle types are absent on a particular MPI task, the value of `store_itype` could differ. If `store_itype` is not true, then `itype` is not set. Symptom: when using dustgrowth, some dust particles do not receive the update:
```
dustprop(:,i) = dustprop(:,i) + hdti*ddustprop(:,i)
```
and 
```
dustproppred(:,i) = dustprop(:,i) + hdti*ddustprop(:,i)
```
resulting in incorrect dust properties. The initial grain density is not set, and if it is left as zero, `dt` becomes zero, causing the code to crash.

Testing:
The `growth` benchmark now runs to completion with MPI, whereas it previously did not. There is still no automated test for dustgrowth + MPI.

Did you run the bots? yes
