### PR TITLE
Parallel build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,90 +53,90 @@ jobs:
           echo "::set-output name=nbatch::1"
         fi
 
-  build:
-    needs: matrix_prep
-    strategy:
-      fail-fast: false
-      matrix:
-        system: ${{ fromJson(needs.matrix_prep.outputs.matrix).include }}
-        batch: ${{ fromJson(needs.matrix_prep.outputs.batch) }}
+  # build:
+  #   needs: matrix_prep
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       system: ${{ fromJson(needs.matrix_prep.outputs.matrix).include }}
+  #       batch: ${{ fromJson(needs.matrix_prep.outputs.batch) }}
 
 
-    name: build (batch ${{ matrix.batch }}/${{ needs.matrix_prep.outputs.nbatch }}, SYSTEM=${{ matrix.system[1] }})
+  #   name: build (batch ${{ matrix.batch }}/${{ needs.matrix_prep.outputs.nbatch }}, SYSTEM=${{ matrix.system[1] }})
 
-    runs-on: ${{ matrix.system[0] }}
+  #   runs-on: ${{ matrix.system[0] }}
 
-    steps:
+  #   steps:
 
-    - name: "Nuke the github workspace before doing anything"
-      run: rm -r ${{ github.workspace }} && mkdir ${{ github.workspace }}
+  #   - name: "Nuke the github workspace before doing anything"
+  #     run: rm -r ${{ github.workspace }} && mkdir ${{ github.workspace }}
 
-    - name: "Clone phantom"
-      uses: actions/checkout@v2
+  #   - name: "Clone phantom"
+  #     uses: actions/checkout@v2
 
-    - name: "Grab a copy of splash source code"
-      uses: actions/checkout@v2
-      with:
-        repository: danieljprice/splash
-        path: splash
+  #   - name: "Grab a copy of splash source code"
+  #     uses: actions/checkout@v2
+  #     with:
+  #       repository: danieljprice/splash
+  #       path: splash
 
-    - name: "Create logs directory"
-      if: github.event_name == 'schedule'
-      run: mkdir logs
+  #   - name: "Create logs directory"
+  #     if: github.event_name == 'schedule'
+  #     run: mkdir logs
 
-    - name: "Grab previous build logs from web server"
-      if: github.event_name == 'schedule'
-      env:
-        WGET: wget --recursive --no-parent --reject "index.html*" --cut-dirs=2 --no-host-directories
-      run: ${WGET} -A '*${{ matrix.system[1] }}.txt' http://${WEB_SERVER}${BUILD_LOG_DIR}/ || true
+  #   - name: "Grab previous build logs from web server"
+  #     if: github.event_name == 'schedule'
+  #     env:
+  #       WGET: wget --recursive --no-parent --reject "index.html*" --cut-dirs=2 --no-host-directories
+  #     run: ${WGET} -A '*${{ matrix.system[1] }}.txt' http://${WEB_SERVER}${BUILD_LOG_DIR}/ || true
 
-    - name: "Run buildbot.sh"
-      run: ./buildbot.sh --maxdim 17000000 --url http://${WEB_SERVER}/${BUILD_LOG_DIR} --parallel ${{ matrix.batch }} ${{ env.NPARALLEL }}
-      working-directory: scripts
-      env:
-        SYSTEM: ${{ matrix.system[1] }}
-        RETURN_ERR: yes
+  #   - name: "Run buildbot.sh"
+  #     run: ./buildbot.sh --maxdim 17000000 --url http://${WEB_SERVER}/${BUILD_LOG_DIR} --parallel ${{ matrix.batch }} ${{ env.NPARALLEL }}
+  #     working-directory: scripts
+  #     env:
+  #       SYSTEM: ${{ matrix.system[1] }}
+  #       RETURN_ERR: yes
 
-    - name: "Install SSH Key"
-      if: github.event_name == 'schedule'
-      uses: webfactory/ssh-agent@v0.5.3
-      with:
-        ssh-private-key: ${{ secrets.RUNNER_PRIVATE_KEY }}
+  #   - name: "Install SSH Key"
+  #     if: github.event_name == 'schedule'
+  #     uses: webfactory/ssh-agent@v0.5.3
+  #     with:
+  #       ssh-private-key: ${{ secrets.RUNNER_PRIVATE_KEY }}
 
-    - name: "Copy new build logs to web server"
-      if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
-      run: rsync -vau logs/*.txt ${WEB_USER}@${WEB_SERVER}:${WEB_HTML_DIR}/${BUILD_LOG_DIR}
+  #   - name: "Copy new build logs to web server"
+  #     if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
+  #     run: rsync -vau logs/*.txt ${WEB_USER}@${WEB_SERVER}:${WEB_HTML_DIR}/${BUILD_LOG_DIR}
 
-    - name: "Copy HTML files to web server"
-      if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
-      run: |
-        export WEB_BUILD_DIR=${WEB_HTML_DIR}/nightly/build/$(date "+%Y%m%d")
-        ssh -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" ${WEB_USER}@${WEB_SERVER} -- mkdir -p ${WEB_BUILD_DIR}
-        rsync -vau logs/*.html ${WEB_USER}@${WEB_SERVER}:${WEB_BUILD_DIR}/
+  #   - name: "Copy HTML files to web server"
+  #     if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
+  #     run: |
+  #       export WEB_BUILD_DIR=${WEB_HTML_DIR}/nightly/build/$(date "+%Y%m%d")
+  #       ssh -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" ${WEB_USER}@${WEB_SERVER} -- mkdir -p ${WEB_BUILD_DIR}
+  #       rsync -vau logs/*.html ${WEB_USER}@${WEB_SERVER}:${WEB_BUILD_DIR}/
 
-    - name: logs/build-failures-${{ matrix.system[1] }}.txt
-      if: always()
-      run: cat logs/build-failures-${{ matrix.system[1] }}.txt || true
+  #   - name: logs/build-failures-${{ matrix.system[1] }}.txt
+  #     if: always()
+  #     run: cat logs/build-failures-${{ matrix.system[1] }}.txt || true
 
-    - name: logs/setup-failures-${{ matrix.system[1] }}.txt
-      if: always()
-      run: cat logs/setup-failures-${{ matrix.system[1] }}.txt || true
+  #   - name: logs/setup-failures-${{ matrix.system[1] }}.txt
+  #     if: always()
+  #     run: cat logs/setup-failures-${{ matrix.system[1] }}.txt || true
 
-    - name: logs/make-*-${{ matrix.system[1] }}.txt
-      if: always()
-      run: |
-        echo
-        for item in $(ls logs/make-*-${{ matrix.system[1] }}.txt); do
-          echo ::group::"${item}"
-          cat $item
-          echo ::endgroup::
-        done
+  #   - name: logs/make-*-${{ matrix.system[1] }}.txt
+  #     if: always()
+  #     run: |
+  #       echo
+  #       for item in $(ls logs/make-*-${{ matrix.system[1] }}.txt); do
+  #         echo ::group::"${item}"
+  #         cat $item
+  #         echo ::endgroup::
+  #       done
 
   # Gather results into a dummy job that will fail if the previous job fails
   gather_results:
     if: always()
-    needs:
-    - build
+    # needs:
+    # - build
 
     # This name matches the branch protection requirement
     name: build
@@ -145,11 +145,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Check all builds succeeded
-      run: |
-        if [[ "${{ needs.build.result }}" == "success" ]]; then
-          echo "All build succeeded"
-        else
-          echo "At least one build failed"
-          exit 1
-        fi
+    - run: echo "ok"
+    # - name: Check all builds succeeded
+    #   run: |
+    #     if [[ "${{ needs.build.result }}" == "success" ]]; then
+    #       echo "All build succeeded"
+    #     else
+    #       echo "At least one build failed"
+    #       exit 1
+    #     fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: build
 
 on:
   push:
-    branches: [ master ]
     paths-ignore:
       - 'docs/**'
       - 'README.md'
@@ -23,6 +22,7 @@ env:
   WEB_HTML_DIR: /var/www/html
   BUILD_LOG_DIR: /ci/build/logs
   RSYNC_RSH: ssh -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null"
+  NPARALLEL: 10
 
 jobs:
   matrix_prep:
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      batch: ${{ steps.set-sequence.outputs.batch }}
+      nbatch: ${{ steps.set-sequence.outputs.nbatch }}
     steps:
     - name: Check out repo
       uses: actions/checkout@v2
@@ -38,6 +40,17 @@ jobs:
       with:
         inputFile: '.github/workflows/matrix_system.json'
         filter: '["${{ github.repository }}", "always"]'
+    - name: Generate sequence of batch numbers for normal tests, or run sequentially for scheduled tests
+      id: set-sequence
+      run: |
+        if [[ ${{ github.event_name == 'schedule' }} ]]; then
+          range=$(jq -ncR "[range(1;${NPARALLEL}+1)]")
+          echo "::set-output name=batch::${range}"
+          echo "::set-output name=nbatch::${NPARALLEL}"
+        else
+          echo "::set-output name=batch::[1]"
+          echo "::set-output name=nbatch::1"
+        fi
 
   build:
     needs: matrix_prep
@@ -45,8 +58,10 @@ jobs:
       fail-fast: false
       matrix:
         system: ${{ fromJson(needs.matrix_prep.outputs.matrix).include }}
+        batch: ${{ fromJson(needs.matrix_prep.outputs.batch) }}
 
-    name: build (SYSTEM=${{ matrix.system[1] }})
+
+    name: build (batch ${{ matrix.batch }}/${{ needs.matrix_prep.outputs.nbatch }}, SYSTEM=${{ matrix.system[1] }})
 
     runs-on: ${{ matrix.system[0] }}
 
@@ -73,7 +88,7 @@ jobs:
       run: ${WGET} -A '*${{ matrix.system[1] }}.txt' http://${WEB_SERVER}${BUILD_LOG_DIR}/ || true
 
     - name: "Run buildbot.sh"
-      run: ./buildbot.sh 17000000 http://${WEB_SERVER}/${BUILD_LOG_DIR}
+      run: ./buildbot.sh --maxdim 17000000 --url http://${WEB_SERVER}/${BUILD_LOG_DIR} --parallel ${{ matrix.batch }} ${{ env.NPARALLEL }}
       working-directory: scripts
       env:
         SYSTEM: ${{ matrix.system[1] }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,12 +97,6 @@ jobs:
         SYSTEM: ${{ matrix.system[1] }}
         RETURN_ERR: yes
 
-    - name: Update label temporarily for status checking
-      uses: actions-ecosystem/action-add-labels@v1
-      if: failure()
-      with:
-        labels: build-fail-${{ matrix.system[1] }})
-
     - name: "Install SSH Key"
       if: github.event_name == 'schedule'
       uses: webfactory/ssh-agent@v0.5.3
@@ -138,33 +132,24 @@ jobs:
           echo ::endgroup::
         done
 
-# Gather results using this hack since github actions can't get status of
-# a subset of a matrix:
-# https://github.community/t/status-check-for-a-matrix-jobs/127354/12
+  # Gather results into a dummy job that will fail if the previous job fails
   gather_results:
     if: always()
     needs:
-    - matrix_prep
     - build
-    strategy:
-      fail-fast: false
-      matrix:
-        system: ${{ fromJson(needs.matrix_prep.outputs.matrix).include }}
 
     # This name matches the branch protection requirement
-    name: build (SYSTEM=${{ matrix.system[1] }})
+    name: build
 
     # Always run on github runner; no need to use custom runner for the check
     runs-on: ubuntu-latest
 
     steps:
-      - uses: mheap/github-action-required-labels@v1
-        with:
-          mode: exactly
-          count: 0
-          labels: build-fail-${{ matrix.system[1] }})
-      - name: Clean up labels
-        uses: actions-ecosystem/action-remove-labels@v1
-        if: always()
-        with:
-          labels: build-fail-${{ matrix.system[1] }})
+    - name: Check all builds succeeded
+      run: |
+        if [[ "${{ needs.build.result }}" == "success" ]]; then
+          echo "All build succeeded"
+        else
+          echo "At least one build failed"
+          exit 1
+        fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,7 @@ jobs:
         path: splash
 
     - name: "Create logs directory"
+      if: github.event_name == 'schedule'
       run: mkdir logs
 
     - name: "Grab previous build logs from web server"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Check all builds succeeded
+    - name: Check all builds
       run: |
         if [[ "${{ needs.build.result }}" == "success" ]]; then
           echo "All build succeeded"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,7 @@ jobs:
       run: mkdir logs
 
     - name: "Grab previous build logs from web server"
+      if: github.event_name == 'schedule'
       env:
         WGET: wget --recursive --no-parent --reject "index.html*" --cut-dirs=2 --no-host-directories
       run: ${WGET} -A '*${{ matrix.system[1] }}.txt' http://${WEB_SERVER}${BUILD_LOG_DIR}/ || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,12 @@ jobs:
         SYSTEM: ${{ matrix.system[1] }}
         RETURN_ERR: yes
 
+    - name: Update label temporarily for status checking
+      uses: actions-ecosystem/action-add-labels@v1
+      if: failure()
+      with:
+        labels: build-fail-${{ matrix.system[1] }})
+
     - name: "Install SSH Key"
       if: github.event_name == 'schedule'
       uses: webfactory/ssh-agent@v0.5.3
@@ -131,3 +137,26 @@ jobs:
           cat $item
           echo ::endgroup::
         done
+
+# Gather results (https://github.community/t/status-check-for-a-matrix-jobs/127354/12)
+  gather_results:
+    if: always()
+    needs:
+    - matrix_prep
+    - build
+    strategy:
+      fail-fast: false
+      matrix:
+        system: ${{ fromJson(needs.matrix_prep.outputs.matrix).include }}
+
+    name: build (SYSTEM=${{ matrix.system[1] }})
+
+    # Always run on github runner; no need to use custom runner for the check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: exactly
+          count: 0
+          labels: build-fail-${{ matrix.system[1] }})

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ env:
   WEB_HTML_DIR: /var/www/html
   BUILD_LOG_DIR: /ci/build/logs
   RSYNC_RSH: ssh -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null"
-  NPARALLEL: 10
+  NPARALLEL: 32
 
 jobs:
   matrix_prep:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,90 +53,90 @@ jobs:
           echo "::set-output name=nbatch::1"
         fi
 
-  # build:
-  #   needs: matrix_prep
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       system: ${{ fromJson(needs.matrix_prep.outputs.matrix).include }}
-  #       batch: ${{ fromJson(needs.matrix_prep.outputs.batch) }}
+  build:
+    needs: matrix_prep
+    strategy:
+      fail-fast: false
+      matrix:
+        system: ${{ fromJson(needs.matrix_prep.outputs.matrix).include }}
+        batch: ${{ fromJson(needs.matrix_prep.outputs.batch) }}
 
 
-  #   name: build (batch ${{ matrix.batch }}/${{ needs.matrix_prep.outputs.nbatch }}, SYSTEM=${{ matrix.system[1] }})
+    name: build (batch ${{ matrix.batch }}/${{ needs.matrix_prep.outputs.nbatch }}, SYSTEM=${{ matrix.system[1] }})
 
-  #   runs-on: ${{ matrix.system[0] }}
+    runs-on: ${{ matrix.system[0] }}
 
-  #   steps:
+    steps:
 
-  #   - name: "Nuke the github workspace before doing anything"
-  #     run: rm -r ${{ github.workspace }} && mkdir ${{ github.workspace }}
+    - name: "Nuke the github workspace before doing anything"
+      run: rm -r ${{ github.workspace }} && mkdir ${{ github.workspace }}
 
-  #   - name: "Clone phantom"
-  #     uses: actions/checkout@v2
+    - name: "Clone phantom"
+      uses: actions/checkout@v2
 
-  #   - name: "Grab a copy of splash source code"
-  #     uses: actions/checkout@v2
-  #     with:
-  #       repository: danieljprice/splash
-  #       path: splash
+    - name: "Grab a copy of splash source code"
+      uses: actions/checkout@v2
+      with:
+        repository: danieljprice/splash
+        path: splash
 
-  #   - name: "Create logs directory"
-  #     if: github.event_name == 'schedule'
-  #     run: mkdir logs
+    - name: "Create logs directory"
+      if: github.event_name == 'schedule'
+      run: mkdir logs
 
-  #   - name: "Grab previous build logs from web server"
-  #     if: github.event_name == 'schedule'
-  #     env:
-  #       WGET: wget --recursive --no-parent --reject "index.html*" --cut-dirs=2 --no-host-directories
-  #     run: ${WGET} -A '*${{ matrix.system[1] }}.txt' http://${WEB_SERVER}${BUILD_LOG_DIR}/ || true
+    - name: "Grab previous build logs from web server"
+      if: github.event_name == 'schedule'
+      env:
+        WGET: wget --recursive --no-parent --reject "index.html*" --cut-dirs=2 --no-host-directories
+      run: ${WGET} -A '*${{ matrix.system[1] }}.txt' http://${WEB_SERVER}${BUILD_LOG_DIR}/ || true
 
-  #   - name: "Run buildbot.sh"
-  #     run: ./buildbot.sh --maxdim 17000000 --url http://${WEB_SERVER}/${BUILD_LOG_DIR} --parallel ${{ matrix.batch }} ${{ env.NPARALLEL }}
-  #     working-directory: scripts
-  #     env:
-  #       SYSTEM: ${{ matrix.system[1] }}
-  #       RETURN_ERR: yes
+    - name: "Run buildbot.sh"
+      run: ./buildbot.sh --maxdim 17000000 --url http://${WEB_SERVER}/${BUILD_LOG_DIR} --parallel ${{ matrix.batch }} ${{ env.NPARALLEL }}
+      working-directory: scripts
+      env:
+        SYSTEM: ${{ matrix.system[1] }}
+        RETURN_ERR: yes
 
-  #   - name: "Install SSH Key"
-  #     if: github.event_name == 'schedule'
-  #     uses: webfactory/ssh-agent@v0.5.3
-  #     with:
-  #       ssh-private-key: ${{ secrets.RUNNER_PRIVATE_KEY }}
+    - name: "Install SSH Key"
+      if: github.event_name == 'schedule'
+      uses: webfactory/ssh-agent@v0.5.3
+      with:
+        ssh-private-key: ${{ secrets.RUNNER_PRIVATE_KEY }}
 
-  #   - name: "Copy new build logs to web server"
-  #     if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
-  #     run: rsync -vau logs/*.txt ${WEB_USER}@${WEB_SERVER}:${WEB_HTML_DIR}/${BUILD_LOG_DIR}
+    - name: "Copy new build logs to web server"
+      if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
+      run: rsync -vau logs/*.txt ${WEB_USER}@${WEB_SERVER}:${WEB_HTML_DIR}/${BUILD_LOG_DIR}
 
-  #   - name: "Copy HTML files to web server"
-  #     if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
-  #     run: |
-  #       export WEB_BUILD_DIR=${WEB_HTML_DIR}/nightly/build/$(date "+%Y%m%d")
-  #       ssh -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" ${WEB_USER}@${WEB_SERVER} -- mkdir -p ${WEB_BUILD_DIR}
-  #       rsync -vau logs/*.html ${WEB_USER}@${WEB_SERVER}:${WEB_BUILD_DIR}/
+    - name: "Copy HTML files to web server"
+      if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
+      run: |
+        export WEB_BUILD_DIR=${WEB_HTML_DIR}/nightly/build/$(date "+%Y%m%d")
+        ssh -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" ${WEB_USER}@${WEB_SERVER} -- mkdir -p ${WEB_BUILD_DIR}
+        rsync -vau logs/*.html ${WEB_USER}@${WEB_SERVER}:${WEB_BUILD_DIR}/
 
-  #   - name: logs/build-failures-${{ matrix.system[1] }}.txt
-  #     if: always()
-  #     run: cat logs/build-failures-${{ matrix.system[1] }}.txt || true
+    - name: logs/build-failures-${{ matrix.system[1] }}.txt
+      if: always()
+      run: cat logs/build-failures-${{ matrix.system[1] }}.txt || true
 
-  #   - name: logs/setup-failures-${{ matrix.system[1] }}.txt
-  #     if: always()
-  #     run: cat logs/setup-failures-${{ matrix.system[1] }}.txt || true
+    - name: logs/setup-failures-${{ matrix.system[1] }}.txt
+      if: always()
+      run: cat logs/setup-failures-${{ matrix.system[1] }}.txt || true
 
-  #   - name: logs/make-*-${{ matrix.system[1] }}.txt
-  #     if: always()
-  #     run: |
-  #       echo
-  #       for item in $(ls logs/make-*-${{ matrix.system[1] }}.txt); do
-  #         echo ::group::"${item}"
-  #         cat $item
-  #         echo ::endgroup::
-  #       done
+    - name: logs/make-*-${{ matrix.system[1] }}.txt
+      if: always()
+      run: |
+        echo
+        for item in $(ls logs/make-*-${{ matrix.system[1] }}.txt); do
+          echo ::group::"${item}"
+          cat $item
+          echo ::endgroup::
+        done
 
   # Gather results into a dummy job that will fail if the previous job fails
   gather_results:
     if: always()
-    # needs:
-    # - build
+    needs:
+    - build
 
     # This name matches the branch protection requirement
     name: build
@@ -145,12 +145,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - run: echo "ok"
-    # - name: Check all builds succeeded
-    #   run: |
-    #     if [[ "${{ needs.build.result }}" == "success" ]]; then
-    #       echo "All build succeeded"
-    #     else
-    #       echo "At least one build failed"
-    #       exit 1
-    #     fi
+    - name: Check all builds succeeded
+      run: |
+        if [[ "${{ needs.build.result }}" == "success" ]]; then
+          echo "All build succeeded"
+        else
+          echo "At least one build failed"
+          exit 1
+        fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: build
 
 on:
   push:
+    branches: [ master ]
     paths-ignore:
       - 'docs/**'
       - 'README.md'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,9 @@ jobs:
           echo ::endgroup::
         done
 
-# Gather results (https://github.community/t/status-check-for-a-matrix-jobs/127354/12)
+# Gather results using this hack since github actions can't get status of
+# a subset of a matrix:
+# https://github.community/t/status-check-for-a-matrix-jobs/127354/12
   gather_results:
     if: always()
     needs:
@@ -149,6 +151,7 @@ jobs:
       matrix:
         system: ${{ fromJson(needs.matrix_prep.outputs.matrix).include }}
 
+    # This name matches the branch protection requirement
     name: build (SYSTEM=${{ matrix.system[1] }})
 
     # Always run on github runner; no need to use custom runner for the check
@@ -159,4 +162,9 @@ jobs:
         with:
           mode: exactly
           count: 0
+          labels: build-fail-${{ matrix.system[1] }})
+      - name: Clean up labels
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: always()
+        with:
           labels: build-fail-${{ matrix.system[1] }})

--- a/.github/workflows/mpi.yml
+++ b/.github/workflows/mpi.yml
@@ -42,3 +42,24 @@ jobs:
 
     - name: Test with MPI
       run: mpirun --allow-run-as-root -np 2 ./bin/phantomtest
+
+  # Gather results into a dummy job that will fail if the previous job fails
+  gather_results:
+    if: always()
+    needs:
+    - test
+
+    # This name matches the branch protection requirement
+    name: mpi
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check all builds succeeded
+      run: |
+        if [[ "${{ needs.test.result }}" == "success" ]]; then
+          echo "All tests succeeded"
+        else
+          echo "At least one test failed"
+          exit 1
+        fi

--- a/.github/workflows/mpi.yml
+++ b/.github/workflows/mpi.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Check all builds succeeded
+    - name: Check all tests
       run: |
         if [[ "${{ needs.test.result }}" == "success" ]]; then
           echo "All tests succeeded"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Check all builds succeeded
+    - name: Check all tests
       run: |
         if [[ "${{ needs.test.result }}" == "success" ]]; then
           echo "All tests succeeded"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,3 +72,24 @@ jobs:
 
     - name: "Run phantom tests"
       run: ./bin/phantomtest ${{ matrix.input[1] }}
+
+  # Gather results into a dummy job that will fail if the previous job fails
+  gather_results:
+    if: always()
+    needs:
+    - test
+
+    # This name matches the branch protection requirement
+    name: test
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check all builds succeeded
+      run: |
+        if [[ "${{ needs.test.result }}" == "success" ]]; then
+          echo "All tests succeeded"
+        else
+          echo "At least one test failed"
+          exit 1
+        fi


### PR DESCRIPTION
Type of PR: 
other

Description:
The build check action makes each configuration sequentially. Currently there are 93 setups, so this takes about 3 hours to finish. This test slows down development pace because developers must wait a long time for checks on pull requests.

While waiting for build checks on my other PRs to finish, I parallelised the build action 😄

The maximum github action matrix size is 128. The tests cannot be run individually because all 93 tests have to be run for each compiler, >128. buildbot.sh has been modified to run setups in batches. It takes the argument
```
./buildbot.sh --parallel i j
```
where `j` is the number of batches to split the setups into, and the `i`'th batch is run. For example, `--parallel 2 10` will split the setups into 10 batches, and run the 2nd one. To run all the setups, the command must be called `j` times, for `i=1` to `i=j`. This is split across github runners.

`j` is set to 32. Using the github runner (for gfortran compiler), the entire build test runs in ~12 minutes, which is ~15x faster. The ifort compiler will be bottlenecked by the number of available custom runners.

A summary job is added to the end of all workflows with a matrix so that the branch protection requirement does not need to be changed when the matrix changes. The requirements `build`, `mpi`, `test` will now cover all tests. Resolves #226 

Testing:
build test continues to run all setups

Did you run the bots? no - not required
