### PR TITLE
Cooling, timing, & misc

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,28 +29,28 @@ Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
 Simon Glover <glover@uni-heidelberg.de>
 Martina Toscani <mtoscani94@gmail.com>
 Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
-Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Simone Ceppi <simo.ceppi@gmail.com>
+Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Christopher Russell <crussell@udel.edu>
-Alessia Franchini <alessia.franchini@unlv.edu>
 Megha Sharma <msha0023@student.monash.edu>
+Alessia Franchini <alessia.franchini@unlv.edu>
 Alex Pettitt <alex@astro1.sci.hokudai.ac.jp>
 Kieran Hirsh <kieran.hirsh1@monash.edu>
 Nicole Rodrigues <nicole.rodrigues@monash.edu>
 Chris Nixon <cjn@leicester.ac.uk>
+Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Nicolas Cuello <cuellonicolas@gmail.com>
 Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
 Orsola De Marco <orsola.demarco@mq.edu.au>
 Zachary Pellow <zpel1@student.monash.edu>
 Joe Fisher <jwfis1@student.monash.edu>
 Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
-Benoit Commercon <benoit.commercon@gmail.com>
 David Trevascus <dtre10@student.monash.edu>
 Cristiano Longarini <cristiano.longarini@unimi.it>
-Alison Young <ayoung@astro.ex.ac.uk>
-Cox, Samuel <sc676@leicester.ac.uk>
+Benoit Commercon <benoit.commercon@gmail.com>
 Steven Rieder <steven@rieder.nl>
-Stéven Toupin <steven.toupin@gmail.com>
-Conrad Chan <8309215+conradtchan@users.noreply.github.com>
-Maxime Lombart <maxime.lombart@ens-lyon.fr>
 Jorge Cuadra <jcuadra@astro.puc.cl>
+Stéven Toupin <steven.toupin@gmail.com>
+Cox, Samuel <sc676@leicester.ac.uk>
+Maxime Lombart <maxime.lombart@ens-lyon.fr>
+Alison Young <ayoung@astro.ex.ac.uk>

--- a/src/main/cooling.F90
+++ b/src/main/cooling.F90
@@ -33,7 +33,7 @@ module cooling
 !   - dust_collision : *dust collision [1=on/0=off]*
 !   - excitation_HI  : *cooling via electron excitation of HI [1=on/0=off]*
 !   - habund         : *Hydrogen abundance assumed in cooling function*
-!   - icooling       : *cooling function (0=off, 1=explicit, 2=Townsend table, 3=Gammie, 5=KI02)*
+!   - icooling       : *cooling function (0=off, 1=explicit, 2=Townsend table, 3=Gammie, 5,6=KI02)*
 !   - relax_bowen    : *Bowen (diffusive) relaxation [1=on/0=off]*
 !   - relax_stefan   : *radiative relaxation [1=on/0=off]*
 !   - temp_floor     : *Minimum allowed temperature in K for Townsend cooling table*

--- a/src/main/cooling.F90
+++ b/src/main/cooling.F90
@@ -14,7 +14,7 @@ module cooling
 !     2 = Townsend (2009) cooling tables [implicitly calculated]
 !     3 = Gammie cooling [explicitly calculated]
 !     5 = Koyama & Inutuska (2002) [explicitly calculated]
-!     6 = Koyama & Inutuska (2002) [implicitly calculated][not yet implemented; JHW]
+!     6 = Koyama & Inutuska (2002) [implicitly calculated]
 !
 ! :References:
 !   Koyama & Inutsuka (2002), ApJL 564, 97-100
@@ -55,19 +55,24 @@ module cooling
  logical, public :: cooling_implicit
  logical, public :: cooling_explicit
  real,    public :: bowen_Cprime = 3.000d-5
+ real,    public :: GammaKI_cgs = 2.d-26 ! [erg/s] heating rate for Koyama & Inutuska cooling
 
  private
  integer, parameter :: nTg = 64
  integer, parameter :: maxt = 1000
  real,    parameter :: Tref = 1.d5, T_floor = 10.   ! required for exact_cooling
  integer :: nt
- real    :: temper(maxt),lambda(maxt),slope(maxt),yfunc(maxt)
+ real    :: temper(maxt),lambda(maxt),slope(maxt),yfunc(maxt),rhov4_KI02(2,maxt)
  real    :: beta_cool  = 3.
  real    :: habund     = 0.7
  real    :: temp_floor = 1.e4                       ! required for exact_cooling_table
  real    :: Tgrid(nTg)
- real    :: crate_coef
+ real    :: LambdaKI_coef,GammaKI
+ real    :: KI02_rho_min_cgs = 1.0d-30  ! minimum density of the KI02 cooling curve
+ real    :: KI02_rho_max_cgs = 1.0d-14  ! maximum density of the KI02 cooling curve
+ real    :: KI02_rho_min,KI02_rho_max
  integer :: excitation_HI = 0, relax_Bowen = 0, dust_collision = 0, relax_Stefan = 0
+ integer :: icool_radiation_H0 = 0, icool_relax_Bowen = 0, icool_dust_collision = 0, icool_relax_Stefan = 0
  character(len=120) :: cooltable = 'cooltable.dat'
  !--Minimum temperature (failsafe to prevent u < 0); optional for ALL cooling options
  real,    public :: Tfloor = 0. ! [K]; set in .in file.  On if Tfloor > 0.
@@ -122,8 +127,11 @@ subroutine init_cooling(id,master,iprint,ierr)
     !--initialise remaining variables
     if (icooling == 2) then
        call init_cooltable(ierr)
-    elseif (icooling == 5) then
-       crate_coef = 2.0d-26*umass*utime**3/(mass_proton_cgs**2 * udist**5)
+    elseif (icooling == 5 .or. icooling == 6) then
+       LambdaKI_coef = GammaKI_cgs*umass*utime**3/(mass_proton_cgs**2 * udist**5)
+       GammaKI       = GammaKI_cgs*utime**3/(mass_proton_cgs*udist**2)
+       call init_hv4table(ierr)
+       if (ierr > 0) call fatal('init_cooling','Failed to create KI02 cooling table')
     elseif (icooling > 0) then
        call set_Tgrid
     endif
@@ -209,6 +217,71 @@ subroutine init_cooltable(ierr)
  enddo
 end subroutine init_cooltable
 
+!-----------------------------------------------------------------------
+!+
+!  create a h-v4 table based upon the cooling curve of KI02
+!+
+!-----------------------------------------------------------------------
+subroutine init_hv4table(ierr)
+ use part,    only:hrho,igas
+ use physcon, only:mass_proton_cgs,kboltz
+ use units,   only:unit_density,unit_velocity
+ use eos,     only:gmw,gamma
+ integer, intent(out) :: ierr
+ integer              :: i,ctr
+ real                 :: nrho0_min,nrho0_max,nrho,dnrho,dGammaKI,Lambda,dLambda
+ real                 :: T,Tnew,Trat,fatT,faTdT
+ logical              :: iterate
+ logical              :: print_cc = .false. ! Print the cooling curve (for testing)
+
+ !--Initialise densities
+ KI02_rho_min = KI02_rho_min_cgs/unit_density
+ KI02_rho_max = KI02_rho_max_cgs/unit_density
+ nrho0_min    = KI02_rho_min_cgs/mass_proton_cgs
+ nrho0_max    = KI02_rho_max_cgs/mass_proton_cgs
+ dnrho        = (log10(nrho0_max) - log10(nrho0_min))/maxt
+ !--Initialise additional variables
+ dGammaKI     = 0.0
+ ierr         = 0
+
+ if (print_cc) open(unit=1031,file='coolingcurve.dat')
+
+ !--Iterate (in cgs units)!
+ T = 20000.
+ do i = 1,maxt
+    ctr     = 0
+    iterate = .true.
+    nrho    = 10**(log10(nrho0_min) + (i-1)*dnrho)
+    do while ( iterate )
+       Lambda  = 1.d7*exp(-1.184d5/(T+1.d3)) + 0.014*sqrt(T)*exp(-92./T) ! This is actually Lamda / Gamma
+       dLambda = 0.007*exp(-92./T)*(T+184.)*T**(-1.5) + 1.184d12*exp(-1.184d5/(T+1.d3))*(T+1.d3)**(-2)
+       fatT    =  Lambda*GammaKI_cgs*nrho -  GammaKI_cgs
+       faTdT   = dLambda*GammaKI_cgs*nrho - dGammaKI
+       Tnew    = abs(T - fatT/faTdT)
+       Trat    = abs( 1.0 - T/Tnew )
+       T       = Tnew
+       ctr     = ctr + 1
+       !--converged
+       if (Trat < 1.0d-6) iterate = .false.
+       !--failed to converge
+       if (T < 0. .or. ctr > 2000) then
+          iterate = .false.
+          ierr    = 1
+       endif
+    enddo
+    if (print_cc) write(1031,*) nrho,nrho*mass_proton_cgs,T,T*nrho,Lambda*GammaKI_cgs
+    rhov4_KI02(1,i) = nrho
+    rhov4_KI02(2,i) = T
+ enddo
+ if (print_cc) close(1031)
+
+ !--Convert to useful values
+ do i = 1,maxt
+    rhov4_KI02(1,i) = rhov4_KI02(1,i)*mass_proton_cgs/unit_density                               ! number density (cm^-3) -> mass density (code units)
+    rhov4_KI02(2,i) = kboltz*rhov4_KI02(2,i)/(gmw*mass_proton_cgs*(gamma-1.0))/unit_velocity**2  ! T -> internal energy (code units)
+ enddo
+
+end subroutine init_hv4table
 !-----------------------------------------------------------------------
 !
 !  calculate cooling rates
@@ -395,17 +468,85 @@ end subroutine cooling_Gammie
 !+
 !   Cooling rate as per Koyama & Inutuska (2002; eqns 4 & 5);
 !   typos corrected as per Vazquez-Semadeni+ (2007)
+!   This is for the explicit calculation
+!   In equilibrium, n*LambdaKI = (rho/mp)*LambdaKI = GammaKI
 !+
 !-----------------------------------------------------------------------
-subroutine cooling_KoyamaInutuska(rhoi,Tgas,dudti)
+subroutine cooling_KoyamaInutuska_explicit(rhoi,Tgas,dudti)
  real, intent(in)    :: rhoi,Tgas
  real, intent(inout) :: dudti
- real                :: crate
+ real                :: LambdaKI
 
- crate = crate_coef*(1.d7*exp(-118400./(Tgas+1000.))+0.014*sqrt(Tgas)*exp(-92./Tgas))
- dudti = dudti - crate*rhoi
+ ! Derivation to obtain correct units; used Koyama & Inutuska (2002) as the reference
+ !LambdaKI = GammaKI_cgs * (1.d7*exp(-118400./(Tgas+1000))+0.014*sqrt(Tgas)*exp(-92./Tgas)) ! The cooling rate in erg cm^3/s = g cm^5/s^3
+ !LambdaKI = LambdaKI/mass_proton_cgs**2                                                    ! units are now cm^5/(g s^3) ! since [u] = erg/g = cm^2/s^2
+ !LambdaKI = LambdaKI*umass*utime**3/udist**5                                               ! convert to from cm^5/(g s^3) to code units
+ !dudti    = dudti - LambdaKI*rhoi*fac                                                      ! multiply by rho (code) to get l^5/(m t^3) * m/l^3 = l^2/s^3 = [u]
+ !
+ !GammaKI = GammaKI_cgs                                                                     ! The heating rate in erg /s = g cm^2/s^3
+ !GammaKI = GammaKI/mass_proton_cgs                                                         ! divide by proton mass.  Units are now g cm^2 / s^3 / g = cm^2/s^3
+ !GammaKI = GammaKI*utime**3/udist**2                                                       ! convert from cm^2/s^3 to code units
+ !dudti   = dudti + GammaKI                                                                 ! units and dependencies are correct
 
-end subroutine cooling_KoyamaInutuska
+ LambdaKI = LambdaKI_coef*(1.d7*exp(-118400./(Tgas+1000.))+0.014*sqrt(Tgas)*exp(-92./Tgas))
+ dudti    = dudti - LambdaKI*rhoi + GammaKI
+
+end subroutine cooling_KoyamaInutuska_explicit
+
+!-----------------------------------------------------------------------
+!+
+!   Cooling rate as per Koyama & Inutuska (2002; eqns 4 & 5);
+!   typos corrected as per Vazquez-Semadeni+ (2007)
+!   This is the implicit method given by (5)-(6) in Vazquez-Semadeni+ (2007)
+!+
+!-----------------------------------------------------------------------
+subroutine cooling_KoyamaInutuska_implicit(eni,rhoi,dt,dudti)
+ use eos, only: gamma,temperature_coef,gmw
+ real, intent(in)    :: rhoi,eni,dt
+ real, intent(out)   :: dudti
+ integer             :: i,j,jm1
+ real                :: ponrhoi,tempi,eni_equil,eni_final,deni,tau1,LambdaKI
+
+ !--Determine the indicies surrounding the input h
+ i = minloc(abs(rhov4_KI02(1,1:maxt)-rhoi), 1)
+ if (i==1) then
+    !print*, 'min density too large! extrapolating using two smallest densities'
+    j = 2
+ elseif (i==maxt) then
+    !print*, 'max density too small! extrapolating using two largest densities'
+    j = maxt
+ elseif (rhov4_KI02(1,i-1) <= rhoi .and. rhoi <= rhov4_KI02(1,i  )) then
+    j = i
+ elseif (rhov4_KI02(1,i  ) <= rhoi .and. rhoi <= rhov4_KI02(1,i+1)) then
+    j = i+1
+ else
+    print*, rhoi,rhov4_KI02(1,i-1:i+1)
+    print*, 'this should not happen'
+    stop
+ endif
+
+ !--Calculate the equilibrium energy by linear interpolation
+ jm1       = j - 1
+ eni_equil = rhov4_KI02(2,j) + (rhov4_KI02(2,jm1)-rhov4_KI02(2,j))/(rhov4_KI02(1,jm1)-rhov4_KI02(1,j))*(rhoi-rhov4_KI02(1,j))
+
+ !--Determine the inverse time require to radiate/acquire excess/deficit energy & Update energy
+ ponrhoi  = (gamma-1.)*eni
+ tempi    = temperature_coef*gmw*ponrhoi
+ LambdaKI = LambdaKI_coef*(1.d7*exp(-118400./(tempi+1000.))+0.014*sqrt(tempi)*exp(-92./tempi))
+ dudti    = LambdaKI*rhoi - GammaKI
+ deni     = eni - eni_equil
+
+ if (abs(deni) > 0.) then
+    ! in both limits, this will approach the correct value
+    tau1      = abs(dudti/deni)
+    eni_final = eni_equil + deni*exp(-dt*tau1)
+    dudti     = -(eni - eni_final)/dt
+ else
+    ! in the unlikly chance deni = 0
+    dudti = -dudti
+ endif
+
+end subroutine cooling_KoyamaInutuska_implicit
 
 !-----------------------------------------------------------------------
 !
@@ -515,10 +656,12 @@ subroutine energ_cooling(xi,yi,zi,ui,dudt,rho,dt,Trad,mu_in,K2,kappa,Tgas)
     call exact_cooling_table(ui,rho,dt,dudt)
  case (5)
     if (present(Tgas)) then
-       call cooling_KoyamaInutuska(rho,Tgas,dudt)
+       call cooling_KoyamaInutuska_explicit(rho,Tgas,dudt)
     else
        call fatal('energ_cooling','Koyama & Inutuska cooling requires gas temperature')
     endif
+ case (6)
+    call cooling_KoyamaInutuska_implicit(ui,rho,dt,dudt)
  case default
     !call exact_cooling(r, u, dudt, rho, dt, Trad, mu_in, K2, kappa)
     !call implicit_cooling(u, dudt, rho, dt, Trad, mu_in, K2, kappa)
@@ -722,7 +865,7 @@ subroutine write_options_cooling(iunit)
        call write_options_h2cooling(iunit)
     endif
  else
-    call write_inopt(icooling,'icooling','cooling function (0=off, 1=explicit, 2=Townsend table, 3=Gammie, 5=KI02)',iunit)
+    call write_inopt(icooling,'icooling','cooling function (0=off, 1=explicit, 2=Townsend table, 3=Gammie, 5,6=KI02)',iunit)
     select case(icooling)
     case(1)
        call write_options_molecularcooling(iunit)

--- a/src/main/eos.F90
+++ b/src/main/eos.F90
@@ -855,7 +855,11 @@ subroutine eosinfo(eos_type,iprint)
 
  select case(eos_type)
  case(1,11)
-    write(iprint,"(/,a,f10.6)") ' Isothermal equation of state:     cs^2 = ',polyk
+    if (1.0d-5 < polyk .and. polyk < 1.0d3) then
+       write(iprint,"(/,a,f10.6)")  ' Isothermal equation of state:     cs^2 = ',polyk
+    else
+       write(iprint,"(/,a,Es13.6)") ' Isothermal equation of state:     cs^2 = ',polyk
+    endif
     if (eos_type==11) write(iprint,*) ' (ZERO PRESSURE) '
  case(2)
     if (use_entropy) then

--- a/src/main/ionization.f90
+++ b/src/main/ionization.f90
@@ -14,7 +14,7 @@ module ionization_mod
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: physcon
+! :Dependencies: eos_idealplusrad, part, physcon, units
 !
  implicit none
 

--- a/src/main/readwrite_dumps_fortran.F90
+++ b/src/main/readwrite_dumps_fortran.F90
@@ -1495,7 +1495,7 @@ subroutine fill_header(sphNGdump,t,nparttot,npartoftypetot,nblocks,nptmass,hdr,i
                           idust,grainsize,graindens,ndusttypes
  use checkconserved, only:get_conserv,etot_in,angtot_in,totmom_in,mdust_in
  use setup_params,   only:rhozero
- use timestep,       only:dtmax,C_cour,C_force
+ use timestep,       only:dtmax,dtmax0,C_cour,C_force
  use externalforces, only:write_headeropts_extern
  use boundary,       only:xmin,xmax,ymin,ymax,zmin,zmax
  use dump_utils,     only:reset_header,add_to_rheader,add_to_header,add_to_iheader,num_in_header
@@ -1537,6 +1537,11 @@ subroutine fill_header(sphNGdump,t,nparttot,npartoftypetot,nblocks,nptmass,hdr,i
  ! default real variables
  call add_to_rheader(t,'time',hdr,ierr)
  call add_to_rheader(dtmax,'dtmax',hdr,ierr)
+ if (dtmax0 > 0.) then
+    call add_to_rheader(dtmax0,'dtmax0',hdr,ierr)
+ else
+    call add_to_rheader(dtmax, 'dtmax0',hdr,ierr)
+ endif
  call add_to_rheader(gamma,'gamma',hdr,ierr)
  call add_to_rheader(rhozero,'rhozero',hdr,ierr)
  call add_to_rheader(1.5*polyk,'RK2',hdr,ierr)
@@ -1629,6 +1634,7 @@ subroutine unfill_rheader(hdr,phantomdump,ntypesinfile,nptmass,&
  use dump_utils,     only:extract
  use dust,           only:grainsizecgs,graindenscgs
  use units,          only:unit_density,udist
+ use timestep,       only:dtmax0
  type(dump_h), intent(in)  :: hdr
  logical,      intent(in)  :: phantomdump
  integer,      intent(in)  :: iprint,ntypesinfile,nptmass
@@ -1645,6 +1651,7 @@ subroutine unfill_rheader(hdr,phantomdump,ntypesinfile,nptmass,&
  call extract('time',tfile,hdr,ierr)
  if (ierr/=0)  call extract('gt',tfile,hdr,ierr)  ! this is sphNG's label for time
  call extract('dtmax',dtmaxi,hdr,ierr)
+ call extract('dtmax0',dtmax0,hdr,ierr)
  call extract('gamma',gamma,hdr,ierr)
  call extract('rhozero',rhozero,hdr,ierr)
  call extract('RK2',rk2,hdr,ierr)

--- a/src/main/step_leapfrog.F90
+++ b/src/main/step_leapfrog.F90
@@ -1298,13 +1298,13 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
              ! evolve chemical composition and determine new internal energy
              ! Krome also computes cooling function but only associated with chemical processes
              ui = vxyzu(4,i)
-             call update_krome(dt,xyzh(:,i),ui,rhoi,pmassi),abundance(:,i),gamma_chem(i),mu_chem(i),T_gas_cool(i))
+             call update_krome(dt,xyzh(:,i),ui,rhoi,abundance(:,i),gamma_chem(i),mu_chem(i),T_gas_cool(i))
              dudt_chem(i) = (ui-vxyzu(4,i))/dt
              dudtcool     = dudt_chem(i)
 #else
 #ifdef NUCLEATION
              !evolve dust chemistry and compute dust cooling
-             call evolve_dust(dt, xyzh(:,i), vxyzu(4,i), nucleation(:,i), dust_temp(i), rhoi)
+             call evolve_dust(dt,xyzh(:,i),vxyzu(4,i),nucleation(:,i),dust_temp(i),rhoi)
 #endif
              !
              ! COOLING

--- a/src/main/step_leapfrog.F90
+++ b/src/main/step_leapfrog.F90
@@ -121,6 +121,7 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
  use timestep_sts,   only:sts_get_dtau_next,use_sts,ibin_sts,sts_it_n
  use part,           only:ibin,ibin_old,twas,iactive
 #endif
+ use timestep_ind,   only:dt_too_small
 #ifdef GR
  use part,           only:metricderivs
  use metric_tools,   only:imet_minkowski,imetric
@@ -379,11 +380,19 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
 
  if (npart > 0) then
     if (gr) vpred = vxyzu ! Need primitive utherm as a guess in cons2prim
+    dt_too_small = .false.
     call derivs(1,npart,nactive,xyzh,vpred,fxyzu,fext,divcurlv,&
                 divcurlB,Bpred,dBevol,radpred,drad,radprop,dustproppred,ddustprop,&
                 dustpred,ddustevol,dustfrac,eos_vars,timei,dtsph,dtnew,&
                 ppred,dens,metrics)
     if (gr) vxyzu = vpred ! May need primitive variables elsewhere?
+    if (dt_too_small) then
+       ! dt < dtmax/2**nbinmax and exit
+       ! Perform this here rather than in get_newbin so that we can get some diagnostic info
+       ! This is only used for individual timesteps
+       call summary_printout(iprint,nptmass)
+       call fatal('step','step too small: bin would exceed maximum')
+    endif
  endif
 !
 ! if using super-timestepping, determine what dt will be used on the next loop
@@ -1083,7 +1092,7 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
  integer(kind=1) :: ibin_wakei
  real            :: timei,hdt,fextx,fexty,fextz,fextxi,fextyi,fextzi,phii,pmassi
  real            :: dtphi2,dtphi2i,vxhalfi,vyhalfi,vzhalfi,fxi,fyi,fzi,deni
- real            :: dudtcool,fextv(3),poti,fextrad(3),ui
+ real            :: dudtcool,fextv(3),poti,fextrad(3),ui,rhoi
  real            :: dt,dtextforcenew,dtsinkgas,fonrmax,fonrmaxi
  real            :: dtf,accretedmass,t_end_step,dtextforce_min
  real, allocatable :: dptmass(:,:) ! dptmass(ndptmass,nptmass)
@@ -1186,7 +1195,7 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
     !$omp shared(gamma_chem,mu_chem,dudt_chem) &
 #endif
     !$omp private(dphot,abundi,gmwvar) &
-    !$omp private(fextrad,ui) &
+    !$omp private(fextrad,ui,rhoi) &
     !$omp private(i,ichem,dudtcool,fxi,fyi,fzi,phii) &
     !$omp private(fextx,fexty,fextz,fextxi,fextyi,fextzi,poti,deni,fextv,accreted) &
     !$omp private(fonrmaxi,dtphi2i,dtf) &
@@ -1273,6 +1282,7 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
              !       calculated in force and requires a cooling timestep.
 
              dudtcool = 0.
+             rhoi = rhoh(xyzh(4,i),pmassi)
              !
              ! CHEMISTRY
              !
@@ -1281,21 +1291,20 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
                 ! Get updated abundances of all species, updates 'chemarrays',
                 !
                 dphot = get_dphot(dphotflag,dphot0,xyzh(1,i),xyzh(2,i),xyzh(3,i))
-                call update_abundances(vxyzu(4,i),rhoh(xyzh(4,i),pmassi),abundance(:,i),&
+                call update_abundances(vxyzu(4,i),rhoi,abundance(:,i),&
                       nabundances,dphot,dt,abundi,nabn,gmwvar,abundc,abunde,abundo,abundsi)
              endif
 #ifdef KROME
              ! evolve chemical composition and determine new internal energy
              ! Krome also computes cooling function but only associated with chemical processes
              ui = vxyzu(4,i)
-             call update_krome(dt,xyzh(:,i),ui,rhoh(xyzh(4,i),pmassi),&
-                               abundance(:,i),gamma_chem(i),mu_chem(i),T_gas_cool(i))
+             call update_krome(dt,xyzh(:,i),ui,rhoi,pmassi),abundance(:,i),gamma_chem(i),mu_chem(i),T_gas_cool(i))
              dudt_chem(i) = (ui-vxyzu(4,i))/dt
              dudtcool     = dudt_chem(i)
 #else
 #ifdef NUCLEATION
              !evolve dust chemistry and compute dust cooling
-             call evolve_dust(dt, xyzh(:,i), vxyzu(4,i), nucleation(:,i), dust_temp(i), rhoh(xyzh(4,i),pmassi))
+             call evolve_dust(dt, xyzh(:,i), vxyzu(4,i), nucleation(:,i), dust_temp(i), rhoi)
 #endif
              !
              ! COOLING
@@ -1306,21 +1315,18 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
                    ! Call cooling routine, requiring total density, some distance measure and
                    ! abundances in the 'abund' format
                    !
-                   call energ_h2cooling(vxyzu(4,i),rhoh(xyzh(4,i),pmassi),divcurlv(1,i),&
-                        gmwvar,abundi,dudtcool)
+                   call energ_h2cooling(vxyzu(4,i),rhoi,divcurlv(1,i),gmwvar,abundi,dudtcool)
                 elseif (store_dust_temperature) then
                    ! cooling with stored dust temperature
 #ifdef NUCLEATION
                    call energ_cooling(xyzh(1,i),xyzh(2,i),xyzh(3,i),vxyzu(4,i),dudtcool,&
-                        rhoh(xyzh(4,i),pmassi), dt, dust_temp(i),nucleation(6,i),nucleation(4,i),nucleation(8,i))
+                        rhoi,dt,dust_temp(i),nucleation(6,i),nucleation(4,i),nucleation(8,i))
 #else
-                   call energ_cooling(xyzh(1,i),xyzh(2,i),xyzh(3,i),vxyzu(4,i),dudtcool,&
-                        rhoh(xyzh(4,i),pmassi), dt, dust_temp(i))
+                   call energ_cooling(xyzh(1,i),xyzh(2,i),xyzh(3,i),vxyzu(4,i),dudtcool,rhoi,dt,dust_temp(i))
 #endif
                 else
                    ! cooling without stored dust temperature
-                   call energ_cooling(xyzh(1,i),xyzh(2,i),xyzh(3,i),vxyzu(4,i),dudtcool,&
-                        rhoh(xyzh(4,i),pmassi), dt)
+                   call energ_cooling(xyzh(1,i),xyzh(2,i),xyzh(3,i),vxyzu(4,i),dudtcool,rhoi,dt)
                 endif
              endif
 #endif

--- a/src/main/utils_indtimesteps.F90
+++ b/src/main/utils_indtimesteps.F90
@@ -25,6 +25,7 @@ module timestep_ind
  integer            :: istepfrac
  integer            :: nactive
  integer(kind=8)    :: nactivetot
+ logical            :: dt_too_small
  integer, parameter :: maxbins = 30 ! limit of 2**(n+1) with reals
  integer, parameter :: itdt    = 1
  integer, parameter :: ithdt   = 2
@@ -211,7 +212,7 @@ end subroutine change_nbinmax
 !+
 !----------------------------------------------------------------
 subroutine get_newbin(dti,dtmax,ibini,allow_decrease,limit_maxbin,dtchar)
- use io, only:fatal
+ use io, only:warning
  real,            intent(in)    :: dti,dtmax
  integer(kind=1), intent(inout) :: ibini
  logical,         intent(in), optional :: allow_decrease,limit_maxbin
@@ -249,7 +250,8 @@ subroutine get_newbin(dti,dtmax,ibini,allow_decrease,limit_maxbin,dtchar)
        write(*,'(a,Es16.7)') 'get_newbin: dt_ibin(max) = ', dtmax/2**(maxbins-1)
        write(*,'(2a)'      ) 'get_newbin: dt = ', dtchar
     endif
-    call fatal('get_newbin','step too small: bin would exceed maximum',var='dt',val=dti)
+    dt_too_small = .true.
+    call warning('get_newbin','step too small: bin would exceed maximum',var='dt',val=dti)
  endif
 
  if (ibin_newi > ibin_oldi) then

--- a/src/setup/set_disc.F90
+++ b/src/setup/set_disc.F90
@@ -938,7 +938,13 @@ subroutine write_discinfo(iunit,R_in,R_out,R_ref,Q,npart,sigmaprofile, &
  write(iunit,"(a)")
 
  !--print some of these diagnostics in more useful form
- if (itype == igas) write(iunit,"(a,f5.1,a,f5.1,a,f4.1,a,/)") '# Temperature profile  = ',T_ref,'K (R/',R_ref,')^(',-2.*q_index,')'
+ if (itype == igas) then
+    if (T_ref < 1.0d3) then
+       write(iunit,"(a,f5.1,a,f5.1,a,f4.1,a,/)")  '# Temperature profile  = ',T_ref,'K (R/',R_ref,')^(',-2.*q_index,')'
+    else
+       write(iunit,"(a,es9.2,a,f5.1,a,f4.1,a,/)") '# Temperature profile  = ',T_ref,'K (R/',R_ref,')^(',-2.*q_index,')'
+    endif
+ endif
  if (sigmaprofile==0) then
     write(iunit,"(a,es9.2,a,f5.1,a,f4.1,a,/)") '# Surface density      = ',&
          sigma_norm*umass/udist**2,' g/cm^2 (R/',R_ref,')^(',-p_index,')'

--- a/src/setup/set_sphere.f90
+++ b/src/setup/set_sphere.f90
@@ -390,6 +390,7 @@ subroutine set_unifdis_sphereN(lattice,id,master,xmin,xmax,ymin,ymax,zmin,zmax,p
     endif
  endif
  write(*,'(a,I10,2a)') ' set_sphere: Iterations complete: added ',npart0,' particles in the ',trim(c_shape)
+ psep = (xmax-xmin)/nint((xmax-xmin)/psep)
 
 end subroutine set_unifdis_sphereN
 !-----------------------------------------------------------------------
@@ -419,9 +420,14 @@ subroutine set_ellipse(lattice,id,master,r_ellipsoid,delta,hfact,xyzh,np,nptot,n
  yi = 1.5*r_ellipsoid(2)
  zi = 1.5*r_ellipsoid(3)
 
- vol_ellipse = 4.0*pi/3.0*r_ellipsoid(1)*r_ellipsoid(2)*r_ellipsoid(3)
- call set_unifdis_sphereN(lattice,id,master,-xi,xi,-yi,yi,-zi,zi,delta,hfact,np,np_requested,xyzh, &
-                          vol_ellipse,nptot,my_mask,ierr,r_ellipsoid=r_ellipsoid,in_ellipsoid=.true.)
+ if (trim(lattice)=='random') then
+    call set_unifdis(lattice,id,master,-xi,xi,-yi,yi,-zi,zi,delta,hfact,np,xyzh,.false.,npnew_in=np_requested,&
+                     rellipsoid=r_ellipsoid,in_ellipsoid=.true.,nptot=nptot,verbose=.false.,centre=.true.)
+ else
+    vol_ellipse = 4.0*pi/3.0*r_ellipsoid(1)*r_ellipsoid(2)*r_ellipsoid(3)
+    call set_unifdis_sphereN(lattice,id,master,-xi,xi,-yi,yi,-zi,zi,delta,hfact,np,np_requested,xyzh, &
+                             vol_ellipse,nptot,my_mask,ierr,r_ellipsoid=r_ellipsoid,in_ellipsoid=.true.)
+ endif
 
 end subroutine set_ellipse
 !-----------------------------------------------------------------------

--- a/src/setup/set_unifdis.f90
+++ b/src/setup/set_unifdis.f90
@@ -48,7 +48,7 @@ contains
 subroutine set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
                        zmin,zmax,delta,hfact,np,xyzh,periodic, &
                        rmin,rmax,rcylmin,rcylmax,rellipsoid,in_ellipsoid, &
-                       nptot,npy,npz,rhofunc,inputiseed,verbose,centre,dir,geom,mask,err)
+                       nptot,npy,npz,npnew_in,rhofunc,inputiseed,verbose,centre,dir,geom,mask,err)
  use random,     only:ran2
  use stretchmap, only:set_density_profile
  !use domain,     only:i_belong
@@ -63,7 +63,7 @@ subroutine set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
  real,             intent(in),    optional :: rcylmin,rcylmax
  real,             intent(in),    optional :: rellipsoid(3)
  integer(kind=8),  intent(inout), optional :: nptot
- integer,          intent(in),    optional :: npy,npz,dir,geom
+ integer,          intent(in),    optional :: npy,npz,npnew_in,dir,geom
  procedure(rho_func), pointer,    optional :: rhofunc
  integer,          intent(in),    optional :: inputiseed
  logical,          intent(in),    optional :: verbose,centre,in_ellipsoid
@@ -521,6 +521,7 @@ subroutine set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
     ny = nint(dybound/delta)
     nz = nint(dzbound/delta)
     npnew = nx*ny*nz
+    if (present(npnew_in)) npnew = npnew_in
 
     do while (iparttot < iparttot0+npnew)
        xi = xmin + ran2(iseed)*dxbound
@@ -685,17 +686,17 @@ pure subroutine get_xyzmin_xyzmax_exact(latticetype,xmin,xmax,ymin,ymax,zmin,zma
 
  ! adjust boundaries as required
  exact_width = nx*deltax
- dbounds     = abs(boxx - exact_width)
+ dbounds     = exact_width - boxx
  xmin = xmin - 0.5*dbounds
  xmax = xmax + 0.5*dbounds
 
  exact_width = ny*deltay
- dbounds     = abs(boxy - exact_width)
+ dbounds     = exact_width - boxy
  ymin = ymin - 0.5*dbounds
  ymax = ymax + 0.5*dbounds
 
  exact_width = nz*deltaz
- dbounds     = abs(boxz - exact_width)
+ dbounds     = exact_width - boxz
  zmin = zmin - 0.5*dbounds
  zmax = zmax + 0.5*dbounds
 

--- a/src/setup/setup_star.f90
+++ b/src/setup/setup_star.f90
@@ -742,7 +742,7 @@ subroutine write_setupfile(filename,gamma,polyk)
  write(iunit,"(/,a)") '# resolution'
  call write_inopt(np,'np','approx number of particles (in box of size 2R)',iunit)
  call write_inopt(use_exactN,'use_exactN','find closest particle number to np',iunit)
- 
+
  write(iunit,"(/,a)") '# equation of state'
  call write_inopt(use_var_comp,'use_var_comp','Use variable composition (X, Z, mu)',iunit)
  call write_inopt(ieos,'ieos','1=isothermal,2=adiabatic,10=MESA,12=idealplusrad',iunit)

--- a/src/setup/setup_wave.f90
+++ b/src/setup/setup_wave.f90
@@ -109,7 +109,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  fac = 6.*(int((1.-epsilon(0.))*radkern/6.) + 1)
  deltay = fac*deltax*sqrt(0.75)
  deltaz = fac*deltax*sqrt(6.)/3.
- call set_boundary(xmin,xmax,-deltay,deltay,-deltaz,deltaz)
+ call set_boundary(xmini,xmaxi,-deltay,deltay,-deltaz,deltaz)
 !
 ! general parameters
 !

--- a/src/utils/analysis_common_envelope.F90
+++ b/src/utils/analysis_common_envelope.F90
@@ -14,8 +14,8 @@ module analysis
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: centreofmass, energies, eos, eos_idealplusrad, eos_mesa,
-!   extern_corotate, kernel, mesa_microphysics, part, physcon, prompting,
+! :Dependencies: centreofmass, energies, eos, eos_mesa, extern_corotate,
+!   ionization_mod, kernel, mesa_microphysics, part, physcon, prompting,
 !   ptmass, setbinary, sortutils, table_utils, units
 !
 


### PR DESCRIPTION
Type of PR: 
Multiple

Description:
Bug fix: Corrected explicit Koyama&Inutuska cooling
New Physics: added implicit Koyama&Inutuska cooling
Updated numerics: set_ellipse can now use random particle placement
Updated numerics: set_unifdis can use particle number rather than psep
Updated numerics: if dt < dtmax*0.5**maxbins, the exit will now occur in step after printing useful diagnostic info.
Bug fix/update: updated how dtmax can increase if dtmax is permitted to change with wall time

Testing:
These changes have been successfully used in test & production runs.

Did you run the bots? yes


(Sorry for the multiple topics in a single PR; each topic is localised to a single commit)