### PR TITLE
moddump_binary

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,32 +25,33 @@ Giovanni Dipierro <giovanni.dipierro@leicester.ac.uk>
 Enrico Ragusa <enr.ragusa@gmail.com>
 Hauke Worpel <hworpel@aip.de>
 Roberto Iaconi <robertoiaconi1@gmail.com>
-Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
 Simon Glover <glover@uni-heidelberg.de>
-Martina Toscani <mtoscani94@gmail.com>
+Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
 Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
-Simone Ceppi <simo.ceppi@gmail.com>
+Martina Toscani <mtoscani94@gmail.com>
 Benedetta Veronesi <benedetta.veronesi@unimi.it>
+Simone Ceppi <simo.ceppi@gmail.com>
+Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Christopher Russell <crussell@udel.edu>
 Megha Sharma <msha0023@student.monash.edu>
 Alessia Franchini <alessia.franchini@unlv.edu>
 Alex Pettitt <alex@astro1.sci.hokudai.ac.jp>
-Kieran Hirsh <kieran.hirsh1@monash.edu>
 Nicole Rodrigues <nicole.rodrigues@monash.edu>
+Kieran Hirsh <kieran.hirsh1@monash.edu>
 Chris Nixon <cjn@leicester.ac.uk>
-Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Nicolas Cuello <cuellonicolas@gmail.com>
 Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
-Orsola De Marco <orsola.demarco@mq.edu.au>
+Cristiano Longarini <cristiano.longarini@unimi.it>
 Zachary Pellow <zpel1@student.monash.edu>
 Joe Fisher <jwfis1@student.monash.edu>
+Orsola De Marco <orsola.demarco@mq.edu.au>
+Benoit Commercon <benoit.commercon@gmail.com>
 Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
 David Trevascus <dtre10@student.monash.edu>
-Cristiano Longarini <cristiano.longarini@unimi.it>
-Benoit Commercon <benoit.commercon@gmail.com>
+Alison Young <ayoung@astro.ex.ac.uk>
+James <jhw5@st-andrews.ac.uk>
 Steven Rieder <steven@rieder.nl>
-Jorge Cuadra <jcuadra@astro.puc.cl>
 Stéven Toupin <steven.toupin@gmail.com>
 Cox, Samuel <sc676@leicester.ac.uk>
 Maxime Lombart <maxime.lombart@ens-lyon.fr>
-Alison Young <ayoung@astro.ex.ac.uk>
+Jorge Cuadra <jcuadra@astro.puc.cl>

--- a/src/main/eos.F90
+++ b/src/main/eos.F90
@@ -895,6 +895,10 @@ subroutine eosinfo(eos_type,iprint)
     call eos_info_barotropic(polyk,polyk2,iprint)
  case(9)
     call eos_info_piecewise(iprint)
+ case(10)
+    write(iprint,"(/,a,f10.6,a,f10.6,a,f10.6,a)") ' MESA EoS: X = ',X_in,' Z = ',Z_in,' (1-X-Z = ',1.-X_in-Z_in,')'
+ case(12)
+    write(iprint,"(/,a,f10.6,a,f10.6)") ' Gas + radiation equation of state: gmw = ',gmw,' gamma = ',gamma
  case(15)
     call eos_helmholtz_eosinfo(iprint)
  end select

--- a/src/main/eos.F90
+++ b/src/main/eos.F90
@@ -863,7 +863,8 @@ subroutine eosinfo(eos_type,iprint)
     if (eos_type==11) write(iprint,*) ' (ZERO PRESSURE) '
  case(2)
     if (use_entropy) then
-       write(iprint,"(/,a,f10.6,a,f10.6)") ' Adiabatic equation of state (evolving ENTROPY): polyk = ',polyk,' gamma = ',gamma
+       write(iprint,"(/,a,f10.6,a,f10.6,a,f10.6)") ' Adiabatic equation of state (evolving ENTROPY): polyk = ',polyk,&
+                                                   ' gamma = ',gamma,' gmw = ',gmw
 !
 !--run a unit test on the en-> utherm and utherm-> en conversion utilities
 !
@@ -877,12 +878,13 @@ subroutine eosinfo(eos_type,iprint)
        endif
     elseif (maxvxyzu >= 4) then
        if (gr) then
-          write(iprint,"(/,a,f10.6)") ' Adiabatic equation of state with gamma = ',gamma
+          write(iprint,"(/,a,f10.6,a,f10.6)") ' Adiabatic equation of state with gamma = ',gamma,' gmw = ',gmw
        else
-          write(iprint,"(/,a,f10.6)") ' Adiabatic equation of state (evolving UTHERM): P = (gamma-1)*rho*u, gamma = ',gamma
+          write(iprint,"(/,a,f10.6,a,f10.6)") ' Adiabatic equation of state (evolving UTHERM): P = (gamma-1)*rho*u, gamma = ',&
+                                              gamma,' gmw = ',gmw
        endif
     else
-       write(iprint,"(/,a,f10.6,a,f10.6)") ' Polytropic equation of state: P = ',polyk,'*rho^',gamma
+       write(iprint,"(/,a,f10.6,a,f10.6,a,f10.6)") ' Polytropic equation of state: P = ',polyk,'*rho^',gamma,' gmw = ',gmw
     endif
  case(3)
     write(iprint,"(/,a,f10.6,a,f10.6)") ' Locally isothermal eq of state (R_sph): cs^2_0 = ',polyk,' qfac = ',qfacdisc

--- a/src/utils/libphantom-evolve.F90
+++ b/src/utils/libphantom-evolve.F90
@@ -259,16 +259,16 @@ subroutine finalize_step(infile, logfile, evfile, dumpfile)
      .or.(time >= tmax)            &
      .or.((mod(nsteps,nout)==0).and.(nout > 0)) &
      .or.(nsteps >= nmax)) then
- !--modify evfile and logfile names with new number
- if (noutput==1) then
-    evfile = getnextfilename(evfile)
-    logfile = getnextfilename(logfile)
- endif
- dumpfile = getnextfilename(dumpfile)
+    !--modify evfile and logfile names with new number
+    if (noutput==1) then
+       evfile = getnextfilename(evfile)
+       logfile = getnextfilename(logfile)
+    endif
+    dumpfile = getnextfilename(dumpfile)
 
 #ifdef MPI
- !--do not dump dead particles into dump files
- if (ideadhead > 0) call shuffle_part(npart)
+    !--do not dump dead particles into dump files
+    if (ideadhead > 0) call shuffle_part(npart)
 #endif
 
 !
@@ -276,15 +276,15 @@ subroutine finalize_step(infile, logfile, evfile, dumpfile)
 !  (get these before writing the dump so we can check whether or not we
 !   need to write a full dump based on the wall time)
 !
- call get_timings(t2,tcpu2)
- tcpu     = tcpu2-tcpulast
- tcpu     = reduce_mpi('+',tcpu)
- tcputot  = tcpu2 - tcpustart
- tcputot  = reduce_mpi('+',tcputot)
- tcpustep = reduce_mpi('+',tcpustep)
- tcpuev   = reduce_mpi('+',tcpuev)
+    call get_timings(t2,tcpu2)
+    tcpu     = tcpu2-tcpulast
+    tcpu     = reduce_mpi('+',tcpu)
+    tcputot  = tcpu2 - tcpustart
+    tcputot  = reduce_mpi('+',tcputot)
+    tcpustep = reduce_mpi('+',tcpustep)
+    tcpuev   = reduce_mpi('+',tcpuev)
 
- fulldump = (mod(noutput,nfulldump)==0)
+    fulldump = (mod(noutput,nfulldump)==0)
 !
 !--if max wall time is set (> 1 sec) stop the run at the last full dump
 !  that will fit into the walltime constraint, based on the wall time between
@@ -292,95 +292,95 @@ subroutine finalize_step(infile, logfile, evfile, dumpfile)
 !  If we are about to write a small dump but it looks like we won't make the next dump,
 !  dump a full dump instead and stop the run
 !
- abortrun = .false.
- if (twallmax > 1.) then
-    twallused = t2-tstart
-    twallperdump = t2-twalllast
-    if (fulldump) then
-       if ((twallused + abs(nfulldump)*twallperdump) > twallmax) then
-          abortrun = .true.
-       endif
-    else
-       if ((twallused + twallperdump) > twallmax) then
-          fulldump = .true.
-          abortrun = .true.
-          write(iprint,"(1x,a)") '>> PROMOTING DUMP TO FULL DUMP BASED ON WALL TIME CONSTRAINTS... '
-          nfulldump = 1  !  also set all future dumps to be full dumps (otherwise gets confusing)
+    abortrun = .false.
+    if (twallmax > 1.) then
+       twallused = t2-tstart
+       twallperdump = t2-twalllast
+       if (fulldump) then
+          if ((twallused + abs(nfulldump)*twallperdump) > twallmax) then
+             abortrun = .true.
+          endif
+       else
+          if ((twallused + twallperdump) > twallmax) then
+             fulldump = .true.
+             abortrun = .true.
+             write(iprint,"(1x,a)") '>> PROMOTING DUMP TO FULL DUMP BASED ON WALL TIME CONSTRAINTS... '
+             nfulldump = 1  !  also set all future dumps to be full dumps (otherwise gets confusing)
+          endif
        endif
     endif
- endif
 !
 !--flush any buffered warnings to the log file
 !
- if (id==master) call flush_warnings()
+    if (id==master) call flush_warnings()
 !
 !--write dump file
 !
- at_dump_time = .true.
- if (fulldump) then
-    call write_fulldump(time,dumpfile)
-    if (id==master) then
-       call write_infile(infile,logfile,evfile,dumpfile,iwritein,iprint)
+    at_dump_time = .true.
+    if (fulldump) then
+       call write_fulldump(time,dumpfile)
+       if (id==master) then
+          call write_infile(infile,logfile,evfile,dumpfile,iwritein,iprint)
 #ifdef DRIVING
-       call write_forcingdump(time,dumpfile)
+          call write_forcingdump(time,dumpfile)
 #endif
-    endif
-    ncount_fulldumps = ncount_fulldumps + 1
+       endif
+       ncount_fulldumps = ncount_fulldumps + 1
 
 #ifndef IND_TIMESTEPS
 #endif
- else
-    call write_smalldump(time,dumpfile)
- endif
+    else
+       call write_smalldump(time,dumpfile)
+    endif
 
- if (id==master) call print_timinginfo(iprint,nsteps,nsteplast,t2,tstart,&
+    if (id==master) call print_timinginfo(iprint,nsteps,nsteplast,t2,tstart,&
                               tcpu,tcpustep,tcputot,twalllast,tstep,tev,tcpuev)
 #ifdef IND_TIMESTEPS
- !--print summary of timestep bins
- if (iverbose >= 0 .and. id==master .and. abs(tall) > tiny(tall) .and. ntot > 0) then
-    fracactive = nmovedtot/real(ntot)
-    speedup = (t2-twalllast)/(tall + tiny(tall))
-    write(iprint,"(/,a,f6.2,'%')") ' IND TIMESTEPS efficiency = ',100.*fracactive/speedup
-    if (iverbose >= 1) then
-       write(iprint,"(a,1pe14.2,'s')") '  wall time per particle (last full step) : ',tall/real(ntot)
-       write(iprint,"(a,1pe14.2,'s')") '  wall time per particle (ave. all steps) : ',(t2-twalllast)/real(nmovedtot)
+    !--print summary of timestep bins
+    if (iverbose >= 0 .and. id==master .and. abs(tall) > tiny(tall) .and. ntot > 0) then
+       fracactive = nmovedtot/real(ntot)
+       speedup = (t2-twalllast)/(tall + tiny(tall))
+       write(iprint,"(/,a,f6.2,'%')") ' IND TIMESTEPS efficiency = ',100.*fracactive/speedup
+       if (iverbose >= 1) then
+          write(iprint,"(a,1pe14.2,'s')") '  wall time per particle (last full step) : ',tall/real(ntot)
+          write(iprint,"(a,1pe14.2,'s')") '  wall time per particle (ave. all steps) : ',(t2-twalllast)/real(nmovedtot)
+       endif
     endif
- endif
- if (iverbose >= 0) then
-    call write_binsummary(npart,nbinmax,dtmax,timeperbin,iphase,ibin,xyzh)
-    timeperbin(:) = 0.
- endif
- tlast = tprint
- istepfrac = 0
- nmovedtot = 0
+    if (iverbose >= 0) then
+       call write_binsummary(npart,nbinmax,dtmax,timeperbin,iphase,ibin,xyzh)
+       timeperbin(:) = 0.
+    endif
+    tlast = tprint
+    istepfrac = 0
+    nmovedtot = 0
 #endif
- !
- !--if twallmax > 1s stop the run at the last full dump that will fit into the walltime constraint,
- !  based on the wall time between the last two dumps added to the current total walltime used.
- !
- if (abortrun) then
-    call print_time(t2-tstart,'>> WALL TIME = ',iprint)
-    call print_time(twallmax,'>> NEXT DUMP WILL TRIP OVER MAX WALL TIME: ',iprint)
-    write(iprint,"(1x,a)") '>> ABORTING... '
-    return
+    !
+    !--if twallmax > 1s stop the run at the last full dump that will fit into the walltime constraint,
+    !  based on the wall time between the last two dumps added to the current total walltime used.
+    !
+    if (abortrun) then
+       call print_time(t2-tstart,'>> WALL TIME = ',iprint)
+       call print_time(twallmax,'>> NEXT DUMP WILL TRIP OVER MAX WALL TIME: ',iprint)
+       write(iprint,"(1x,a)") '>> ABORTING... '
+       return
+    endif
+
+    if (nmaxdumps > 0 .and. ncount_fulldumps >= nmaxdumps) then
+       write(iprint,"(a)") '>> reached maximum number of full dumps as specified in input file, stopping...'
+       return
+    endif
+
+    twalllast = t2
+    tcpulast = tcpu2
+    tstep = 0.
+    tcpustep = 0.
+    tev = 0.
+    tcpuev = 0.
+
+    noutput = noutput + 1
+    tprint = tzero + noutput*dtmax
+    nsteplast = nsteps
  endif
-
- if (nmaxdumps > 0 .and. ncount_fulldumps >= nmaxdumps) then
-    write(iprint,"(a)") '>> reached maximum number of full dumps as specified in input file, stopping...'
-    return
- endif
-
- twalllast = t2
- tcpulast = tcpu2
- tstep = 0.
- tcpustep = 0.
- tev = 0.
- tcpuev = 0.
-
- noutput = noutput + 1
- tprint = tzero + noutput*dtmax
- nsteplast = nsteps
-endif
 !
 !--Calculate total energy etc and write to ev file
 !  For individual timesteps, we do not want to do this every step, but we want
@@ -388,30 +388,30 @@ endif
 !  here is that it is done once >10% of particles (cumulatively) have been evolved.
 !  That is, either >10% are being stepped, or e.g. 1% have moved 10 steps.
 !
-nskipped = nskipped + nskip
-if (nskipped >= nevwrite_threshold .or. at_dump_time) then
-   nskipped = 0
-   call get_timings(t1,tcpu1)
-   call write_evfile(time,dt)
-   !--timings for step call
-   call get_timings(t2,tcpu2)
-   tev= tev + t2-t1
-   tcpuev = tcpuev + tcpu2-tcpu1
-   if (at_dump_time .and. id==master) call write_evlog(iprint)
-   if (id==master .and. iverbose >= 1) write(iprint,*) ' etot = ',etot,' momtot = ',totmom
-endif
+ nskipped = nskipped + nskip
+ if (nskipped >= nevwrite_threshold .or. at_dump_time) then
+    nskipped = 0
+    call get_timings(t1,tcpu1)
+    call write_evfile(time,dt)
+    !--timings for step call
+    call get_timings(t2,tcpu2)
+    tev= tev + t2-t1
+    tcpuev = tcpuev + tcpu2-tcpu1
+    if (at_dump_time .and. id==master) call write_evlog(iprint)
+    if (id==master .and. iverbose >= 1) write(iprint,*) ' etot = ',etot,' momtot = ',totmom
+ endif
 
 #ifdef CORRECT_BULK_MOTION
-call correct_bulk_motion()
+ call correct_bulk_motion()
 #endif
 
 #ifndef IND_TIMESTEPS
  !--reach tprint exactly. must take this out for integrator to be symplectic
-if (dt >= (tprint-time)) dt = tprint-time + epsilon(0.)
+ if (dt >= (tprint-time)) dt = tprint-time + epsilon(0.)
 #endif
 
-if (iverbose >= 1 .and. id==master) write(iprint,*)
-call flush(iprint)
+ if (iverbose >= 1 .and. id==master) write(iprint,*)
+ call flush(iprint)
 end subroutine finalize_step
 
 subroutine evol(infile,logfile,evfile,dumpfile)

--- a/src/utils/moddump_binary.f90
+++ b/src/utils/moddump_binary.f90
@@ -587,7 +587,7 @@ subroutine transform_from_corotating_to_inertial_frame(xyzh,vxyzu,npart,nptmass,
     vxyz_ptmass(3,i) = vxyz_ptmass(3,i) + omegacrossr(3)
  enddo
 
-end subroutine
+end subroutine transform_from_corotating_to_inertial_frame
 
 subroutine set_trinary(mprimary,msecondary,mtertiary,semimajoraxis12,semimajoraxis13,&
                       accretion_radius1,accretion_radius2,accretion_radius3,&

--- a/src/utils/moddump_binary.f90
+++ b/src/utils/moddump_binary.f90
@@ -47,12 +47,12 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  integer, intent(inout)    :: npartoftype(:)
  real,    intent(inout)    :: massoftype(:)
  real,    intent(inout)    :: xyzh(:,:),vxyzu(:,:)
- integer                   :: i,ierr,setup_case,two_sink_case = 1,three_sink_case = 1,irhomax,n
+ integer                   :: i,ierr,setup_case,ioption=1,irhomax,n
  integer                   :: iremove = 2
- integer                   :: nstar1,nstar2
+ integer                   :: nstar1,nstar2,nptmass1
  real                      :: primary_mass,companion_mass_1,companion_mass_2,mass_ratio,m1,a,hsoft2
  real                      :: mass_donor,separation,newCoM,period,m2,primarycore_xpos_old
- real                      :: a1,a2,e,omega_vec(3),omegacrossr(3),vr = 0.0,hsoft_default = 3
+ real                      :: a1,a2,e,vr = 0.0,hsoft_default = 3
  real                      :: hacc1,hacc2,hacc3,hsoft_primary,mcore,comp_shift=100,sink_dist,vel_shift
  real                      :: mcut,rcut,Mstar,radi,rhopart,rhomax = 0.0
  real                      :: time2,hfact2
@@ -66,9 +66,10 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  if (nptmass > 3) then
     stop 'ERROR: Number of sink particles > 3'
  elseif (nptmass == 3) then
+    print*, 'Three sink particles are present. Choose option below:'
     print "(1(/,a))",'1) Remove a sink from the simulation'
-    call prompt('Select option above : ',three_sink_case)
-    select case(three_sink_case)
+    call prompt('Select option above : ',ioption)
+    select case(ioption)
 
     case(1)
        do i=1,nptmass
@@ -88,38 +89,26 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
     end select
 
  elseif (nptmass == 2) then
-    print*, 'Two sinks present. If this is intentional, then choose option below.'
+    print*, 'Two sinks particles are present. Choose option below:'
 
-    print "(2(/,a))",'1) Switch from corotating frame to normal frame', &
-                     '2) Change the position of the companion'
-    call prompt('Select option above : ',two_sink_case)
-    select case(two_sink_case)
+    print "(3(/,a))",'1) Transform from corotating frame to inertial frame', &
+                     '2) Shift companion position in the co-rotating frame', &
+                     '3) Add velocity to companion'
+    call prompt('Select option above : ',ioption)
+    select case(ioption)
 
     case(1)
        call prompt('Please write the name of the input file : ',filename)
        call open_db_from_file(db,filename,20,ierr)
        call read_inopt(omega_corotate,'omega_corotate',db)
        call close_db(db)
-       iexternalforce = 0
-       omega_vec = (/ 0.,0.,omega_corotate /)
-       do i=1,npart
-          call cross(omega_vec,xyzh(:3,i),omegacrossr)
-          vxyzu(1,i) = vxyzu(1,i) + omegacrossr(1)
-          vxyzu(2,i) = vxyzu(2,i) + omegacrossr(2)
-          vxyzu(3,i) = vxyzu(3,i) + omegacrossr(3)
-       enddo
-       do i=1,nptmass
-          call cross(omega_vec,xyzmh_ptmass(:3,i),omegacrossr)
-          vxyz_ptmass(1,i) = vxyz_ptmass(1,i) + omegacrossr(1)
-          vxyz_ptmass(2,i) = vxyz_ptmass(2,i) + omegacrossr(2)
-          vxyz_ptmass(3,i) = vxyz_ptmass(3,i) + omegacrossr(3)
-       enddo
+       call transform_from_corotating_to_inertial_frame(xyzh,vxyzu,npart,nptmass,omega_corotate,xyzmh_ptmass,vxyz_ptmass)
 
     case(2)
        call prompt('How many code units to shift companion (+ve is towards primary)?',comp_shift)
        sink_dist = sqrt((xyzmh_ptmass(1,1)-xyzmh_ptmass(1,2))**2 &
-                 + (xyzmh_ptmass(2,1)-xyzmh_ptmass(2,2))**2 &
-                 + (xyzmh_ptmass(3,1)-xyzmh_ptmass(3,2))**2)
+                      + (xyzmh_ptmass(2,1)-xyzmh_ptmass(2,2))**2 &
+                      + (xyzmh_ptmass(3,1)-xyzmh_ptmass(3,2))**2)
 
        xyzmh_ptmass(1,2) = -(comp_shift/sink_dist * (xyzmh_ptmass(1,2)-xyzmh_ptmass(1,1)) - xyzmh_ptmass(1,2))
        xyzmh_ptmass(2,2) = -(comp_shift/sink_dist * (xyzmh_ptmass(2,2)-xyzmh_ptmass(2,1)) - xyzmh_ptmass(2,2))
@@ -157,9 +146,8 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
 
        call reset_centreofmass(npart,xyzh,vxyzu,nptmass,xyzmh_ptmass,vxyz_ptmass)
     end select
- else
 
-    !choose what to do with the star: set a binary or setup a magnetic field
+ else
     print "(8(/,a))",'1) Set up a binary system by adding a sink companion', &
                      '2) Set up a magnetic field in the star', &
                      '3) Manually cut profile to create sink in core', &
@@ -173,96 +161,81 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
     call prompt('Choose a setup option ',setup_case,1,8)
 
     select case(setup_case)
-
     case(1,8)
-       !takes necessary inputs from user 1
-       print*, 'Current mass unit is ', umass,'g):'
+       ! set binary defaults
        companion_mass_1 = 0.6
-       call prompt('Enter companion mass in code units',companion_mass_1,0.) ! For case 8, eventually want to read mass of star 2 from header instead of prompting it
-
-       print*, 'Current length unit is ', udist ,'cm):'
        a1 = 100.
-       call prompt('Enter orbit semi-major axis in code units', a1, 0.0)
-
        e = 0.0
-       call prompt('Enter orbit eccentricity', e, 0.0, 1.0)
+       mcore = 0.
+       hacc1 = 0.
+       hacc2 = 0.
+       print*, 'Current mass unit is ', umass,'g):'
+       call prompt('Enter companion mass in code units',companion_mass_1,0.) ! For case 8, eventually want to read mass of star 2 from header instead of prompting it
+       print*, 'Current length unit is ', udist ,'cm):'
+       call prompt('Enter orbit semi-major axis in code units', a1, 0.)
+       call prompt('Enter orbit eccentricity', e, 0., 1.)
        call prompt('Enter companion radial velocity', vr)
 
-       print*, 'Current length unit is ', udist ,'cm):'
-
-       if (nptmass == 1) then ! there is a primary core -> add point mass secondary
+       if (nptmass == 1) then ! there is a sink stellar core
+          mcore = xyzmh_ptmass(4,1)
           hacc1 = xyzmh_ptmass(ihacc,1)
           print*, 'Current accretion radius of primary core is ', hacc1,' code units'
-          call prompt('Enter accretion radius for the primary core in code units', hacc1, 0.0)
-          hacc2 = 0. ! Just a dummy
-          call prompt('Enter accretion radius for the companion in code units', hacc2, 0.0)
-       elseif (nptmass == 0) then ! there is no core -> add coreless secondary
-          ! Just dummy values
-          hacc1 = 0.
+          call prompt('Enter accretion radius for the primary core in code units', hacc1, 0.)
           hacc2 = 0.
+          call prompt('Enter accretion radius for the companion in code units', hacc2, 0.)
        endif
 
        corotate_answer = .false.
-       call prompt('Do you want a corotating frame with a corotating binary?', corotate_answer)
-
+       call prompt('Do you want to transform to a corotating frame and simulate corotating binary?', corotate_answer)
        call reset_centreofmass(npart,xyzh,vxyzu,nptmass,xyzmh_ptmass,vxyz_ptmass)
 
        !removes the dead or accreted particles for a correct total mass computation
        call delete_dead_or_accreted_particles(npart,npartoftype)
        print*,' Got ',npart,npartoftype(igas),' after deleting accreted particles'
 
-       !sets up the binary system orbital parameters
-       if (nptmass == 1) then
-          mcore = xyzmh_ptmass(4,1)
-       elseif (nptmass == 0) then
-          mcore = 0.
-       endif
-
        primary_mass = npartoftype(igas) * massoftype(igas) + mcore
        print*, 'Current primary mass in code units is ',primary_mass
 
-       !save value of primary core hsoft before setting up binary
+       ! stash primary core hsoft before calling set_binary, which resets the softening lengths
        hsoft_primary = xyzmh_ptmass(ihsoft,1)
 
-       !sets the binary
-       if (corotate_answer) then !corotating frame
-          !turns on corotation
-          iexternalforce = iext_corotate
-
+       ! set the binary
+       if (corotate_answer) then ! corotating frame
+          iexternalforce = iext_corotate  !turns on corotation
           call set_binary(primary_mass,companion_mass_1,a1,e,hacc1,hacc2,xyzmh_ptmass,vxyz_ptmass,nptmass,ierr,omega_corotate)
-
           print "(/,a,es18.10,/)", ' The angular velocity in the corotating frame is: ', omega_corotate
-
-          !sets all the gas velocities in corotating frame to 0, implying that the binary is corotating
-          !for the moment only a corotating binary can be built in the corotating frame
+          
+          ! set all the gas velocities in corotating frame to 0, implying that the binary is corotating
+          ! at the moment, only a corotating binary can be set up in the corotating frame
           do i=1,npart
-             vxyzu(1,i) = 0.0
-             vxyzu(2,i) = 0.0
-             vxyzu(3,i) = 0.0
+             vxyzu(1:3,i) = 0.
           enddo
-       else !non corotating frame
+       else ! non corotating frame
           call set_binary(primary_mass,companion_mass_1,a1,e,hacc1,hacc2,xyzmh_ptmass,vxyz_ptmass,nptmass,ierr)
           ! sink no. 2 & 3 are created by "set_binary" in the ptmass arrays
        endif
 
        if (nptmass == 3) then ! if original star has a point mass core
-          !new primary from pos 2 to 1
+          !move primary core from pos 2 to 1
           xyzmh_ptmass(1:3,1) = xyzmh_ptmass(1:3,2)
           vxyz_ptmass(1:3,1) = vxyz_ptmass(1:3,2)
 
-          !new companion from pos 3 to 2
+          !move companion point mass from pos 3 to 2
           xyzmh_ptmass(:,2) = xyzmh_ptmass(:,3)
           vxyz_ptmass(1:3,2) = vxyz_ptmass(1:3,3)
           vxyz_ptmass(1,2) = vxyz_ptmass(1,2) + vr
 
-          ! Delete third point mass
-          nptmass = nptmass - 1
+          if (setup_case == 1) then  ! Assume companion should be a sink particle
+             nptmass = nptmass - 1  ! Delete point mass 3 (duplicate of companion)
+          elseif (setup_case == 8) then  ! Companion does not contain a sink particle and is read from second dumpfile
+             nptmass = nptmass - 2  ! Delete point masses 2 and 3, leaving just the primary core
+          endif
 
           !takes necessary inputs from user 2 (the softening lengths for the sinks have to be taken in input after using the "set_binary" function since it resets them)
           xyzmh_ptmass(ihsoft,1) = hsoft_primary
           print*, 'Current softening length of the primary core is ', xyzmh_ptmass(ihsoft,1),' code units'
           call prompt('Enter softening length for the primary core',xyzmh_ptmass(ihsoft,1),0.)
-          call prompt('Enter softening length for companion',xyzmh_ptmass(ihsoft,2),0.)
+          if (setup_case == 1) call prompt('Enter softening length for companion',xyzmh_ptmass(ihsoft,2),0.)
 
        elseif (nptmass == 2) then ! if original star is coreless
           ! Just need to delete both point masses
@@ -294,7 +267,9 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
           endif
 
           ! read dump file containing star 2
+          nptmass1 = nptmass  ! stash nptmass for dump 1, as read_dumps overwrites it
           call read_dump(trim(dumpname),time2,hfact2,idisk1+1,iprint,0,1,ierr)
+          nptmass = nptmass1 + nptmass  ! set nptmass to be sum of nptmass in dump 1 and dump 2 
           if (ierr /= 0) stop 'error reading second dump file'
 
           if (nstar1 > nstar2) then ! Move ith particle of star 1 to nstar2+i
@@ -318,7 +293,6 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
           enddo
 
        endif
-
        call reset_centreofmass(npart,xyzh,vxyzu,nptmass,xyzmh_ptmass,vxyz_ptmass)
 
     case(2)
@@ -574,21 +548,7 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
           vxyz_ptmass(1:3,1) = 0.
        endif
 
-       ! Transform from corotating to inertial frame
-       iexternalforce = 0
-       omega_vec = (/ 0.,0.,omega_corotate /)
-       do i = 1,npart
-          call cross(omega_vec,xyzh(:3,i),omegacrossr)
-          vxyzu(1,i) = vxyzu(1,i) + omegacrossr(1)
-          vxyzu(2,i) = vxyzu(2,i) + omegacrossr(2)
-          vxyzu(3,i) = vxyzu(3,i) + omegacrossr(3)
-       enddo
-       do i = 1,2
-          call cross(omega_vec,xyzmh_ptmass(:3,i),omegacrossr)
-          vxyz_ptmass(1,i) = vxyz_ptmass(1,i) + omegacrossr(1)
-          vxyz_ptmass(2,i) = vxyz_ptmass(2,i) + omegacrossr(2)
-          vxyz_ptmass(3,i) = vxyz_ptmass(3,i) + omegacrossr(3)
-       enddo
+       call transform_from_corotating_to_inertial_frame(xyzh,vxyzu,npart,nptmass,omega_corotate,xyzmh_ptmass,vxyz_ptmass)
        call reset_centreofmass(npart,xyzh,vxyzu,nptmass,xyzmh_ptmass,vxyz_ptmass)
 
        ! Set tmax and dtmax
@@ -602,18 +562,32 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  return
 end subroutine modify_dump
 
-subroutine cross(a,b,c)
 
- ! Return the vector cross product of two 3d vectors
- implicit none
- real,intent(in),dimension(3)  :: a,b
- real,intent(out),dimension(3) :: c
+subroutine transform_from_corotating_to_inertial_frame(xyzh,vxyzu,npart,nptmass,omega_corotate,xyzmh_ptmass,vxyz_ptmass)
+ use options,     only:iexternalforce
+ use vectorutils, only:cross_product3D
+ integer, intent(in) :: npart,nptmass
+ real, intent(in) :: omega_corotate,xyzh(:,:),xyzmh_ptmass(:,:)
+ real, intent(inout) :: vxyzu(:,:),vxyz_ptmass(:,:)
+ real, dimension(3) :: omega_vec,omegacrossr
+ integer :: i
 
- c(1) = a(2)*b(3)-b(2)*a(3)
- c(2) = a(3)*b(1)-b(3)*a(1)
- c(3) = a(1)*b(2)-b(1)*a(2)
+ iexternalforce = 0
+ omega_vec = (/ 0.,0.,omega_corotate /)
+ do i=1,npart
+    call cross_product3D(omega_vec,xyzh(1:3,i),omegacrossr)
+    vxyzu(1,i) = vxyzu(1,i) + omegacrossr(1)
+    vxyzu(2,i) = vxyzu(2,i) + omegacrossr(2)
+    vxyzu(3,i) = vxyzu(3,i) + omegacrossr(3)
+ enddo
+ do i=1,nptmass
+    call cross_product3D(omega_vec,xyzmh_ptmass(1:3,i),omegacrossr)
+    vxyz_ptmass(1,i) = vxyz_ptmass(1,i) + omegacrossr(1)
+    vxyz_ptmass(2,i) = vxyz_ptmass(2,i) + omegacrossr(2)
+    vxyz_ptmass(3,i) = vxyz_ptmass(3,i) + omegacrossr(3)
+ enddo
 
-end subroutine cross
+end subroutine
 
 subroutine set_trinary(mprimary,msecondary,mtertiary,semimajoraxis12,semimajoraxis13,&
                       accretion_radius1,accretion_radius2,accretion_radius3,&

--- a/src/utils/moddump_binary.f90
+++ b/src/utils/moddump_binary.f90
@@ -204,7 +204,7 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
           iexternalforce = iext_corotate  !turns on corotation
           call set_binary(primary_mass,companion_mass_1,a1,e,hacc1,hacc2,xyzmh_ptmass,vxyz_ptmass,nptmass,ierr,omega_corotate)
           print "(/,a,es18.10,/)", ' The angular velocity in the corotating frame is: ', omega_corotate
-          
+
           ! set all the gas velocities in corotating frame to 0, implying that the binary is corotating
           ! at the moment, only a corotating binary can be set up in the corotating frame
           do i=1,npart
@@ -269,7 +269,7 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
           ! read dump file containing star 2
           nptmass1 = nptmass  ! stash nptmass for dump 1, as read_dumps overwrites it
           call read_dump(trim(dumpname),time2,hfact2,idisk1+1,iprint,0,1,ierr)
-          nptmass = nptmass1 + nptmass  ! set nptmass to be sum of nptmass in dump 1 and dump 2 
+          nptmass = nptmass1 + nptmass  ! set nptmass to be sum of nptmass in dump 1 and dump 2
           if (ierr /= 0) stop 'error reading second dump file'
 
           if (nstar1 > nstar2) then ! Move ith particle of star 1 to nstar2+i

--- a/src/utils/moddump_binary.f90
+++ b/src/utils/moddump_binary.f90
@@ -16,7 +16,7 @@ module moddump
 !
 ! :Dependencies: centreofmass, dim, extern_corotate, externalforces,
 !   infile_utils, io, options, part, physcon, prompting, readwrite_dumps,
-!   rho_profile, setbinary, table_utils, timestep, units
+!   rho_profile, setbinary, table_utils, timestep, units, vectorutils
 !
  implicit none
 

--- a/src/utils/moddump_recalcuT.f90
+++ b/src/utils/moddump_recalcuT.f90
@@ -22,8 +22,10 @@ module moddump
 contains
 
 subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
- use eos, only:equationofstate,ieos,init_eos,done_init_eos,calc_temp_and_ene,finish_eos,gmw,X_in,Z_in,irecomb,gamma
- use part, only:rhoh,eos_vars,itemp,igasP,igas,store_temperature
+ use eos,   only:equationofstate,ieos,init_eos,done_init_eos,calc_temp_and_ene,finish_eos,&
+                 gmw,X_in,Z_in,irecomb,gamma,eosinfo
+ use io,    only:iprint
+ use part,  only:rhoh,eos_vars,itemp,igasP,igas,store_temperature
  use units, only:unit_density,unit_pressure,unit_ergg
  integer, intent(inout) :: npart
  integer, intent(inout) :: npartoftype(:)
@@ -33,14 +35,11 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  real :: densi,eni,tempi,ponrhoi
  real :: dum,dum2
 
- !-SET-EOS-OF-INPUT-DUMP--------
- ieos = 12
- gamma = 5./3.
- gmw = 0.61821
- !--------------------------
- print*,'Assuming input dump has ieos = ',ieos
- if (ieos==12 .or. ieos==2) print*,'Assuming input dump has gmw = ',gmw,'gamma=',gamma
+ write(iprint,"(/,a,i2)") 'Assuming input dump has ieos = ',ieos
  if (.not. done_init_eos) call init_eos(ieos,ierr)
+ call eosinfo(ieos,iprint)
+ print*,'Check if this is correct. Enter to proceed'
+ read*
 
  dum = 0.0
  do i = 1,npart
@@ -52,15 +51,23 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  enddo
 
  !-SET-EOS-OF-OUTPUT-DUMP--------
- ieos = 20
+ ! Comment out to leave quantity
+ ieos = 2
+ gamma = 5./3.
+ gmw = 0.60319
  irecomb = 2
  if (ieos == 10) then
     X_in = 0.69843
     Z_in = 0.01426
  endif
- !--------------------------
+ !-------------------------------
+
+ write(iprint,"(/,a,i2)")'Changing to ieos = ',ieos
  call init_eos(ieos,ierr)
- print*,'Changing to ieos = ',ieos
+ call eosinfo(ieos,iprint)
+ print*,'Check if this is correct. Enter to proceed'
+ read*
+
  tempi = 0.
  do i = 1,npart
     densi = rhoh(xyzh(4,i),massoftype(igas))

--- a/src/utils/moddump_recalcuT.f90
+++ b/src/utils/moddump_recalcuT.f90
@@ -15,7 +15,7 @@ module moddump
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: eos, part, units
+! :Dependencies: eos, io, part, units
 !
  implicit none
 


### PR DESCRIPTION
Type of PR: 
Minor functionalities and cleanup

Description:
* Cleanup of `moddump_binary` and generalise the ability to add a companion star from a second dump file.
* Change`moddump_recalcuT` to use eos parameters from input dump instead of relying on user input.
* Update `eosinfo` to print mean molecular weight, `gmw`.

Testing:
Code compiles for my setup and used it to set up a stellar binary.

Did you run the bots? yes/no
Yes