### PR TITLE
Use pre-commit framework

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,13 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+-   repo: local
+    hooks:
+    -   id: bots
+        name: Run bots
+        entry: scripts/bots.sh --staged-files-only --apply
+        language: script

--- a/AUTHORS
+++ b/AUTHORS
@@ -29,28 +29,28 @@ Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
 Simon Glover <glover@uni-heidelberg.de>
 Martina Toscani <mtoscani94@gmail.com>
 Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
-Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Simone Ceppi <simo.ceppi@gmail.com>
+Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Christopher Russell <crussell@udel.edu>
-Alessia Franchini <alessia.franchini@unlv.edu>
 Megha Sharma <msha0023@student.monash.edu>
+Alessia Franchini <alessia.franchini@unlv.edu>
 Alex Pettitt <alex@astro1.sci.hokudai.ac.jp>
 Kieran Hirsh <kieran.hirsh1@monash.edu>
 Nicole Rodrigues <nicole.rodrigues@monash.edu>
 Chris Nixon <cjn@leicester.ac.uk>
+Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Nicolas Cuello <cuellonicolas@gmail.com>
 Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
 Orsola De Marco <orsola.demarco@mq.edu.au>
 Zachary Pellow <zpel1@student.monash.edu>
 Joe Fisher <jwfis1@student.monash.edu>
 Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
-Benoit Commercon <benoit.commercon@gmail.com>
 David Trevascus <dtre10@student.monash.edu>
 Cristiano Longarini <cristiano.longarini@unimi.it>
-Alison Young <ayoung@astro.ex.ac.uk>
-Cox, Samuel <sc676@leicester.ac.uk>
+Benoit Commercon <benoit.commercon@gmail.com>
 Steven Rieder <steven@rieder.nl>
-Stéven Toupin <steven.toupin@gmail.com>
-Conrad Chan <8309215+conradtchan@users.noreply.github.com>
-Maxime Lombart <maxime.lombart@ens-lyon.fr>
 Jorge Cuadra <jcuadra@astro.puc.cl>
+Stéven Toupin <steven.toupin@gmail.com>
+Cox, Samuel <sc676@leicester.ac.uk>
+Maxime Lombart <maxime.lombart@ens-lyon.fr>
+Alison Young <ayoung@astro.ex.ac.uk>

--- a/scripts/bots.sh
+++ b/scripts/bots.sh
@@ -15,13 +15,10 @@
 #
 # Written by Daniel Price 2014-
 #
+cd "${0%/*}"
 tmpdir="/tmp/";
 pwd=$PWD;
 phantomdir="$pwd/../";
-if [ ! -s $phantomdir/scripts/$0 ]; then
-   echo "Error: This script needs to be run from the phantom/scripts directory";
-   exit 100;
-fi
 scriptdir="$phantomdir/scripts";
 codedir="../";
 if [ ! -d $codedir ]; then

--- a/scripts/bots.sh
+++ b/scripts/bots.sh
@@ -20,13 +20,13 @@ pwd=$PWD;
 phantomdir="$pwd/../";
 if [ ! -s $phantomdir/scripts/$0 ]; then
    echo "Error: This script needs to be run from the phantom/scripts directory";
-   exit;
+   exit 100;
 fi
 scriptdir="$phantomdir/scripts";
 codedir="../";
 if [ ! -d $codedir ]; then
    echo "Error running bots: $codedir does not exist";
-   exit;
+   exit 100;
 fi
 headerfile="$scriptdir/HEADER-module";
 programfile="$scriptdir/HEADER-program";
@@ -116,6 +116,7 @@ if [[ $doindent == 1 ]]; then
    bots_to_run="${bots_to_run} indent";
 fi
 #bots_to_run='shout';
+modified=0
 for edittype in $bots_to_run; do
     filelist='';
     case $edittype in
@@ -262,6 +263,7 @@ for edittype in $bots_to_run; do
           echo "$msg";
        fi
        echo "Modified files = $filelist";
+       modified=$((modified + 1))
     fi
     if [[ $docommit == 1 ]]; then
        git commit -m "$msg" $filelist;
@@ -282,3 +284,4 @@ else
       echo "No changes";
    fi
 fi
+exit $modified

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,3 +1,0 @@
-#!/bin/bash
-cd scripts
-./bots.sh --staged-files-only --apply


### PR DESCRIPTION
Type of PR: 
modification to existing code

Description:
The current pre-commit hook allows the commit to proceed, even if changes have been made. It also doesn't distinguish between staged and unstaged changes within the same file.

Use pre-commit framework to run the bots script instead of using a manual bash script. When pre-commit is enabled (completely optional), commits are blocked unless they are bot compliant.

Previously, pre-commit was installed by copying scripts/pre-commit into the git hooks directory. Now it is installed using 
```
pre-commit install
```
See https://pre-commit.com

The workflow pre-commit.yml is added, which runs the bots script on push and PRs.

Testing:
- Made a change to fortran code that was not bot compliant
- Attempt commit and verify that the commit is stopped, but files were modified
- Stage new changes and attempt commit, which was successful

Did you run the bots? yes
