### PR TITLE
MPI-compatible direct sum gravity test

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,28 +29,28 @@ Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
 Simon Glover <glover@uni-heidelberg.de>
 Martina Toscani <mtoscani94@gmail.com>
 Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
-Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Simone Ceppi <simo.ceppi@gmail.com>
+Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Christopher Russell <crussell@udel.edu>
-Alessia Franchini <alessia.franchini@unlv.edu>
 Megha Sharma <msha0023@student.monash.edu>
+Alessia Franchini <alessia.franchini@unlv.edu>
 Alex Pettitt <alex@astro1.sci.hokudai.ac.jp>
 Kieran Hirsh <kieran.hirsh1@monash.edu>
 Nicole Rodrigues <nicole.rodrigues@monash.edu>
 Chris Nixon <cjn@leicester.ac.uk>
+Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Nicolas Cuello <cuellonicolas@gmail.com>
 Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
 Orsola De Marco <orsola.demarco@mq.edu.au>
 Zachary Pellow <zpel1@student.monash.edu>
 Joe Fisher <jwfis1@student.monash.edu>
 Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
-Benoit Commercon <benoit.commercon@gmail.com>
 David Trevascus <dtre10@student.monash.edu>
 Cristiano Longarini <cristiano.longarini@unimi.it>
-Alison Young <ayoung@astro.ex.ac.uk>
-Cox, Samuel <sc676@leicester.ac.uk>
+Benoit Commercon <benoit.commercon@gmail.com>
 Steven Rieder <steven@rieder.nl>
-Stéven Toupin <steven.toupin@gmail.com>
-Conrad Chan <8309215+conradtchan@users.noreply.github.com>
-Maxime Lombart <maxime.lombart@ens-lyon.fr>
 Jorge Cuadra <jcuadra@astro.puc.cl>
+Stéven Toupin <steven.toupin@gmail.com>
+Cox, Samuel <sc676@leicester.ac.uk>
+Maxime Lombart <maxime.lombart@ens-lyon.fr>
+Alison Young <ayoung@astro.ex.ac.uk>

--- a/src/main/mpi_utils.F90
+++ b/src/main/mpi_utils.F90
@@ -661,30 +661,30 @@ end function reduceall_mpi_realarr
 !--------------------------------------------------------------------------
 function reduceall_mpi_realarr2(string,xproc)
 #ifdef MPI
-   use io, only:fatal
+ use io, only:fatal
 #endif
-   character(len=*), intent(in) :: string
-   real(kind=8),     intent(in) :: xproc(:,:)
-   real(kind=8) :: reduceall_mpi_realarr2(size(xproc,1),size(xproc,2))
+ character(len=*), intent(in) :: string
+ real(kind=8),     intent(in) :: xproc(:,:)
+ real(kind=8) :: reduceall_mpi_realarr2(size(xproc,1),size(xproc,2))
 #ifdef MPI
-   real(kind=8) :: xred(size(xproc,1),size(xproc,2)),xsend(size(xproc,1),size(xproc,2))
+ real(kind=8) :: xred(size(xproc,1),size(xproc,2)),xsend(size(xproc,1),size(xproc,2))
 
-   xsend(:,:) = xproc(:,:)  ! mpi calls don't like it if send and receive addresses are the same
-   select case(trim(string))
-   case('+')
-      call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_SUM,MPI_COMM_WORLD,mpierr)
-   case('max')
-      call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_MAX,MPI_COMM_WORLD,mpierr)
-   case('min')
-      call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_MIN,MPI_COMM_WORLD,mpierr)
-   case default
-      call fatal('reduceall (mpi)','unknown reduction operation')
-   end select
-   if (mpierr /= 0) call fatal('reduceall','error in mpi_reduce call')
+ xsend(:,:) = xproc(:,:)  ! mpi calls don't like it if send and receive addresses are the same
+ select case(trim(string))
+ case('+')
+    call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_SUM,MPI_COMM_WORLD,mpierr)
+ case('max')
+    call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_MAX,MPI_COMM_WORLD,mpierr)
+ case('min')
+    call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_MIN,MPI_COMM_WORLD,mpierr)
+ case default
+    call fatal('reduceall (mpi)','unknown reduction operation')
+ end select
+ if (mpierr /= 0) call fatal('reduceall','error in mpi_reduce call')
 
-   reduceall_mpi_realarr2(:,:) = xred(:,:)
+ reduceall_mpi_realarr2(:,:) = xred(:,:)
 #else
-   reduceall_mpi_realarr2(:,:) = xproc(:,:)
+ reduceall_mpi_realarr2(:,:) = xproc(:,:)
 #endif
 
 end function reduceall_mpi_realarr2

--- a/src/main/mpi_utils.F90
+++ b/src/main/mpi_utils.F90
@@ -736,33 +736,33 @@ end function reduceall_mpi_real4arr
 !--------------------------------------------------------------------------
 function reduceall_mpi_real4arr2(string,xproc)
 #ifdef MPI
-   use io, only:fatal
+ use io, only:fatal
 #endif
-   character(len=*), intent(in) :: string
-   real(kind=4),     intent(in) :: xproc(:,:)
-   real(kind=4) :: reduceall_mpi_real4arr2(size(xproc,1),size(xproc,2))
+ character(len=*), intent(in) :: string
+ real(kind=4),     intent(in) :: xproc(:,:)
+ real(kind=4) :: reduceall_mpi_real4arr2(size(xproc,1),size(xproc,2))
 #ifdef MPI
-   real(kind=4) :: xred(size(xproc,1),size(xproc,2)),xsend(size(xproc,1),size(xproc,2))
+ real(kind=4) :: xred(size(xproc,1),size(xproc,2)),xsend(size(xproc,1),size(xproc,2))
 
-   xsend(:,:) = xproc(:,:)  ! mpi calls don't like it if send and receive addresses are the same
-   select case(trim(string))
-   case('+')
-      call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_SUM,MPI_COMM_WORLD,mpierr)
-   case('max')
-      call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_MAX,MPI_COMM_WORLD,mpierr)
-   case('min')
-      call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_MIN,MPI_COMM_WORLD,mpierr)
-   case default
-      call fatal('reduceall (mpi)','unknown reduction operation')
-   end select
-   if (mpierr /= 0) call fatal('reduceall','error in mpi_reduce call')
+ xsend(:,:) = xproc(:,:)  ! mpi calls don't like it if send and receive addresses are the same
+ select case(trim(string))
+ case('+')
+    call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_SUM,MPI_COMM_WORLD,mpierr)
+ case('max')
+    call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_MAX,MPI_COMM_WORLD,mpierr)
+ case('min')
+    call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_MIN,MPI_COMM_WORLD,mpierr)
+ case default
+    call fatal('reduceall (mpi)','unknown reduction operation')
+ end select
+ if (mpierr /= 0) call fatal('reduceall','error in mpi_reduce call')
 
-   reduceall_mpi_real4arr2(:,:) = xred(:,:)
+ reduceall_mpi_real4arr2(:,:) = xred(:,:)
 #else
-   reduceall_mpi_real4arr2(:,:) = xproc(:,:)
+ reduceall_mpi_real4arr2(:,:) = xproc(:,:)
 #endif
 
-   end function reduceall_mpi_real4arr2
+end function reduceall_mpi_real4arr2
 
 !--------------------------------------------------------------------------
 !+

--- a/src/main/mpi_utils.F90
+++ b/src/main/mpi_utils.F90
@@ -62,8 +62,8 @@ module mpiutils
 !--generic interface send_recv
 !
  interface send_recv
-  module procedure send_recv_arr2, send_recv_arr2_r4, send_recv_arr1_r4, &
-                    send_recv_int, send_recv_arr1_int1, send_recv_arr2_buf, &
+  module procedure send_recv_arr2,send_recv_arr2_r4,send_recv_arr1_r4, &
+                    send_recv_int,send_recv_arr1_int1,send_recv_arr2_buf, &
                     send_recv_arr1_buf_r4
  end interface send_recv
 
@@ -77,15 +77,16 @@ module mpiutils
 !--generic interface reduce_mpi
 !
  interface reduce_mpi
-  module procedure reduce_mpi_real, reduce_mpi_real4, reduce_mpi_int, reduce_mpi_int8, &
-                     reduce_mpi_int_arr, reduce_mpi_int8_arr, reduce_mpi_real4arr, reduce_mpi_real8arr
+  module procedure reduce_mpi_real,reduce_mpi_real4,reduce_mpi_int,reduce_mpi_int8, &
+                     reduce_mpi_int_arr,reduce_mpi_int8_arr,reduce_mpi_real4arr,reduce_mpi_real8arr
  end interface reduce_mpi
 !
 !--generic interface reduceall_mpi
 !
  interface reduceall_mpi
-  module procedure reduceall_mpi_real, reduceall_mpi_real4, reduceall_mpi_int, reduceall_mpi_int8, reduceall_mpi_int1, &
-                     reduceall_mpi_realarr, reduceall_mpi_realarr2, reduceall_mpi_real4arr, reduceall_mpi_int4arr
+  module procedure reduceall_mpi_real,reduceall_mpi_real4,reduceall_mpi_int,reduceall_mpi_int8,reduceall_mpi_int1, &
+                     reduceall_mpi_realarr,reduceall_mpi_realarr2,reduceall_mpi_real4arr,reduceall_mpi_real4arr2, &
+                     reduceall_mpi_int4arr
  end interface reduceall_mpi
  !
  !--generic interface reduceloc_mpi
@@ -97,14 +98,14 @@ module mpiutils
 !  generic interface reduce_in_place
 !
  interface reduce_in_place_mpi
-  module procedure reduce_in_place_mpi_real8arr2, reduce_in_place_mpi_real4arr2
+  module procedure reduce_in_place_mpi_real8arr2,reduce_in_place_mpi_real4arr2
  end interface reduce_in_place_mpi
 !
 !--generic interface bcast_mpi
 !
  interface bcast_mpi
-  module procedure bcast_mpi_int1, bcast_mpi_int, bcast_mpi_int8, bcast_mpi_real4, bcast_mpi_real8, &
-                   bcast_mpi_real8arr, bcast_mpi_real4arr, bcast_mpi_real8arr2, bcast_mpi_real4arr2
+  module procedure bcast_mpi_int1,bcast_mpi_int,bcast_mpi_int8,bcast_mpi_real4,bcast_mpi_real8, &
+                   bcast_mpi_real8arr,bcast_mpi_real4arr,bcast_mpi_real8arr2,bcast_mpi_real4arr2
  end interface bcast_mpi
 !
 !--generic interface fill_buffer
@@ -725,6 +726,43 @@ function reduceall_mpi_real4arr(string,xproc)
 #endif
 
 end function reduceall_mpi_real4arr
+
+!--------------------------------------------------------------------------
+!+
+!  function performing MPI reduction operations (+,max,min) on 2-d array
+!  of real*4 numbers. Can be called from non-MPI routines.
+!  Sends result to all threads.
+!+
+!--------------------------------------------------------------------------
+function reduceall_mpi_real4arr2(string,xproc)
+#ifdef MPI
+   use io, only:fatal
+#endif
+   character(len=*), intent(in) :: string
+   real(kind=4),     intent(in) :: xproc(:,:)
+   real(kind=4) :: reduceall_mpi_real4arr2(size(xproc,1),size(xproc,2))
+#ifdef MPI
+   real(kind=4) :: xred(size(xproc,1),size(xproc,2)),xsend(size(xproc,1),size(xproc,2))
+
+   xsend(:,:) = xproc(:,:)  ! mpi calls don't like it if send and receive addresses are the same
+   select case(trim(string))
+   case('+')
+      call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_SUM,MPI_COMM_WORLD,mpierr)
+   case('max')
+      call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_MAX,MPI_COMM_WORLD,mpierr)
+   case('min')
+      call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_MIN,MPI_COMM_WORLD,mpierr)
+   case default
+      call fatal('reduceall (mpi)','unknown reduction operation')
+   end select
+   if (mpierr /= 0) call fatal('reduceall','error in mpi_reduce call')
+
+   reduceall_mpi_real4arr2(:,:) = xred(:,:)
+#else
+   reduceall_mpi_real4arr2(:,:) = xproc(:,:)
+#endif
+
+   end function reduceall_mpi_real4arr2
 
 !--------------------------------------------------------------------------
 !+

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -1397,8 +1397,8 @@ subroutine fill_sendbuf(i,xtemp)
        call fill_buffer(xtemp, dustevol(:,i),nbuf)
        call fill_buffer(xtemp, dustpred(:,i),nbuf)
        if (use_dustgrowth) then
-         call fill_buffer(xtemp, dustprop(:,i),nbuf)
-         call fill_buffer(xtemp, dustproppred(:,i),nbuf)
+          call fill_buffer(xtemp, dustprop(:,i),nbuf)
+          call fill_buffer(xtemp, dustproppred(:,i),nbuf)
        endif
     endif
     if (maxp_h2==maxp .or. maxp_krome==maxp) then
@@ -1470,8 +1470,8 @@ subroutine unfill_buffer(ipart,xbuf)
     dustevol(:,ipart)   = unfill_buf(xbuf,j,maxdustsmall)
     dustpred(:,ipart)   = unfill_buf(xbuf,j,maxdustsmall)
     if (use_dustgrowth) then
-      dustprop(:,ipart)       = unfill_buf(xbuf,j,2)
-      dustproppred(:,ipart)   = unfill_buf(xbuf,j,2)
+       dustprop(:,ipart)       = unfill_buf(xbuf,j,2)
+       dustproppred(:,ipart)   = unfill_buf(xbuf,j,2)
     endif
  endif
  if (maxp_h2==maxp .or. maxp_krome==maxp) then

--- a/src/tests/test_gravity.F90
+++ b/src/tests/test_gravity.F90
@@ -232,10 +232,11 @@ end subroutine test_taylorseries
 !+
 !-----------------------------------------------------------------------
 subroutine test_directsum(ntests,npass)
+ use io,        only:id,master
  use dim,       only:maxp,maxptmass
  use part,      only:init_part,npart,npartoftype,massoftype,xyzh,hfact,vxyzu,fxyzu, &
                      gradh,poten,iphase,isetphase,maxphase,labeltype,&
-                     nptmass,xyzmh_ptmass,fxyz_ptmass
+                     nptmass,xyzmh_ptmass,fxyz_ptmass,ibelong
  use eos,       only:polyk,gamma
  use options,   only:ieos,alpha,alphau,alphaB,tolh
  use spherical, only:set_sphere
@@ -247,13 +248,19 @@ subroutine test_directsum(ntests,npass)
  use kdtree,    only:tree_accuracy
  use testutils, only:checkval,checkvalbuf_end,update_test_scores
  use ptmass,    only:get_accel_sink_sink,get_accel_sink_gas,h_soft_sinksink
+ use mpiutils,  only:reduceall_mpi,bcast_mpi
+ use linklist,  only:set_linklist
+ use balance,   only:balancedomains
+ use sort_particles, only:sort_part_id
+
  integer, intent(inout) :: ntests,npass
  integer :: nfailed(18)
- integer :: maxvxyzu,nx,np,i,k,merge_n,merge_ij(maxptmass)
+ integer :: maxvxyzu,nx,np,i,k,merge_n,merge_ij(maxptmass),nfgrav
  real :: psep,totvol,totmass,rhozero,tol,pmassi
  real :: time,rmin,rmax,phitot,dtsinksink,fonrmax,phii,epot_gas_sink
  real(kind=4) :: t1,t2
  real :: epoti,tree_acc_prev
+ real, allocatable :: fgrav(:,:),fxyz_ptmass_gas(:,:)
 
  tree_acc_prev = tree_accuracy
  do k = 1,6
@@ -278,22 +285,22 @@ subroutine test_directsum(ntests,npass)
        totvol   = 4./3.*pi*rmax**3
        nx       = int(np**(1./3.))
        psep     = totvol**(1./3.)/real(nx)
-       !print*,' got psep = ',nx,psep
        psep     = 0.18
        npart    = 0
-       call set_sphere('cubic',id,master,rmin,rmax,psep,hfact,npart,xyzh)
-       !print*,' using npart = ',npart
+       ! only set up particles on master, otherwise we will end up with n duplicates
+       if (id==master) then
+        call set_sphere('cubic',id,master,rmin,rmax,psep,hfact,npart,xyzh)
+       endif
        np       = npart
-       !iverbose = 5
 !
 !--set particle properties
 !
        totmass        = 1.
        rhozero        = totmass/totvol
        npartoftype(:) = 0
-       npartoftype(k) = npart
+       npartoftype(k) = int(reduceall_mpi('+',npart),kind=kind(npartoftype))
        massoftype(:)  = 0.0
-       massoftype(k)  = totmass/npart
+       massoftype(k)  = totmass/npartoftype(k)
        if (maxphase==maxp) then
           do i=1,npart
              iphase(i) = isetphase(k,iactive=.true.)
@@ -311,6 +318,44 @@ subroutine test_directsum(ntests,npass)
        alphau = 0.
        alphaB = 0.
        tolh = 1.e-5
+
+       fxyzu = 0.0
+!
+!--call derivs to get everything initialised
+!
+       call get_derivs_global()
+!
+!--reset force to zero
+!
+       fxyzu = 0.0
+!
+!--move particles to master for direct summation
+!
+       ibelong(:) = 0
+       call balancedomains(npart)
+!
+!--compute gravitational forces by direct summation
+!
+       if (id == master) then
+        call directsum_grav(xyzh,gradh,fxyzu,phitot,npart)
+       endif
+!
+!--send phitot to all tasks
+!
+       call bcast_mpi(phitot)
+!
+!--call linklist to move particles to the task that derivs will move them to
+!
+       call set_linklist(npart,npart,xyzh,vxyzu)
+!
+!--allocate an array to write the directsum results into
+!
+      allocate(fgrav(maxvxyzu,npart))
+      fgrav(:,1:npart) = fxyzu(:,1:npart)
+!
+!--reset force to zero
+!
+      fxyzu = 0.0
 !
 !--calculate derivatives
 !
@@ -319,19 +364,17 @@ subroutine test_directsum(ntests,npass)
        call getused(t2)
        if (id==master) call printused(t1)
 !
-!--compute gravitational forces by direct summation
-!
-       call directsum_grav(xyzh,gradh,vxyzu,phitot,npart)
-!
 !--compare the results
 !
-       call checkval(np,fxyzu(1,:),vxyzu(1,:),5.e-3,nfailed(1),'fgrav(x)')
-       call checkval(np,fxyzu(2,:),vxyzu(2,:),6.e-3,nfailed(2),'fgrav(y)')
-       call checkval(np,fxyzu(3,:),vxyzu(3,:),9.4e-3,nfailed(3),'fgrav(z)')
+       call checkval(npart,fxyzu(1,:),fgrav(1,:),5.e-3,nfailed(1),'fgrav(x)')
+       call checkval(npart,fxyzu(2,:),fgrav(2,:),6.e-3,nfailed(2),'fgrav(y)')
+       call checkval(npart,fxyzu(3,:),fgrav(3,:),9.4e-3,nfailed(3),'fgrav(z)')
+       deallocate(fgrav)
        epoti = 0.
        do i=1,npart
           epoti = epoti + poten(i)
        enddo
+       epoti = reduceall_mpi('+',epoti)
        call checkval(epoti,phitot,5.2e-4,nfailed(4),'potential')
        call checkval(epoti,-3./5.*totmass**2/rmax,3.6e-2,nfailed(5),'potential=-3/5 GMM/R')
        ! check that potential energy computed via compute_energies is also correct
@@ -341,40 +384,55 @@ subroutine test_directsum(ntests,npass)
     endif
  enddo
 
-!
+
 !--test that the same results can be obtained from a cloud of sink particles
 !  with softening lengths equal to the original SPH particle smoothing lengths
 !
  if (maxptmass >= npart) then
     if (id==master) write(*,"(/,3a)") '--> testing gravity in uniform cloud of softened sink particles'
+!
+!--move particles to master for sink creation
+!
+    ibelong(:) = 0
+    call balancedomains(npart)
+!
+!--sort particles so that they can be compared at the end
+!
+    call sort_part_id
 
-    pmassi = totmass/npart
+    pmassi = totmass/reduceall_mpi('+',npart)
     call copy_gas_particles_to_sinks(npart,nptmass,xyzh,xyzmh_ptmass,pmassi)
     h_soft_sinksink = hfact*psep
 !
 !--compute direct sum for comparison, but with fixed h and hence gradh terms switched off
-
+!
     do i=1,npart
        xyzh(4,i)  = h_soft_sinksink
        gradh(1,i) = 1.
        gradh(2,i) = 0.
        vxyzu(:,i) = 0.
     enddo
-    call directsum_grav(xyzh,gradh,vxyzu,phitot,npart)
+    allocate(fgrav(maxvxyzu,npart))
+    fgrav = 0.0
+    call directsum_grav(xyzh,gradh,fgrav,phitot,npart)
+    call bcast_mpi(phitot)
 !
 !--compute gravity on the sink particles
 !
     call get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,epoti,dtsinksink,0,0.,merge_ij,merge_n)
+    call bcast_mpi(epoti)
 !
 !--compare the results
 !
     tol = 1.e-14
-    call checkval(np,fxyz_ptmass(1,:),vxyzu(1,:),tol,nfailed(1),'fgrav(x)')
-    call checkval(np,fxyz_ptmass(2,:),vxyzu(2,:),tol,nfailed(2),'fgrav(y)')
-    call checkval(np,fxyz_ptmass(3,:),vxyzu(3,:),tol,nfailed(3),'fgrav(z)')
+    call checkval(npart,fxyz_ptmass(1,:),fgrav(1,:),tol,nfailed(1),'fgrav(x)')
+    call checkval(npart,fxyz_ptmass(2,:),fgrav(2,:),tol,nfailed(2),'fgrav(y)')
+    call checkval(npart,fxyz_ptmass(3,:),fgrav(3,:),tol,nfailed(3),'fgrav(z)')
     call checkval(epoti,phitot,8e-3,nfailed(4),'potential')
     call checkval(epoti,-3./5.*totmass**2/rmax,4.1e-2,nfailed(5),'potential=-3/5 GMM/R')
     call update_test_scores(ntests,nfailed(1:5),npass)
+
+
 !
 !--now perform the same test, but with HALF the cloud made of sink particles
 !  and HALF the cloud made of gas particles. Do not re-evaluate smoothing lengths
@@ -382,38 +440,81 @@ subroutine test_directsum(ntests,npass)
 !
     if (id==master) write(*,"(/,3a)") &
        '--> testing softened gravity in uniform sphere with half sinks and half gas'
+
+!--sort the particles by ID so that the first half will have the same order
+!  even after half the particles have been converted into sinks. This sort is
+!  not really necessary because the order shouldn't have changed since the
+!  last test because derivs hasn't been called since.
+    call sort_part_id
     call copy_half_gas_particles_to_sinks(npart,nptmass,xyzh,xyzmh_ptmass,pmassi)
+
     print*,' Using ',npart,' SPH particles and ',nptmass,' point masses'
     call get_derivs_global()
 
-    epoti = 0.
+    epoti = 0.0
     call get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,epoti,dtsinksink,0,0.,merge_ij,merge_n)
-    epot_gas_sink = 0.
+!
+!--prevent double counting of sink contribution to potential due to MPI
+!
+    if (id /= master) epoti = 0.0
+!
+!--allocate an array for the gas contribution to sink acceleration
+!
+    allocate(fxyz_ptmass_gas(size(fxyz_ptmass,dim=1),nptmass))
+    fxyz_ptmass_gas = 0.0
+
+    epot_gas_sink = 0.0
     do i=1,npart
        call get_accel_sink_gas(nptmass,xyzh(1,i),xyzh(2,i),xyzh(3,i),xyzh(4,i),&
                                xyzmh_ptmass,fxyzu(1,i),fxyzu(2,i),fxyzu(3,i),&
-                               phii,pmassi,fxyz_ptmass,fonrmax,dtsinksink)
+                               phii,pmassi,fxyz_ptmass_gas,fonrmax,dtsinksink)
        epot_gas_sink = epot_gas_sink + pmassi*phii
        epoti = epoti + poten(i)
-!       write(88,*) xyzh(1:3,i),fxyzu(1:3,i)
-!       write(89,*) xyzh(1:3,i),vxyzu(1:3,i)
     enddo
-    call checkval(npart,fxyzu(1,:),vxyzu(1,:),5.e-2,nfailed(1),'fgrav(x)')
-    call checkval(npart,fxyzu(2,:),vxyzu(2,:),6.e-2,nfailed(2),'fgrav(y)')
-    call checkval(npart,fxyzu(3,:),vxyzu(3,:),9.4e-2,nfailed(3),'fgrav(z)')
-    !print*,' particle 370, pos = ',xyzh(1:3,371),' fx = ',vxyzu(1:3,371)
-    !print*,' pos = ',xyzmh_ptmass(1:3,2),' got force = ',fxyz_ptmass(1:3,2)!,vxyzu(1:3,371)
-    call checkval(nptmass,fxyz_ptmass(1,:),vxyzu(1,npart+1:2*npart),2.3e-2,nfailed(4),'fgrav(xsink)')
-    call checkval(nptmass,fxyz_ptmass(2,:),vxyzu(2,npart+1:2*npart),2.9e-2,nfailed(5),'fgrav(ysink)')
-    call checkval(nptmass,fxyz_ptmass(3,:),vxyzu(3,npart+1:2*npart),3.7e-2,nfailed(6),'fgrav(zsink)')
-!    do i=1,nptmass
-!       write(88,*) xyzmh_ptmass(1:3,i),fxyz_ptmass(1:3,i)
-!       write(89,*) xyzmh_ptmass(1:3,i),vxyzu(1:3,npart+i)
-!    enddo
+!
+!--the gas contribution to sink acceleration has to be added afterwards to
+!  prevent double counting the sink contribution when calling reduceall_mpi
+!
+    fxyz_ptmass_gas = reduceall_mpi('+',fxyz_ptmass_gas)
+    fxyz_ptmass = fxyz_ptmass + fxyz_ptmass_gas
+    deallocate(fxyz_ptmass_gas)
+!
+!--sum up potentials across MPI tasks
+!
+    epoti         = reduceall_mpi('+',epoti)
+    epot_gas_sink = reduceall_mpi('+',epot_gas_sink)
+
+!
+!--move particles to master for comparison
+!
+    ibelong(:) = 0
+    call balancedomains(npart)
+    call sort_part_id
+
+    call checkval(npart,fxyzu(1,:),fgrav(1,:),5.e-2,nfailed(1),'fgrav(x)')
+    call checkval(npart,fxyzu(2,:),fgrav(2,:),6.e-2,nfailed(2),'fgrav(y)')
+    call checkval(npart,fxyzu(3,:),fgrav(3,:),9.4e-2,nfailed(3),'fgrav(z)')
+
+!
+!--fgrav doesn't exist on worker tasks, so it needs to be sent from master
+!
+    call bcast_mpi(npart)
+    if (id == master) nfgrav = size(fgrav,dim=2)
+    call bcast_mpi(nfgrav)
+    if (id /= master) then
+      deallocate(fgrav)
+      allocate(fgrav(maxvxyzu,nfgrav))
+    endif
+    call bcast_mpi(fgrav)
+
+    call checkval(nptmass,fxyz_ptmass(1,:),fgrav(1,npart+1:2*npart),2.3e-2,nfailed(4),'fgrav(xsink)')
+    call checkval(nptmass,fxyz_ptmass(2,:),fgrav(2,npart+1:2*npart),2.9e-2,nfailed(5),'fgrav(ysink)')
+    call checkval(nptmass,fxyz_ptmass(3,:),fgrav(3,npart+1:2*npart),3.7e-2,nfailed(6),'fgrav(zsink)')
+
     call checkval(epoti+epot_gas_sink,phitot,8e-3,nfailed(7),'potential')
     call checkval(epoti+epot_gas_sink,-3./5.*totmass**2/rmax,4.1e-2,nfailed(8),'potential=-3/5 GMM/R')
     call update_test_scores(ntests,nfailed(1:8),npass)
-
+    deallocate(fgrav)
  endif
 !
 !--clean up doggie-doos
@@ -444,21 +545,47 @@ subroutine copy_gas_particles_to_sinks(npart,nptmass,xyzh,xyzmh_ptmass,massi)
 end subroutine copy_gas_particles_to_sinks
 
 subroutine copy_half_gas_particles_to_sinks(npart,nptmass,xyzh,xyzmh_ptmass,massi)
+  use io,       only: id,master,fatal
+  use mpiutils, only: bcast_mpi
  integer, intent(inout) :: npart
  integer, intent(out)   :: nptmass
  real, intent(in)  :: xyzh(:,:),massi
  real, intent(out) :: xyzmh_ptmass(:,:)
- integer :: i
+ integer :: i, nparthalf
 
  nptmass = 0
- npart = npart/2
- do i=npart+1,2*npart
-    nptmass = nptmass + 1
-    ! make a sink particle with the position of each SPH particle
-    xyzmh_ptmass(1:3,nptmass) = xyzh(1:3,i)
-    xyzmh_ptmass(4,nptmass)  =  massi ! same mass as SPH particles
-    xyzmh_ptmass(5:,nptmass) = 0.
- enddo
+ nparthalf = npart/2
+
+ call bcast_mpi(nparthalf)
+
+ if (id==master) then
+  ! Assuming all gas particles are already on master,
+  ! create sinks here and send them to other tasks
+
+  ! remove half the particles by changing npart
+  npart = nparthalf
+
+  do i=npart+1,2*npart
+      nptmass = nptmass + 1
+      call bcast_mpi(nptmass)
+      ! make a sink particle with the position of each SPH particle
+      xyzmh_ptmass(1:3,nptmass) = xyzh(1:3,i)
+      xyzmh_ptmass(4,nptmass)  =  massi ! same mass as SPH particles
+      xyzmh_ptmass(5:,nptmass) = 0.
+      call bcast_mpi(xyzmh_ptmass(1:5,nptmass))
+  enddo
+else
+  ! Assuming there are no gas particles here,
+  ! get sinks from master
+
+  if (npart /= 0) call fatal("copy_half_gas_particles_to_sinks","there are particles on a non-master task")
+
+  ! Get nparthalf from master, but don't change npart from zero
+  do i=nparthalf+1,2*nparthalf
+    call bcast_mpi(nptmass)
+    call bcast_mpi(xyzmh_ptmass(1:5,nptmass))
+  enddo
+endif
 
 end subroutine copy_half_gas_particles_to_sinks
 

--- a/src/tests/test_gravity.F90
+++ b/src/tests/test_gravity.F90
@@ -332,11 +332,11 @@ subroutine test_directsum(ntests,npass)
        do i=1,npart
           epoti = epoti + poten(i)
        enddo
-       call checkval(epoti,phitot,5.1e-4,nfailed(4),'potential')
+       call checkval(epoti,phitot,5.2e-4,nfailed(4),'potential')
        call checkval(epoti,-3./5.*totmass**2/rmax,3.6e-2,nfailed(5),'potential=-3/5 GMM/R')
        ! check that potential energy computed via compute_energies is also correct
        call compute_energies(0.)
-       call checkval(epot,phitot,5.1e-4,nfailed(6),'epot in compute_energies')
+       call checkval(epot,phitot,5.2e-4,nfailed(6),'epot in compute_energies')
        call update_test_scores(ntests,nfailed(1:6),npass)
     endif
  enddo

--- a/src/tests/test_gravity.F90
+++ b/src/tests/test_gravity.F90
@@ -233,26 +233,28 @@ end subroutine test_taylorseries
 !+
 !-----------------------------------------------------------------------
 subroutine test_directsum(ntests,npass)
- use io,        only:id,master
- use dim,       only:maxp,maxptmass
- use part,      only:init_part,npart,npartoftype,massoftype,xyzh,hfact,vxyzu,fxyzu, &
-                     gradh,poten,iphase,isetphase,maxphase,labeltype,&
-                     nptmass,xyzmh_ptmass,fxyz_ptmass,ibelong
- use eos,       only:polyk,gamma
- use options,   only:ieos,alpha,alphau,alphaB,tolh
- use spherical, only:set_sphere
- use deriv,     only:get_derivs_global
- use physcon,   only:pi
- use timing,    only:getused,printused
- use directsum, only:directsum_grav
- use energies,  only:compute_energies,epot
- use kdtree,    only:tree_accuracy
- use testutils, only:checkval,checkvalbuf_end,update_test_scores
- use ptmass,    only:get_accel_sink_sink,get_accel_sink_gas,h_soft_sinksink
- use mpiutils,  only:reduceall_mpi,bcast_mpi
- use linklist,  only:set_linklist
- use balance,   only:balancedomains
- use sort_particles, only:sort_part_id
+ use io,              only:id,master
+ use dim,             only:maxp,maxptmass
+ use part,            only:init_part,npart,npartoftype,massoftype,xyzh,hfact,vxyzu,fxyzu, &
+                           gradh,poten,iphase,isetphase,maxphase,labeltype,&
+                           nptmass,xyzmh_ptmass,fxyz_ptmass,ibelong
+ use eos,             only:polyk,gamma
+ use options,         only:ieos,alpha,alphau,alphaB,tolh
+ use spherical,       only:set_sphere
+ use deriv,           only:get_derivs_global
+ use physcon,         only:pi
+ use timing,          only:getused,printused
+ use directsum,       only:directsum_grav
+ use energies,        only:compute_energies,epot
+ use kdtree,          only:tree_accuracy
+ use testutils,       only:checkval,checkvalbuf_end,update_test_scores
+ use ptmass,          only:get_accel_sink_sink,get_accel_sink_gas,h_soft_sinksink
+ use mpiutils,        only:reduceall_mpi,bcast_mpi
+ use linklist,        only:set_linklist
+ use sort_particles,  only:sort_part_id
+#ifdef MPI
+ use balance,         only:balancedomains
+#endif
 
  integer, intent(inout) :: ntests,npass
  integer :: nfailed(18)
@@ -332,8 +334,10 @@ subroutine test_directsum(ntests,npass)
 !
 !--move particles to master and sort for direct summation
 !
+#ifdef MPI
        ibelong(:) = 0
        call balancedomains(npart)
+#endif
        call sort_part_id
 !
 !--allocate array for storing direct sum gravitational force
@@ -360,8 +364,10 @@ subroutine test_directsum(ntests,npass)
 !
 !--move particles to master and sort for test comparison
 !
+#ifdef MPI
        ibelong(:) = 0
        call balancedomains(npart)
+#endif
        call sort_part_id
 !
 !--compare the results
@@ -393,8 +399,10 @@ subroutine test_directsum(ntests,npass)
 !
 !--move particles to master for sink creation
 !
+#ifdef MPI
     ibelong(:) = 0
     call balancedomains(npart)
+#endif
 !
 !--sort particles so that they can be compared at the end
 !
@@ -487,8 +495,10 @@ subroutine test_directsum(ntests,npass)
 !
 !--move particles to master for comparison
 !
+#ifdef MPI
     ibelong(:) = 0
     call balancedomains(npart)
+#endif
     call sort_part_id
 
     call checkval(npart,fxyzu(1,:),fgrav(1,:),5.e-2,nfailed(1),'fgrav(x)')

--- a/src/tests/test_gravity.F90
+++ b/src/tests/test_gravity.F90
@@ -484,7 +484,7 @@ subroutine test_directsum(ntests,npass)
 !  prevent double counting the sink contribution when calling reduceall_mpi
 !
     fxyz_ptmass_gas = reduceall_mpi('+',fxyz_ptmass_gas)
-    fxyz_ptmass = fxyz_ptmass + fxyz_ptmass_gas
+    fxyz_ptmass(:,1:nptmass) = fxyz_ptmass(:,1:nptmass) + fxyz_ptmass_gas(:,1:nptmass)
     deallocate(fxyz_ptmass_gas)
 !
 !--sum up potentials across MPI tasks


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
`directsum_grav`, the routine for calculating the gravitational force via direct summation is not MPI aware, and will give incorrect results when particles are distributed over multiple MPI tasks.

This PR shuffles all the particles onto the master task to calculate the direct summation, before allowing derivs to redistribute the particles across the MPI tasks. Care is taken to sort the particles by ID so that the test compares the results of the same particles.

Fixes #219 

Testing:
```
make MPI=yes DEBUG=no SETUP=testgrav OPENMP=no phantomtest
mpirun -n 4 bin/phantomtest gravity
```

Did you run the bots? yes
