### PR TITLE
Fix incorrectly reduced variables in nimhd test

### DIFF
--- a/src/tests/test_nonidealmhd.F90
+++ b/src/tests/test_nonidealmhd.F90
@@ -297,7 +297,7 @@ subroutine test_standingshock(ntests,npass)
  real                   :: t,dt,dtext,dtnew
  real                   :: dexact,bexact,vexact,L2d,L2v,L2b,dx
  real                   :: leftstate(8),rightstate(8),exact_x(51),exact_d(51),exact_vx(51),exact_by(51)
- real, parameter        :: told = 2.1d-2, tolv=3.1d-2, tolb=3.1d-2
+ real, parameter        :: told = 2.1d-2, tolv=3.1d-2, tolb=1.e-1
  logical                :: valid_dt
  logical, parameter     :: print_output = .false.
  logical                :: valid_bdy_rho,valid_bdy_v

--- a/src/tests/test_nonidealmhd.F90
+++ b/src/tests/test_nonidealmhd.F90
@@ -297,7 +297,7 @@ subroutine test_standingshock(ntests,npass)
  real                   :: t,dt,dtext,dtnew
  real                   :: dexact,bexact,vexact,L2d,L2v,L2b,dx
  real                   :: leftstate(8),rightstate(8),exact_x(51),exact_d(51),exact_vx(51),exact_by(51)
- real, parameter        :: told = 2.1d-2, tolv=3.1d-2, tolb=1.e-1
+ real, parameter        :: told = 2.1d-2, tolv=3.1d-2, tolb=1.1d-1
  logical                :: valid_dt
  logical, parameter     :: print_output = .false.
  logical                :: valid_bdy_rho,valid_bdy_v

--- a/src/tests/test_nonidealmhd.F90
+++ b/src/tests/test_nonidealmhd.F90
@@ -498,8 +498,8 @@ subroutine test_standingshock(ntests,npass)
  endif
  npts = int(reduceall_mpi('+',npts))
  L2d  = reduceall_mpi('+',L2d)
- L2v  = reduceall_mpi('+',L2d)
- L2b  = reduceall_mpi('+',L2d)
+ L2v  = reduceall_mpi('+',L2v)
+ L2b  = reduceall_mpi('+',L2b)
  if (npts > 0) then
     L2d = sqrt(L2d/npts)
     L2v = sqrt(L2v/npts)


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
Required for #217 

In a93bc90e41e7ad7e777d623b81fd6adeff097fd1, as part of implementing MPI support for nimhd tests, the L2 error variables were reduced across tasks.

There is a typo resulting in the `v_x` and `B_y` error being overwritten by the density error. This produces a test failure due to the tolerance not being met.

In df72df1c12c5588a17824ad6e78fe4c581a21e9f, NICIL 2.1 was added to phantom, where the tolerance for `B_y` was changed to `tolb=3.1d-2`. This was change was made possibly because the apparent improved accuracy was wrongly attributed to improvements to the code, rather than because the the density error was overwriting the `B_y` error.

`tolb` has been reverted to the original value of `1.1d-1`.

This bug is not yet covered by the automated test suite because #217 has not been merged yet, and needs to be tested manually using the commands below.

Testing:
```
make MPI=yes SETUP=testnimhd OPENMP=no phantomtest
mpirun -n 4 bin/phantomtest nimhd
```

Did you run the bots? no, not required
