### PR TITLE
Fix test2 for external forces with MPI

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,32 +25,33 @@ Giovanni Dipierro <giovanni.dipierro@leicester.ac.uk>
 Enrico Ragusa <enr.ragusa@gmail.com>
 Hauke Worpel <hworpel@aip.de>
 Roberto Iaconi <robertoiaconi1@gmail.com>
-Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
 Simon Glover <glover@uni-heidelberg.de>
-Martina Toscani <mtoscani94@gmail.com>
+Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
 Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
-Simone Ceppi <simo.ceppi@gmail.com>
+Martina Toscani <mtoscani94@gmail.com>
 Benedetta Veronesi <benedetta.veronesi@unimi.it>
+Simone Ceppi <simo.ceppi@gmail.com>
+Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Christopher Russell <crussell@udel.edu>
 Megha Sharma <msha0023@student.monash.edu>
 Alessia Franchini <alessia.franchini@unlv.edu>
 Alex Pettitt <alex@astro1.sci.hokudai.ac.jp>
-Kieran Hirsh <kieran.hirsh1@monash.edu>
 Nicole Rodrigues <nicole.rodrigues@monash.edu>
+Kieran Hirsh <kieran.hirsh1@monash.edu>
 Chris Nixon <cjn@leicester.ac.uk>
-Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Nicolas Cuello <cuellonicolas@gmail.com>
 Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
-Orsola De Marco <orsola.demarco@mq.edu.au>
+Cristiano Longarini <cristiano.longarini@unimi.it>
 Zachary Pellow <zpel1@student.monash.edu>
 Joe Fisher <jwfis1@student.monash.edu>
+Orsola De Marco <orsola.demarco@mq.edu.au>
+Benoit Commercon <benoit.commercon@gmail.com>
 Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
 David Trevascus <dtre10@student.monash.edu>
-Cristiano Longarini <cristiano.longarini@unimi.it>
-Benoit Commercon <benoit.commercon@gmail.com>
+Alison Young <ayoung@astro.ex.ac.uk>
+James <jhw5@st-andrews.ac.uk>
 Steven Rieder <steven@rieder.nl>
-Jorge Cuadra <jcuadra@astro.puc.cl>
 Stéven Toupin <steven.toupin@gmail.com>
 Cox, Samuel <sc676@leicester.ac.uk>
 Maxime Lombart <maxime.lombart@ens-lyon.fr>
-Alison Young <ayoung@astro.ex.ac.uk>
+Jorge Cuadra <jcuadra@astro.puc.cl>

--- a/src/tests/test_externf.f90
+++ b/src/tests/test_externf.f90
@@ -30,7 +30,7 @@ contains
 !----------------------------------------------------------
 subroutine test_externf(ntests,npass)
  use io,       only:id,master
- use part,     only:npart,xyzh,hfact,massoftype,igas,periodic
+ use part,     only:npart,xyzh,hfact,massoftype,igas,periodic,npartoftype
  use testutils,only:checkval,checkvalf,checkvalbuf_start,checkvalbuf,checkvalbuf_end,update_test_scores
  use externalforces, only:externalforcetype,externalforce,accrete_particles, &
                           was_accreted,iexternalforce_max,initialise_externalforces,&
@@ -74,6 +74,8 @@ subroutine test_externf(ntests,npass)
  !dhi   = 0.001*hfact*psep
  dhi   = 1.e-8*psep
  massoftype(igas) = 1./real(npart)
+ npartoftype(igas) = npart
+
 !
 !--Test 1: check that external force is the derivative of potential
 !


### PR DESCRIPTION
Type of PR: 
Bug fix 

Description:
The external forces test in test2 needed to be fixed as part of #217 

`npartoftype` was not defined during the problem setup, so the value is inherited from the previous test. `npartoftype(igas)` is used in `update_externalforce` for `make_beta_grids`. If the value is larger than the actual number of particles, junk values will be processed, resulting a crash when using `DEBUG=yes`. This is seen in [mpi #705](https://github.com/danieljprice/phantom/runs/5192077436).

Testing:
```
make MPI=yes SETUP=test2 DEBUG=yes phantomtest && mpirun -n 2 bin/phantomtest
```
Since full MPI tests have not yet been enabled (pending successful checks and merge of #217), the tests were performed on the ADACS fork: https://github.com/ADACS-Australia/phantom/actions/runs/1844881272

The crash did not occur on my local machine, only on github runners. The behaviour depends on undefined variables.

Did you run the bots? yes, pre-commit
