### PR TITLE
increase memory allocation for mpi tasks to 3/n

### DIFF
--- a/src/main/readwrite_dumps_fortran.F90
+++ b/src/main/readwrite_dumps_fortran.F90
@@ -777,7 +777,7 @@ subroutine read_dump_fortran(dumpfile,tfile,hfactfile,idisk1,iprint,id,nprocs,ie
 #ifdef INJECT_PARTICLES
        call allocate_memory(maxp_hard)
 #else
-       call allocate_memory(int( min(nprocs,2)*nparttot / nprocs))
+       call allocate_memory(int(min(nprocs,3)*nparttot/nprocs))
 #endif
     endif
 !
@@ -969,7 +969,7 @@ subroutine read_smalldump_fortran(dumpfile,tfile,hfactfile,idisk1,iprint,id,npro
 #ifdef INJECT_PARTICLES
  call allocate_memory(maxp_hard)
 #else
- call allocate_memory(int( min(nprocs,2)*nparttot / nprocs))
+ call allocate_memory(int(min(nprocs,3)*nparttot/nprocs))
 #endif
 
 !


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
Increase particle memory allocation for MPI tasks to 3/n of the total number of particles. Some problems (e.g. dustgrowth) have a highly asymmetric particle distribution, and 2/n is not enough. Serial runs are not affected.

In the long term, dynamic memory reallocation should be implemented.

Testing:
MPI test suite

Did you run the bots? no
