### PR TITLE
diffdumps: return a non-zero exit code if files differ

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,11 +27,11 @@ Hauke Worpel <hworpel@aip.de>
 Roberto Iaconi <robertoiaconi1@gmail.com>
 Simon Glover <glover@uni-heidelberg.de>
 Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
+Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
 Martina Toscani <mtoscani94@gmail.com>
 Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Simone Ceppi <simo.ceppi@gmail.com>
-Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Christopher Russell <crussell@udel.edu>
 Megha Sharma <msha0023@student.monash.edu>
 Alessia Franchini <alessia.franchini@unlv.edu>

--- a/src/utils/diffdumps.f90
+++ b/src/utils/diffdumps.f90
@@ -134,7 +134,8 @@ program diffdumps
     print "(/,a)",' FILES ARE IDENTICAL '
  endif
 
-!  Exit code = number of lines that differ
- call exit(ndiff)
+ if (ndiff > 0) then
+    call exit(1)
+ endif
 
 end program diffdumps

--- a/src/utils/diffdumps.f90
+++ b/src/utils/diffdumps.f90
@@ -134,4 +134,7 @@ program diffdumps
     print "(/,a)",' FILES ARE IDENTICAL '
  endif
 
+!  Exit code = number of lines that differ
+ call exit(ndiff)
+
 end program diffdumps


### PR DESCRIPTION
Type of PR: 
modification to existing code

Description:
Return a non-zero exit code from diffdumps when the files differ.

This change is needed to resolve (along with https://github.com/phantomSPH/phantom-benchmarks/pull/15) https://github.com/phantomSPH/phantom-benchmarks/issues/14

Testing:
Benchmark tests: `./run-benchmarks.sh`

Did you run the bots? yes, pre-commit
