### PR TITLE
Fix dustgrowth test with MPI

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,32 +25,33 @@ Giovanni Dipierro <giovanni.dipierro@leicester.ac.uk>
 Enrico Ragusa <enr.ragusa@gmail.com>
 Hauke Worpel <hworpel@aip.de>
 Roberto Iaconi <robertoiaconi1@gmail.com>
-Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
 Simon Glover <glover@uni-heidelberg.de>
-Martina Toscani <mtoscani94@gmail.com>
+Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
 Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
-Simone Ceppi <simo.ceppi@gmail.com>
+Martina Toscani <mtoscani94@gmail.com>
 Benedetta Veronesi <benedetta.veronesi@unimi.it>
+Simone Ceppi <simo.ceppi@gmail.com>
+Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Christopher Russell <crussell@udel.edu>
 Megha Sharma <msha0023@student.monash.edu>
 Alessia Franchini <alessia.franchini@unlv.edu>
 Alex Pettitt <alex@astro1.sci.hokudai.ac.jp>
-Kieran Hirsh <kieran.hirsh1@monash.edu>
 Nicole Rodrigues <nicole.rodrigues@monash.edu>
+Kieran Hirsh <kieran.hirsh1@monash.edu>
 Chris Nixon <cjn@leicester.ac.uk>
-Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Nicolas Cuello <cuellonicolas@gmail.com>
 Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
-Orsola De Marco <orsola.demarco@mq.edu.au>
+Cristiano Longarini <cristiano.longarini@unimi.it>
 Zachary Pellow <zpel1@student.monash.edu>
 Joe Fisher <jwfis1@student.monash.edu>
+Orsola De Marco <orsola.demarco@mq.edu.au>
+Benoit Commercon <benoit.commercon@gmail.com>
 Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
 David Trevascus <dtre10@student.monash.edu>
-Cristiano Longarini <cristiano.longarini@unimi.it>
-Benoit Commercon <benoit.commercon@gmail.com>
+Alison Young <ayoung@astro.ex.ac.uk>
+James <jhw5@st-andrews.ac.uk>
 Steven Rieder <steven@rieder.nl>
-Jorge Cuadra <jcuadra@astro.puc.cl>
 Stéven Toupin <steven.toupin@gmail.com>
 Cox, Samuel <sc676@leicester.ac.uk>
 Maxime Lombart <maxime.lombart@ens-lyon.fr>
-Alison Young <ayoung@astro.ex.ac.uk>
+Jorge Cuadra <jcuadra@astro.puc.cl>

--- a/src/main/checksetup.F90
+++ b/src/main/checksetup.F90
@@ -53,11 +53,10 @@ subroutine check_setup(nerror,nwarn,restart)
  use units,           only:G_is_unity,get_G_code
  use boundary,        only:xmin,xmax,ymin,ymax,zmin,zmax
  use nicil,           only:n_nden
- use mpiutils,        only:reduceall_mpi
  integer, intent(out) :: nerror,nwarn
  logical, intent(in), optional :: restart
  integer      :: i,j,nbad,itype,nunity,iu,ndead
- integer      :: ncount(maxtypes),ncounttot(maxtypes),npartoftypetot(maxtypes)
+ integer      :: ncount(maxtypes)
  real         :: xcom(ndim),vcom(ndim)
  real         :: hi,hmin,hmax,dust_to_gas
  logical      :: accreted,dorestart
@@ -163,11 +162,9 @@ subroutine check_setup(nerror,nwarn,restart)
        print*,'ERROR: unknown value of particle type on ',nbad,' particles'
        nerror = nerror + 1
     endif
-    ncounttot      = reduceall_mpi('+',ncount(:))
-    npartoftypetot = reduceall_mpi('+',npartoftype(:))
-    if (any(ncounttot /= npartoftypetot)) then
-       print*,'n(via iphase)=',ncounttot
-       print*,'npartoftype  =',npartoftypetot
+    if (any(ncount /= npartoftype)) then
+       print*,'n(via iphase)=',ncount
+       print*,'npartoftype  =',npartoftype
        print*,'ERROR: sum of types in iphase is not equal to npartoftype'
        nerror = nerror + 1
     endif

--- a/src/main/mpi_balance.F90
+++ b/src/main/mpi_balance.F90
@@ -264,7 +264,8 @@ end subroutine send_part
 !+
 !----------------------------------------------------------------
 subroutine balance_finish(npart,replace)
- use io,  only:id,nprocs,fatal,iverbose
+ use io,    only:id,nprocs,fatal,iverbose
+ use part,  only:recount_npartoftype
  implicit none
  integer, intent(out)            :: npart
  logical, intent(in), optional   :: replace
@@ -314,6 +315,11 @@ subroutine balance_finish(npart,replace)
 !--double check that all receives are complete and free request handle
  call MPI_WAIT(irequestrecv(1),status,mpierr)
  call MPI_REQUEST_FREE(irequestrecv(1),mpierr)
+
+ !
+ !--update npartoftype
+ !
+ call recount_npartoftype
 
 end subroutine balance_finish
 

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -858,6 +858,23 @@ subroutine remove_particle_from_npartoftype(i,npoftype)
 
 end subroutine remove_particle_from_npartoftype
 
+!----------------------------------------------------------------
+!+
+!  recount particle types, useful after particles have moved
+!  between MPI tasks
+!+
+!----------------------------------------------------------------
+subroutine recount_npartoftype
+   integer :: itype
+
+   npartoftype(:) = 0
+   do i=1,npart
+      itype = iamtype(iphase(i))
+      npartoftype(itype) = npartoftype(itype) + 1
+   enddo
+
+end subroutine recount_npartoftype
+
 !----------------------------------------------
 !+
 !  functions to deconstruct iphase

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -321,6 +321,7 @@ module part
 #ifdef DUSTGROWTH
    +2                                   &  ! dustprop
    +2                                   &  ! dustproppred
+   +4                                   &  ! dustgasprop
 #endif
 #endif
 #ifdef H2CHEM
@@ -1431,6 +1432,7 @@ subroutine fill_sendbuf(i,xtemp)
        if (use_dustgrowth) then
           call fill_buffer(xtemp, dustprop(:,i),nbuf)
           call fill_buffer(xtemp, dustproppred(:,i),nbuf)
+          call fill_buffer(xtemp, dustgasprop(:,i),nbuf)
        endif
     endif
     if (maxp_h2==maxp .or. maxp_krome==maxp) then
@@ -1504,6 +1506,7 @@ subroutine unfill_buffer(ipart,xbuf)
     if (use_dustgrowth) then
        dustprop(:,ipart)       = unfill_buf(xbuf,j,2)
        dustproppred(:,ipart)   = unfill_buf(xbuf,j,2)
+       dustgasprop(:,ipart)    = unfill_buf(xbuf,j,4)
     endif
  endif
  if (maxp_h2==maxp .or. maxp_krome==maxp) then

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -866,13 +866,13 @@ end subroutine remove_particle_from_npartoftype
 !+
 !----------------------------------------------------------------
 subroutine recount_npartoftype
-   integer :: itype
+ integer :: itype
 
-   npartoftype(:) = 0
-   do i=1,npart
-      itype = iamtype(iphase(i))
-      npartoftype(itype) = npartoftype(itype) + 1
-   enddo
+ npartoftype(:) = 0
+ do i=1,npart
+    itype = iamtype(iphase(i))
+    npartoftype(itype) = npartoftype(itype) + 1
+ enddo
 
 end subroutine recount_npartoftype
 

--- a/src/tests/test_growth.F90
+++ b/src/tests/test_growth.F90
@@ -243,7 +243,7 @@ subroutine test_farmingbox(ntests,npass,frag,onefluid)
  enddo
  npartoftype(itype)    = npart - npart_previous
  npartoftypetot(itype) = reduceall_mpi('+',npartoftype(itype))
- massoftype(itype)     = totmass/npartoftype(itype)
+ massoftype(itype)     = totmass/npartoftypetot(itype)
 
  !- setting dust particles if not one fluid
  if (.not. use_dustfrac) then

--- a/src/utils/libphantom-evolve.F90
+++ b/src/utils/libphantom-evolve.F90
@@ -259,16 +259,16 @@ subroutine finalize_step(infile, logfile, evfile, dumpfile)
      .or.(time >= tmax)            &
      .or.((mod(nsteps,nout)==0).and.(nout > 0)) &
      .or.(nsteps >= nmax)) then
- !--modify evfile and logfile names with new number
- if (noutput==1) then
-    evfile = getnextfilename(evfile)
-    logfile = getnextfilename(logfile)
- endif
- dumpfile = getnextfilename(dumpfile)
+    !--modify evfile and logfile names with new number
+    if (noutput==1) then
+       evfile = getnextfilename(evfile)
+       logfile = getnextfilename(logfile)
+    endif
+    dumpfile = getnextfilename(dumpfile)
 
 #ifdef MPI
- !--do not dump dead particles into dump files
- if (ideadhead > 0) call shuffle_part(npart)
+    !--do not dump dead particles into dump files
+    if (ideadhead > 0) call shuffle_part(npart)
 #endif
 
 !
@@ -276,15 +276,15 @@ subroutine finalize_step(infile, logfile, evfile, dumpfile)
 !  (get these before writing the dump so we can check whether or not we
 !   need to write a full dump based on the wall time)
 !
- call get_timings(t2,tcpu2)
- tcpu     = tcpu2-tcpulast
- tcpu     = reduce_mpi('+',tcpu)
- tcputot  = tcpu2 - tcpustart
- tcputot  = reduce_mpi('+',tcputot)
- tcpustep = reduce_mpi('+',tcpustep)
- tcpuev   = reduce_mpi('+',tcpuev)
+    call get_timings(t2,tcpu2)
+    tcpu     = tcpu2-tcpulast
+    tcpu     = reduce_mpi('+',tcpu)
+    tcputot  = tcpu2 - tcpustart
+    tcputot  = reduce_mpi('+',tcputot)
+    tcpustep = reduce_mpi('+',tcpustep)
+    tcpuev   = reduce_mpi('+',tcpuev)
 
- fulldump = (mod(noutput,nfulldump)==0)
+    fulldump = (mod(noutput,nfulldump)==0)
 !
 !--if max wall time is set (> 1 sec) stop the run at the last full dump
 !  that will fit into the walltime constraint, based on the wall time between
@@ -292,95 +292,95 @@ subroutine finalize_step(infile, logfile, evfile, dumpfile)
 !  If we are about to write a small dump but it looks like we won't make the next dump,
 !  dump a full dump instead and stop the run
 !
- abortrun = .false.
- if (twallmax > 1.) then
-    twallused = t2-tstart
-    twallperdump = t2-twalllast
-    if (fulldump) then
-       if ((twallused + abs(nfulldump)*twallperdump) > twallmax) then
-          abortrun = .true.
-       endif
-    else
-       if ((twallused + twallperdump) > twallmax) then
-          fulldump = .true.
-          abortrun = .true.
-          write(iprint,"(1x,a)") '>> PROMOTING DUMP TO FULL DUMP BASED ON WALL TIME CONSTRAINTS... '
-          nfulldump = 1  !  also set all future dumps to be full dumps (otherwise gets confusing)
+    abortrun = .false.
+    if (twallmax > 1.) then
+       twallused = t2-tstart
+       twallperdump = t2-twalllast
+       if (fulldump) then
+          if ((twallused + abs(nfulldump)*twallperdump) > twallmax) then
+             abortrun = .true.
+          endif
+       else
+          if ((twallused + twallperdump) > twallmax) then
+             fulldump = .true.
+             abortrun = .true.
+             write(iprint,"(1x,a)") '>> PROMOTING DUMP TO FULL DUMP BASED ON WALL TIME CONSTRAINTS... '
+             nfulldump = 1  !  also set all future dumps to be full dumps (otherwise gets confusing)
+          endif
        endif
     endif
- endif
 !
 !--flush any buffered warnings to the log file
 !
- if (id==master) call flush_warnings()
+    if (id==master) call flush_warnings()
 !
 !--write dump file
 !
- at_dump_time = .true.
- if (fulldump) then
-    call write_fulldump(time,dumpfile)
-    if (id==master) then
-       call write_infile(infile,logfile,evfile,dumpfile,iwritein,iprint)
+    at_dump_time = .true.
+    if (fulldump) then
+       call write_fulldump(time,dumpfile)
+       if (id==master) then
+          call write_infile(infile,logfile,evfile,dumpfile,iwritein,iprint)
 #ifdef DRIVING
-       call write_forcingdump(time,dumpfile)
+          call write_forcingdump(time,dumpfile)
 #endif
-    endif
-    ncount_fulldumps = ncount_fulldumps + 1
+       endif
+       ncount_fulldumps = ncount_fulldumps + 1
 
 #ifndef IND_TIMESTEPS
 #endif
- else
-    call write_smalldump(time,dumpfile)
- endif
+    else
+       call write_smalldump(time,dumpfile)
+    endif
 
- if (id==master) call print_timinginfo(iprint,nsteps,nsteplast,t2,tstart,&
+    if (id==master) call print_timinginfo(iprint,nsteps,nsteplast,t2,tstart,&
                               tcpu,tcpustep,tcputot,twalllast,tstep,tev,tcpuev)
 #ifdef IND_TIMESTEPS
- !--print summary of timestep bins
- if (iverbose >= 0 .and. id==master .and. abs(tall) > tiny(tall) .and. ntot > 0) then
-    fracactive = nmovedtot/real(ntot)
-    speedup = (t2-twalllast)/(tall + tiny(tall))
-    write(iprint,"(/,a,f6.2,'%')") ' IND TIMESTEPS efficiency = ',100.*fracactive/speedup
-    if (iverbose >= 1) then
-       write(iprint,"(a,1pe14.2,'s')") '  wall time per particle (last full step) : ',tall/real(ntot)
-       write(iprint,"(a,1pe14.2,'s')") '  wall time per particle (ave. all steps) : ',(t2-twalllast)/real(nmovedtot)
+    !--print summary of timestep bins
+    if (iverbose >= 0 .and. id==master .and. abs(tall) > tiny(tall) .and. ntot > 0) then
+       fracactive = nmovedtot/real(ntot)
+       speedup = (t2-twalllast)/(tall + tiny(tall))
+       write(iprint,"(/,a,f6.2,'%')") ' IND TIMESTEPS efficiency = ',100.*fracactive/speedup
+       if (iverbose >= 1) then
+          write(iprint,"(a,1pe14.2,'s')") '  wall time per particle (last full step) : ',tall/real(ntot)
+          write(iprint,"(a,1pe14.2,'s')") '  wall time per particle (ave. all steps) : ',(t2-twalllast)/real(nmovedtot)
+       endif
     endif
- endif
- if (iverbose >= 0) then
-    call write_binsummary(npart,nbinmax,dtmax,timeperbin,iphase,ibin,xyzh)
-    timeperbin(:) = 0.
- endif
- tlast = tprint
- istepfrac = 0
- nmovedtot = 0
+    if (iverbose >= 0) then
+       call write_binsummary(npart,nbinmax,dtmax,timeperbin,iphase,ibin,xyzh)
+       timeperbin(:) = 0.
+    endif
+    tlast = tprint
+    istepfrac = 0
+    nmovedtot = 0
 #endif
- !
- !--if twallmax > 1s stop the run at the last full dump that will fit into the walltime constraint,
- !  based on the wall time between the last two dumps added to the current total walltime used.
- !
- if (abortrun) then
-    call print_time(t2-tstart,'>> WALL TIME = ',iprint)
-    call print_time(twallmax,'>> NEXT DUMP WILL TRIP OVER MAX WALL TIME: ',iprint)
-    write(iprint,"(1x,a)") '>> ABORTING... '
-    return
+    !
+    !--if twallmax > 1s stop the run at the last full dump that will fit into the walltime constraint,
+    !  based on the wall time between the last two dumps added to the current total walltime used.
+    !
+    if (abortrun) then
+       call print_time(t2-tstart,'>> WALL TIME = ',iprint)
+       call print_time(twallmax,'>> NEXT DUMP WILL TRIP OVER MAX WALL TIME: ',iprint)
+       write(iprint,"(1x,a)") '>> ABORTING... '
+       return
+    endif
+
+    if (nmaxdumps > 0 .and. ncount_fulldumps >= nmaxdumps) then
+       write(iprint,"(a)") '>> reached maximum number of full dumps as specified in input file, stopping...'
+       return
+    endif
+
+    twalllast = t2
+    tcpulast = tcpu2
+    tstep = 0.
+    tcpustep = 0.
+    tev = 0.
+    tcpuev = 0.
+
+    noutput = noutput + 1
+    tprint = tzero + noutput*dtmax
+    nsteplast = nsteps
  endif
-
- if (nmaxdumps > 0 .and. ncount_fulldumps >= nmaxdumps) then
-    write(iprint,"(a)") '>> reached maximum number of full dumps as specified in input file, stopping...'
-    return
- endif
-
- twalllast = t2
- tcpulast = tcpu2
- tstep = 0.
- tcpustep = 0.
- tev = 0.
- tcpuev = 0.
-
- noutput = noutput + 1
- tprint = tzero + noutput*dtmax
- nsteplast = nsteps
-endif
 !
 !--Calculate total energy etc and write to ev file
 !  For individual timesteps, we do not want to do this every step, but we want
@@ -388,30 +388,30 @@ endif
 !  here is that it is done once >10% of particles (cumulatively) have been evolved.
 !  That is, either >10% are being stepped, or e.g. 1% have moved 10 steps.
 !
-nskipped = nskipped + nskip
-if (nskipped >= nevwrite_threshold .or. at_dump_time) then
-   nskipped = 0
-   call get_timings(t1,tcpu1)
-   call write_evfile(time,dt)
-   !--timings for step call
-   call get_timings(t2,tcpu2)
-   tev= tev + t2-t1
-   tcpuev = tcpuev + tcpu2-tcpu1
-   if (at_dump_time .and. id==master) call write_evlog(iprint)
-   if (id==master .and. iverbose >= 1) write(iprint,*) ' etot = ',etot,' momtot = ',totmom
-endif
+ nskipped = nskipped + nskip
+ if (nskipped >= nevwrite_threshold .or. at_dump_time) then
+    nskipped = 0
+    call get_timings(t1,tcpu1)
+    call write_evfile(time,dt)
+    !--timings for step call
+    call get_timings(t2,tcpu2)
+    tev= tev + t2-t1
+    tcpuev = tcpuev + tcpu2-tcpu1
+    if (at_dump_time .and. id==master) call write_evlog(iprint)
+    if (id==master .and. iverbose >= 1) write(iprint,*) ' etot = ',etot,' momtot = ',totmom
+ endif
 
 #ifdef CORRECT_BULK_MOTION
-call correct_bulk_motion()
+ call correct_bulk_motion()
 #endif
 
 #ifndef IND_TIMESTEPS
  !--reach tprint exactly. must take this out for integrator to be symplectic
-if (dt >= (tprint-time)) dt = tprint-time + epsilon(0.)
+ if (dt >= (tprint-time)) dt = tprint-time + epsilon(0.)
 #endif
 
-if (iverbose >= 1 .and. id==master) write(iprint,*)
-call flush(iprint)
+ if (iverbose >= 1 .and. id==master) write(iprint,*)
+ call flush(iprint)
 end subroutine finalize_step
 
 subroutine evol(infile,logfile,evfile,dumpfile)


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
The dustgrowth tests needed to be fixed as part of #217 . `test_farmingbox` was failing, and now passes.

Summary of fixes:
- `npartoftype` needs to be recalculated after balancing particles
- `npartoftype` was incorrectly used to calculate dust particle mass, changed to `npartoftypetot`
- `dustgasprop` needs to be carried during mpi exchange

Testing:
```
make MPI=yes SETUP=testgrowth phantomtest
mpirun -n 4 bin/phantomtest dustgrowth
```

Did you run the bots? yes
