### PR TITLE
Lock benchmark version

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -64,7 +64,6 @@ jobs:
       with:
         repository: phantomSPH/phantom-benchmarks
         path: phantom-benchmarks
-        lfs: true
 
     - name: "Get number of CPU cores"
       run: echo "::set-output name=count::$(nproc)"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,6 +15,7 @@ on:
     - cron: "0 0 * * *"
 
 env:
+  BENCH_VERSION: v1.0.0
   OMP_STACKSIZE: 512M
   WEB_SERVER: data.phantom.cloud.edu.au
   WEB_USER: github
@@ -36,6 +37,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: phantomSPH/phantom-benchmarks
+          ref:  $${ env.BENCH_VERSION }}
 
       - name: "Extract setups from directory"
         id: extract_step
@@ -64,6 +66,7 @@ jobs:
       with:
         repository: phantomSPH/phantom-benchmarks
         path: phantom-benchmarks
+        ref:  $${ env.BENCH_VERSION }}
 
     - name: "Get number of CPU cores"
       run: echo "::set-output name=count::$(nproc)"


### PR DESCRIPTION
Type of PR: 
other

Description:
Changes in https://github.com/phantomSPH/phantom-benchmarks, which are not tracked here, can change the results of the test suite because it checks out the latest version.

The commit of the benchmarks repo should be locked by checking out a specific tag, which can then only be edited in PRs to prevent changes in the benchmarks repo from unintentionally affecting test results.

This PR looks for the tag `1.0.0`, which does not exist yet at the time of writing. This PR will not pass the tests until that tag is created.

@danieljprice could you please tag the latest stable version on the benchmarks repo? Note that master is broken until https://github.com/phantomSPH/phantom-benchmarks/pull/17 is merged.

Testing:
Not required

Did you run the bots? no, not required
