### PR TITLE
MPI: Fix gravity accuracy and tree building

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,28 +29,28 @@ Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
 Simon Glover <glover@uni-heidelberg.de>
 Martina Toscani <mtoscani94@gmail.com>
 Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
-Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Simone Ceppi <simo.ceppi@gmail.com>
+Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Christopher Russell <crussell@udel.edu>
-Alessia Franchini <alessia.franchini@unlv.edu>
 Megha Sharma <msha0023@student.monash.edu>
+Alessia Franchini <alessia.franchini@unlv.edu>
 Alex Pettitt <alex@astro1.sci.hokudai.ac.jp>
 Kieran Hirsh <kieran.hirsh1@monash.edu>
 Nicole Rodrigues <nicole.rodrigues@monash.edu>
 Chris Nixon <cjn@leicester.ac.uk>
+Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Nicolas Cuello <cuellonicolas@gmail.com>
 Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
 Orsola De Marco <orsola.demarco@mq.edu.au>
 Zachary Pellow <zpel1@student.monash.edu>
 Joe Fisher <jwfis1@student.monash.edu>
 Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
-Benoit Commercon <benoit.commercon@gmail.com>
 David Trevascus <dtre10@student.monash.edu>
 Cristiano Longarini <cristiano.longarini@unimi.it>
-Alison Young <ayoung@astro.ex.ac.uk>
-Cox, Samuel <sc676@leicester.ac.uk>
+Benoit Commercon <benoit.commercon@gmail.com>
 Steven Rieder <steven@rieder.nl>
-Stéven Toupin <steven.toupin@gmail.com>
-Conrad Chan <8309215+conradtchan@users.noreply.github.com>
-Maxime Lombart <maxime.lombart@ens-lyon.fr>
 Jorge Cuadra <jcuadra@astro.puc.cl>
+Stéven Toupin <steven.toupin@gmail.com>
+Cox, Samuel <sc676@leicester.ac.uk>
+Maxime Lombart <maxime.lombart@ens-lyon.fr>
+Alison Young <ayoung@astro.ex.ac.uk>

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -539,7 +539,7 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
 
        call get_neighbour_list(-1,listneigh,nneigh,xyzh,xyzcache,maxcellcache,getj=.true., &
 #ifdef GRAVITY
-                         f=cell%fgrav, local_gravity=.true., &
+                         f=cell%fgrav, &
 #endif
                          cell_xpos=cell%xpos,cell_xsizei=cell%xsizei,cell_rcuti=cell%rcuti)
 

--- a/src/main/kdtree.F90
+++ b/src/main/kdtree.F90
@@ -1024,7 +1024,7 @@ subroutine getneigh(node,xpos,xsizei,rcuti,ndim,listneigh,nneigh,xyzh,xyzcache,i
     if_open_node: if ((r2 < rcut2) .or. open_tree_node) then
        if_leaf: if (ifirstincell(n) /= 0) then ! once we hit a leaf node, retrieve contents into trial neighbour cache
           if_global_walk: if (global_walk) then
-             ! id is stored in ipart as id + 1
+             ! id is stored in cellatid (passed through into ifirstincell) as id + 1
              if (ifirstincell(n) /= (id + 1)) then
                 remote_export(ifirstincell(n)) = .true.
              endif

--- a/src/main/kdtree.F90
+++ b/src/main/kdtree.F90
@@ -1615,7 +1615,7 @@ subroutine maketreeglobal(nodeglobal,node,nodemap,globallevel,refinelevels,xyzh,
     nnodeend = 2**(level + 1) - 1
 
     ! synchronize tree with other owners if this proc is the first in group
-    call tree_sync(mynode, 1,nodeglobal(nnodestart:nnodeend), ifirstingroup, groupsize, level)
+    call tree_sync(mynode,1,nodeglobal(nnodestart:nnodeend),nprocs/groupsize,ifirstingroup,level)
 
     ! at level 0, tree_sync already 'broadcasts'
     if (level > 0) then
@@ -1661,7 +1661,9 @@ subroutine maketreeglobal(nodeglobal,node,nodemap,globallevel,refinelevels,xyzh,
     roffset_prev = roffset
     ! sync, replacing level with globallevel, since all procs will get synced
     ! and deeper comms do not exist
-    call tree_sync(refinementnode(locstart:locend),roffset,nodeglobal(nnodestart:nnodeend),id,1,globallevel)
+    call tree_sync(refinementnode(locstart:locend),roffset, &
+                   nodeglobal(nnodestart:nnodeend),nnodestart-nnodeend, &
+                   id,globallevel)
 
     ! get the mapping from the local tree to the global tree, for future hmax updates
     do inode = locstart,locend

--- a/src/main/kdtree.F90
+++ b/src/main/kdtree.F90
@@ -997,7 +997,7 @@ subroutine getneigh(node,xpos,xsizei,rcuti,ndim,listneigh,nneigh,xyzh,xyzcache,i
 #ifdef GRAVITY
     open_tree_node = tree_acc2*r2 < xsizej*xsizej    ! tree opening criterion for self-gravity
 #endif
-    if ((r2 < rcut2) .or. open_tree_node) then
+    if_open_node: if ((r2 < rcut2) .or. open_tree_node) then
        if_leaf: if (ifirstincell(n) /= 0) then ! once we hit a leaf node, retrieve contents into trial neighbour cache
           if_global_walk: if (global_walk) then
              ! id is stored in ipart as id + 1
@@ -1062,7 +1062,7 @@ subroutine getneigh(node,xpos,xsizei,rcuti,ndim,listneigh,nneigh,xyzh,xyzcache,i
           endif
        endif if_leaf
 #ifdef GRAVITY
-    elseif (present(fnode) .and. ((.not. global_walk) .or. n < 2*nprocs-1)) then
+    elseif (present(fnode) .and. ((.not. global_walk) .or. n < 2*nprocs-1)) then ! if_open_node
 !
 !--long range force on node due to distant node, along node centres
 !  along with derivatives in order to perform series expansion
@@ -1074,7 +1074,7 @@ subroutine getneigh(node,xpos,xsizei,rcuti,ndim,listneigh,nneigh,xyzh,xyzcache,i
 #endif
        call compute_fnode(dx,dy,dz,dr,totmass_node,quads,fnode)
 #endif
-    endif
+    endif if_open_node
  enddo over_stack
 
 end subroutine getneigh

--- a/src/main/kdtree.F90
+++ b/src/main/kdtree.F90
@@ -795,23 +795,49 @@ subroutine construct_node(nodeentry, nnode, mymum, level, xmini, xmaxi, npnode, 
        xminl(1) = minval(xyzh_soa(inoderange(1,il):inoderange(2,il),1))
        xminl(2) = minval(xyzh_soa(inoderange(1,il):inoderange(2,il),2))
        xminl(3) = minval(xyzh_soa(inoderange(1,il):inoderange(2,il),3))
+
        xmaxl(1) = maxval(xyzh_soa(inoderange(1,il):inoderange(2,il),1))
        xmaxl(2) = maxval(xyzh_soa(inoderange(1,il):inoderange(2,il),2))
        xmaxl(3) = maxval(xyzh_soa(inoderange(1,il):inoderange(2,il),3))
+
        xminr(1) = minval(xyzh_soa(inoderange(1,ir):inoderange(2,ir),1))
        xminr(2) = minval(xyzh_soa(inoderange(1,ir):inoderange(2,ir),2))
        xminr(3) = minval(xyzh_soa(inoderange(1,ir):inoderange(2,ir),3))
+
        xmaxr(1) = maxval(xyzh_soa(inoderange(1,ir):inoderange(2,ir),1))
        xmaxr(2) = maxval(xyzh_soa(inoderange(1,ir):inoderange(2,ir),2))
        xmaxr(3) = maxval(xyzh_soa(inoderange(1,ir):inoderange(2,ir),3))
     else
        nl = 0
        nr = 0
-       xminl = xmini
-       xmaxl = xmaxi
-       xminr = xmini
-       xmaxr = xmaxi
+       xminl = 0.0
+       xmaxl = 0.0
+       xminr = 0.0
+       xmaxr = 0.0
     endif
+
+#ifdef MPI
+    ! Reduce node limits of children across MPI tasks belonging to this group.
+    ! The synchronisation needs to happen here, not at the next level, because
+    ! the groups will be independent by then.
+    if (global_build) then
+       xminl(1) = reduce_group(xminl(1),'min',level)
+       xminl(2) = reduce_group(xminl(2),'min',level)
+       xminl(3) = reduce_group(xminl(3),'min',level)
+
+       xmaxl(1) = reduce_group(xmaxl(1),'max',level)
+       xmaxl(2) = reduce_group(xmaxl(2),'max',level)
+       xmaxl(3) = reduce_group(xmaxl(3),'max',level)
+
+       xminr(1) = reduce_group(xminr(1),'min',level)
+       xminr(2) = reduce_group(xminr(2),'min',level)
+       xminr(3) = reduce_group(xminr(3),'min',level)
+
+       xmaxr(1) = reduce_group(xmaxr(1),'max',level)
+       xmaxr(2) = reduce_group(xmaxr(2),'max',level)
+       xmaxr(3) = reduce_group(xmaxr(3),'max',level)
+    endif
+#endif
 
  endif
 

--- a/src/main/mpi_utils.F90
+++ b/src/main/mpi_utils.F90
@@ -85,7 +85,7 @@ module mpiutils
 !
  interface reduceall_mpi
   module procedure reduceall_mpi_real, reduceall_mpi_real4, reduceall_mpi_int, reduceall_mpi_int8, reduceall_mpi_int1, &
-                     reduceall_mpi_realarr, reduceall_mpi_real4arr, reduceall_mpi_int4arr
+                     reduceall_mpi_realarr, reduceall_mpi_realarr2, reduceall_mpi_real4arr, reduceall_mpi_int4arr
  end interface reduceall_mpi
  !
  !--generic interface reduceloc_mpi
@@ -651,6 +651,43 @@ function reduceall_mpi_realarr(string,xproc)
 #endif
 
 end function reduceall_mpi_realarr
+
+!--------------------------------------------------------------------------
+!+
+!  function performing MPI reduction operations (+,max,min) on 2-d array
+!  of real*8 numbers. Can be called from non-MPI routines.
+!  Sends result to all threads.
+!+
+!--------------------------------------------------------------------------
+function reduceall_mpi_realarr2(string,xproc)
+#ifdef MPI
+ use io, only:fatal
+#endif
+ character(len=*), intent(in) :: string
+ real(kind=8),     intent(in) :: xproc(:,:)
+ real(kind=8) :: reduceall_mpi_realarr2(size(xproc,1),size(xproc,2))
+#ifdef MPI
+ real(kind=8) :: xred(size(xproc,1),size(xproc,2)),xsend(size(xproc,1),size(xproc,2))
+
+ xsend(:,:) = xproc(:,:)  ! mpi calls don't like it if send and receive addresses are the same
+ select case(trim(string))
+ case('+')
+    call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_SUM,MPI_COMM_WORLD,mpierr)
+ case('max')
+    call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_MAX,MPI_COMM_WORLD,mpierr)
+ case('min')
+    call MPI_ALLREDUCE(xsend,xred,size(xsend),MPI_REAL8,MPI_MIN,MPI_COMM_WORLD,mpierr)
+ case default
+    call fatal('reduceall (mpi)','unknown reduction operation')
+ end select
+ if (mpierr /= 0) call fatal('reduceall','error in mpi_reduce call')
+
+ reduceall_mpi_realarr2(:,:) = xred(:,:)
+#else
+ reduceall_mpi_realarr2(:,:) = xproc(:,:)
+#endif
+
+end function reduceall_mpi_realarr2
 
 !--------------------------------------------------------------------------
 !+

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -1397,8 +1397,8 @@ subroutine fill_sendbuf(i,xtemp)
        call fill_buffer(xtemp, dustevol(:,i),nbuf)
        call fill_buffer(xtemp, dustpred(:,i),nbuf)
        if (use_dustgrowth) then
-         call fill_buffer(xtemp, dustprop(:,i),nbuf)
-         call fill_buffer(xtemp, dustproppred(:,i),nbuf)
+          call fill_buffer(xtemp, dustprop(:,i),nbuf)
+          call fill_buffer(xtemp, dustproppred(:,i),nbuf)
        endif
     endif
     if (maxp_h2==maxp .or. maxp_krome==maxp) then
@@ -1470,8 +1470,8 @@ subroutine unfill_buffer(ipart,xbuf)
     dustevol(:,ipart)   = unfill_buf(xbuf,j,maxdustsmall)
     dustpred(:,ipart)   = unfill_buf(xbuf,j,maxdustsmall)
     if (use_dustgrowth) then
-      dustprop(:,ipart)       = unfill_buf(xbuf,j,2)
-      dustproppred(:,ipart)   = unfill_buf(xbuf,j,2)
+       dustprop(:,ipart)       = unfill_buf(xbuf,j,2)
+       dustproppred(:,ipart)   = unfill_buf(xbuf,j,2)
     endif
  endif
  if (maxp_h2==maxp .or. maxp_krome==maxp) then

--- a/src/tests/test_gravity.F90
+++ b/src/tests/test_gravity.F90
@@ -14,8 +14,9 @@ module testgravity
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: deriv, dim, directsum, energies, eos, io, kdtree, options,
-!   part, physcon, ptmass, spherical, testutils, timing
+! :Dependencies: balance, deriv, dim, directsum, energies, eos, io, kdtree,
+!   linklist, mpiutils, options, part, physcon, ptmass, sort_particles,
+!   spherical, testutils, timing
 !
  use io, only:id,master
  implicit none
@@ -232,28 +233,37 @@ end subroutine test_taylorseries
 !+
 !-----------------------------------------------------------------------
 subroutine test_directsum(ntests,npass)
- use dim,       only:maxp,maxptmass
- use part,      only:init_part,npart,npartoftype,massoftype,xyzh,hfact,vxyzu,fxyzu, &
-                     gradh,poten,iphase,isetphase,maxphase,labeltype,&
-                     nptmass,xyzmh_ptmass,fxyz_ptmass
- use eos,       only:polyk,gamma
- use options,   only:ieos,alpha,alphau,alphaB,tolh
- use spherical, only:set_sphere
- use deriv,     only:get_derivs_global
- use physcon,   only:pi
- use timing,    only:getused,printused
- use directsum, only:directsum_grav
- use energies,  only:compute_energies,epot
- use kdtree,    only:tree_accuracy
- use testutils, only:checkval,checkvalbuf_end,update_test_scores
- use ptmass,    only:get_accel_sink_sink,get_accel_sink_gas,h_soft_sinksink
+ use io,              only:id,master
+ use dim,             only:maxp,maxptmass
+ use part,            only:init_part,npart,npartoftype,massoftype,xyzh,hfact,vxyzu,fxyzu, &
+                           gradh,poten,iphase,isetphase,maxphase,labeltype,&
+                           nptmass,xyzmh_ptmass,fxyz_ptmass,ibelong
+ use eos,             only:polyk,gamma
+ use options,         only:ieos,alpha,alphau,alphaB,tolh
+ use spherical,       only:set_sphere
+ use deriv,           only:get_derivs_global
+ use physcon,         only:pi
+ use timing,          only:getused,printused
+ use directsum,       only:directsum_grav
+ use energies,        only:compute_energies,epot
+ use kdtree,          only:tree_accuracy
+ use testutils,       only:checkval,checkvalbuf_end,update_test_scores
+ use ptmass,          only:get_accel_sink_sink,get_accel_sink_gas,h_soft_sinksink
+ use mpiutils,        only:reduceall_mpi,bcast_mpi
+ use linklist,        only:set_linklist
+ use sort_particles,  only:sort_part_id
+#ifdef MPI
+ use balance,         only:balancedomains
+#endif
+
  integer, intent(inout) :: ntests,npass
  integer :: nfailed(18)
- integer :: maxvxyzu,nx,np,i,k,merge_n,merge_ij(maxptmass)
+ integer :: maxvxyzu,nx,np,i,k,merge_n,merge_ij(maxptmass),nfgrav
  real :: psep,totvol,totmass,rhozero,tol,pmassi
  real :: time,rmin,rmax,phitot,dtsinksink,fonrmax,phii,epot_gas_sink
  real(kind=4) :: t1,t2
  real :: epoti,tree_acc_prev
+ real, allocatable :: fgrav(:,:),fxyz_ptmass_gas(:,:)
 
  tree_acc_prev = tree_accuracy
  do k = 1,6
@@ -278,22 +288,22 @@ subroutine test_directsum(ntests,npass)
        totvol   = 4./3.*pi*rmax**3
        nx       = int(np**(1./3.))
        psep     = totvol**(1./3.)/real(nx)
-       !print*,' got psep = ',nx,psep
        psep     = 0.18
        npart    = 0
-       call set_sphere('cubic',id,master,rmin,rmax,psep,hfact,npart,xyzh)
-       !print*,' using npart = ',npart
+       ! only set up particles on master, otherwise we will end up with n duplicates
+       if (id==master) then
+          call set_sphere('cubic',id,master,rmin,rmax,psep,hfact,npart,xyzh)
+       endif
        np       = npart
-       !iverbose = 5
 !
 !--set particle properties
 !
        totmass        = 1.
        rhozero        = totmass/totvol
        npartoftype(:) = 0
-       npartoftype(k) = npart
+       npartoftype(k) = int(reduceall_mpi('+',npart),kind=kind(npartoftype))
        massoftype(:)  = 0.0
-       massoftype(k)  = totmass/npart
+       massoftype(k)  = totmass/npartoftype(k)
        if (maxphase==maxp) then
           do i=1,npart
              iphase(i) = isetphase(k,iactive=.true.)
@@ -311,6 +321,39 @@ subroutine test_directsum(ntests,npass)
        alphau = 0.
        alphaB = 0.
        tolh = 1.e-5
+
+       fxyzu = 0.0
+!
+!--call derivs to get everything initialised
+!
+       call get_derivs_global()
+!
+!--reset force to zero
+!
+       fxyzu = 0.0
+!
+!--move particles to master and sort for direct summation
+!
+#ifdef MPI
+       ibelong(:) = 0
+       call balancedomains(npart)
+#endif
+       call sort_part_id
+!
+!--allocate array for storing direct sum gravitational force
+!
+       allocate(fgrav(maxvxyzu,npart))
+       fgrav = 0.0
+!
+!--compute gravitational forces by direct summation
+!
+       if (id == master) then
+          call directsum_grav(xyzh,gradh,fgrav,phitot,npart)
+       endif
+!
+!--send phitot to all tasks
+!
+       call bcast_mpi(phitot)
 !
 !--calculate derivatives
 !
@@ -319,62 +362,85 @@ subroutine test_directsum(ntests,npass)
        call getused(t2)
        if (id==master) call printused(t1)
 !
-!--compute gravitational forces by direct summation
+!--move particles to master and sort for test comparison
 !
-       call directsum_grav(xyzh,gradh,vxyzu,phitot,npart)
+#ifdef MPI
+       ibelong(:) = 0
+       call balancedomains(npart)
+#endif
+       call sort_part_id
 !
 !--compare the results
 !
-       call checkval(np,fxyzu(1,:),vxyzu(1,:),5.e-3,nfailed(1),'fgrav(x)')
-       call checkval(np,fxyzu(2,:),vxyzu(2,:),6.e-3,nfailed(2),'fgrav(y)')
-       call checkval(np,fxyzu(3,:),vxyzu(3,:),9.4e-3,nfailed(3),'fgrav(z)')
+       call checkval(npart,fxyzu(1,:),fgrav(1,:),5.e-3,nfailed(1),'fgrav(x)')
+       call checkval(npart,fxyzu(2,:),fgrav(2,:),6.e-3,nfailed(2),'fgrav(y)')
+       call checkval(npart,fxyzu(3,:),fgrav(3,:),9.4e-3,nfailed(3),'fgrav(z)')
+       deallocate(fgrav)
        epoti = 0.
        do i=1,npart
           epoti = epoti + poten(i)
        enddo
-       call checkval(epoti,phitot,5.1e-4,nfailed(4),'potential')
+       epoti = reduceall_mpi('+',epoti)
+       call checkval(epoti,phitot,5.2e-4,nfailed(4),'potential')
        call checkval(epoti,-3./5.*totmass**2/rmax,3.6e-2,nfailed(5),'potential=-3/5 GMM/R')
        ! check that potential energy computed via compute_energies is also correct
        call compute_energies(0.)
-       call checkval(epot,phitot,5.1e-4,nfailed(6),'epot in compute_energies')
+       call checkval(epot,phitot,5.2e-4,nfailed(6),'epot in compute_energies')
        call update_test_scores(ntests,nfailed(1:6),npass)
     endif
  enddo
 
-!
+
 !--test that the same results can be obtained from a cloud of sink particles
 !  with softening lengths equal to the original SPH particle smoothing lengths
 !
  if (maxptmass >= npart) then
     if (id==master) write(*,"(/,3a)") '--> testing gravity in uniform cloud of softened sink particles'
+!
+!--move particles to master for sink creation
+!
+#ifdef MPI
+    ibelong(:) = 0
+    call balancedomains(npart)
+#endif
+!
+!--sort particles so that they can be compared at the end
+!
+    call sort_part_id
 
-    pmassi = totmass/npart
+    pmassi = totmass/reduceall_mpi('+',npart)
     call copy_gas_particles_to_sinks(npart,nptmass,xyzh,xyzmh_ptmass,pmassi)
     h_soft_sinksink = hfact*psep
 !
 !--compute direct sum for comparison, but with fixed h and hence gradh terms switched off
-
+!
     do i=1,npart
        xyzh(4,i)  = h_soft_sinksink
        gradh(1,i) = 1.
        gradh(2,i) = 0.
        vxyzu(:,i) = 0.
     enddo
-    call directsum_grav(xyzh,gradh,vxyzu,phitot,npart)
+    allocate(fgrav(maxvxyzu,npart))
+    fgrav = 0.0
+    call directsum_grav(xyzh,gradh,fgrav,phitot,npart)
+    call bcast_mpi(phitot)
 !
 !--compute gravity on the sink particles
 !
     call get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,epoti,dtsinksink,0,0.,merge_ij,merge_n)
+    call bcast_mpi(epoti)
 !
 !--compare the results
 !
     tol = 1.e-14
-    call checkval(np,fxyz_ptmass(1,:),vxyzu(1,:),tol,nfailed(1),'fgrav(x)')
-    call checkval(np,fxyz_ptmass(2,:),vxyzu(2,:),tol,nfailed(2),'fgrav(y)')
-    call checkval(np,fxyz_ptmass(3,:),vxyzu(3,:),tol,nfailed(3),'fgrav(z)')
+    call checkval(npart,fxyz_ptmass(1,:),fgrav(1,:),tol,nfailed(1),'fgrav(x)')
+    call checkval(npart,fxyz_ptmass(2,:),fgrav(2,:),tol,nfailed(2),'fgrav(y)')
+    call checkval(npart,fxyz_ptmass(3,:),fgrav(3,:),tol,nfailed(3),'fgrav(z)')
     call checkval(epoti,phitot,8e-3,nfailed(4),'potential')
     call checkval(epoti,-3./5.*totmass**2/rmax,4.1e-2,nfailed(5),'potential=-3/5 GMM/R')
     call update_test_scores(ntests,nfailed(1:5),npass)
+
+
 !
 !--now perform the same test, but with HALF the cloud made of sink particles
 !  and HALF the cloud made of gas particles. Do not re-evaluate smoothing lengths
@@ -382,38 +448,83 @@ subroutine test_directsum(ntests,npass)
 !
     if (id==master) write(*,"(/,3a)") &
        '--> testing softened gravity in uniform sphere with half sinks and half gas'
+
+!--sort the particles by ID so that the first half will have the same order
+!  even after half the particles have been converted into sinks. This sort is
+!  not really necessary because the order shouldn't have changed since the
+!  last test because derivs hasn't been called since.
+    call sort_part_id
     call copy_half_gas_particles_to_sinks(npart,nptmass,xyzh,xyzmh_ptmass,pmassi)
+
     print*,' Using ',npart,' SPH particles and ',nptmass,' point masses'
     call get_derivs_global()
 
-    epoti = 0.
+    epoti = 0.0
     call get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,epoti,dtsinksink,0,0.,merge_ij,merge_n)
-    epot_gas_sink = 0.
+!
+!--prevent double counting of sink contribution to potential due to MPI
+!
+    if (id /= master) epoti = 0.0
+!
+!--allocate an array for the gas contribution to sink acceleration
+!
+    allocate(fxyz_ptmass_gas(size(fxyz_ptmass,dim=1),nptmass))
+    fxyz_ptmass_gas = 0.0
+
+    epot_gas_sink = 0.0
     do i=1,npart
        call get_accel_sink_gas(nptmass,xyzh(1,i),xyzh(2,i),xyzh(3,i),xyzh(4,i),&
                                xyzmh_ptmass,fxyzu(1,i),fxyzu(2,i),fxyzu(3,i),&
-                               phii,pmassi,fxyz_ptmass,fonrmax,dtsinksink)
+                               phii,pmassi,fxyz_ptmass_gas,fonrmax,dtsinksink)
        epot_gas_sink = epot_gas_sink + pmassi*phii
        epoti = epoti + poten(i)
-!       write(88,*) xyzh(1:3,i),fxyzu(1:3,i)
-!       write(89,*) xyzh(1:3,i),vxyzu(1:3,i)
     enddo
-    call checkval(npart,fxyzu(1,:),vxyzu(1,:),5.e-2,nfailed(1),'fgrav(x)')
-    call checkval(npart,fxyzu(2,:),vxyzu(2,:),6.e-2,nfailed(2),'fgrav(y)')
-    call checkval(npart,fxyzu(3,:),vxyzu(3,:),9.4e-2,nfailed(3),'fgrav(z)')
-    !print*,' particle 370, pos = ',xyzh(1:3,371),' fx = ',vxyzu(1:3,371)
-    !print*,' pos = ',xyzmh_ptmass(1:3,2),' got force = ',fxyz_ptmass(1:3,2)!,vxyzu(1:3,371)
-    call checkval(nptmass,fxyz_ptmass(1,:),vxyzu(1,npart+1:2*npart),2.3e-2,nfailed(4),'fgrav(xsink)')
-    call checkval(nptmass,fxyz_ptmass(2,:),vxyzu(2,npart+1:2*npart),2.9e-2,nfailed(5),'fgrav(ysink)')
-    call checkval(nptmass,fxyz_ptmass(3,:),vxyzu(3,npart+1:2*npart),3.7e-2,nfailed(6),'fgrav(zsink)')
-!    do i=1,nptmass
-!       write(88,*) xyzmh_ptmass(1:3,i),fxyz_ptmass(1:3,i)
-!       write(89,*) xyzmh_ptmass(1:3,i),vxyzu(1:3,npart+i)
-!    enddo
+!
+!--the gas contribution to sink acceleration has to be added afterwards to
+!  prevent double counting the sink contribution when calling reduceall_mpi
+!
+    fxyz_ptmass_gas = reduceall_mpi('+',fxyz_ptmass_gas)
+    fxyz_ptmass = fxyz_ptmass + fxyz_ptmass_gas
+    deallocate(fxyz_ptmass_gas)
+!
+!--sum up potentials across MPI tasks
+!
+    epoti         = reduceall_mpi('+',epoti)
+    epot_gas_sink = reduceall_mpi('+',epot_gas_sink)
+
+!
+!--move particles to master for comparison
+!
+#ifdef MPI
+    ibelong(:) = 0
+    call balancedomains(npart)
+#endif
+    call sort_part_id
+
+    call checkval(npart,fxyzu(1,:),fgrav(1,:),5.e-2,nfailed(1),'fgrav(x)')
+    call checkval(npart,fxyzu(2,:),fgrav(2,:),6.e-2,nfailed(2),'fgrav(y)')
+    call checkval(npart,fxyzu(3,:),fgrav(3,:),9.4e-2,nfailed(3),'fgrav(z)')
+
+!
+!--fgrav doesn't exist on worker tasks, so it needs to be sent from master
+!
+    call bcast_mpi(npart)
+    if (id == master) nfgrav = size(fgrav,dim=2)
+    call bcast_mpi(nfgrav)
+    if (id /= master) then
+       deallocate(fgrav)
+       allocate(fgrav(maxvxyzu,nfgrav))
+    endif
+    call bcast_mpi(fgrav)
+
+    call checkval(nptmass,fxyz_ptmass(1,:),fgrav(1,npart+1:2*npart),2.3e-2,nfailed(4),'fgrav(xsink)')
+    call checkval(nptmass,fxyz_ptmass(2,:),fgrav(2,npart+1:2*npart),2.9e-2,nfailed(5),'fgrav(ysink)')
+    call checkval(nptmass,fxyz_ptmass(3,:),fgrav(3,npart+1:2*npart),3.7e-2,nfailed(6),'fgrav(zsink)')
+
     call checkval(epoti+epot_gas_sink,phitot,8e-3,nfailed(7),'potential')
     call checkval(epoti+epot_gas_sink,-3./5.*totmass**2/rmax,4.1e-2,nfailed(8),'potential=-3/5 GMM/R')
     call update_test_scores(ntests,nfailed(1:8),npass)
-
+    deallocate(fgrav)
  endif
 !
 !--clean up doggie-doos
@@ -444,21 +555,47 @@ subroutine copy_gas_particles_to_sinks(npart,nptmass,xyzh,xyzmh_ptmass,massi)
 end subroutine copy_gas_particles_to_sinks
 
 subroutine copy_half_gas_particles_to_sinks(npart,nptmass,xyzh,xyzmh_ptmass,massi)
+ use io,       only: id,master,fatal
+ use mpiutils, only: bcast_mpi
  integer, intent(inout) :: npart
  integer, intent(out)   :: nptmass
  real, intent(in)  :: xyzh(:,:),massi
  real, intent(out) :: xyzmh_ptmass(:,:)
- integer :: i
+ integer :: i, nparthalf
 
  nptmass = 0
- npart = npart/2
- do i=npart+1,2*npart
-    nptmass = nptmass + 1
-    ! make a sink particle with the position of each SPH particle
-    xyzmh_ptmass(1:3,nptmass) = xyzh(1:3,i)
-    xyzmh_ptmass(4,nptmass)  =  massi ! same mass as SPH particles
-    xyzmh_ptmass(5:,nptmass) = 0.
- enddo
+ nparthalf = npart/2
+
+ call bcast_mpi(nparthalf)
+
+ if (id==master) then
+    ! Assuming all gas particles are already on master,
+    ! create sinks here and send them to other tasks
+
+    ! remove half the particles by changing npart
+    npart = nparthalf
+
+    do i=npart+1,2*npart
+       nptmass = nptmass + 1
+       call bcast_mpi(nptmass)
+       ! make a sink particle with the position of each SPH particle
+       xyzmh_ptmass(1:3,nptmass) = xyzh(1:3,i)
+       xyzmh_ptmass(4,nptmass)  =  massi ! same mass as SPH particles
+       xyzmh_ptmass(5:,nptmass) = 0.
+       call bcast_mpi(xyzmh_ptmass(1:5,nptmass))
+    enddo
+ else
+    ! Assuming there are no gas particles here,
+    ! get sinks from master
+
+    if (npart /= 0) call fatal("copy_half_gas_particles_to_sinks","there are particles on a non-master task")
+
+    ! Get nparthalf from master, but don't change npart from zero
+    do i=nparthalf+1,2*nparthalf
+       call bcast_mpi(nptmass)
+       call bcast_mpi(xyzmh_ptmass(1:5,nptmass))
+    enddo
+ endif
 
 end subroutine copy_half_gas_particles_to_sinks
 


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
Fixes #221

Several bugs squashed:
- Spatial extents of the children of nodes were not synchronised between MPI tasks, causing an incorrect choice of the split axis (`iaxis`), resulting in nodes with a long aspect ratio, reducing accuracy. This also caused the tree to deviate from serial runs.
- Fix double counting of gravitational potential due to the global tree refinement optimisation. The solution is to always count contributions from the global tree, and only count them on the remote tree if that part of the tree has not been included in the global tree.

Testing:
```
make MPI=yes SETUP=testgrav phantomtest
mpirun -n 1 bin/phantomtest gravity
mpirun -n 4 bin/phantomtest gravity
```

Did you run the bots? yes
