### PR TITLE
Store npartoftypetot as a global variable

### DIFF
--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -131,7 +131,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
  use readwrite_infile, only:read_infile,write_infile
  use readwrite_dumps,  only:read_dump,write_fulldump
  use part,             only:npart,xyzh,vxyzu,fxyzu,fext,divcurlv,divcurlB,Bevol,dBevol,&
-                            npartoftype,maxtypes,ndusttypes,alphaind,ntot,ndim, &
+                            npartoftype,maxtypes,ndusttypes,alphaind,ntot,ndim,update_npartoftypetot,&
                             maxphase,iphase,isetphase,iamtype, &
                             nptmass,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,igas,idust,massoftype,&
                             epot_sinksink,get_ntypes,isdead_or_accreted,dustfrac,ddustevol,&
@@ -225,7 +225,6 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
  character(len=*), intent(out) :: logfile,evfile,dumpfile
  logical,          intent(in), optional :: noread
  integer         :: ierr,i,j,nerr,nwarn,ialphaloc,merge_n,merge_ij(maxptmass)
- integer(kind=8) :: npartoftypetot(maxtypes)
  real            :: poti,dtf,hfactfile,fextv(3)
  real            :: hi,pmassi,rhoi1
  real            :: dtsinkgas,dtsinksink,fonrmax,dtphi2,dtnew_first,dtinject
@@ -305,7 +304,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
 !--get total number of particles (on all processors)
 !
  ntot           = reduceall_mpi('+',npart)
- npartoftypetot = reduce_mpi('+',npartoftype)
+ call update_npartoftypetot
  if (id==master) write(iprint,"(a,i12)") ' npart total   = ',ntot
  if (npart > 0) then
     if (id==master .and. maxalpha==maxp)  write(iprint,*) 'mean alpha  initial: ',sum(alphaind(1,1:npart))/real(npart)

--- a/src/main/mpi_balance.F90
+++ b/src/main/mpi_balance.F90
@@ -96,7 +96,7 @@ end subroutine balance_init
 !----------------------------------------------------------------
 subroutine balancedomains(npart)
  use io,     only:id,master,iverbose,fatal
- use part,   only:shuffle_part,count_dead_particles,ibelong
+ use part,   only:shuffle_part,count_dead_particles,ibelong,update_npartoftypetot
  use timing, only:getused,printused
  use mpiutils, only:barrier_mpi
  implicit none
@@ -144,6 +144,10 @@ subroutine balancedomains(npart)
     print*,id,'ntot_start',ntot_start
     call fatal('balance','number of particles before and after balance not equal')
  endif
+
+ !  Update particle types
+ call update_npartoftypetot
+
  if (id==master .and. iverbose >= 3) call printused(tstart)
 
  return

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -361,8 +361,9 @@ module part
  integer(kind=8) :: ntot
  integer         :: ideadhead = 0
 
- integer :: npartoftype(maxtypes)
- real    :: massoftype(maxtypes)
+ integer         :: npartoftype(maxtypes)
+ integer(kind=8) :: npartoftypetot(maxtypes)
+ real            :: massoftype(maxtypes)
 
  integer :: ndustsmall,ndustlarge,ndusttypes
 !
@@ -564,6 +565,7 @@ subroutine init_part
  npart = 0
  nptmass = 0
  npartoftype(:) = 0
+ npartoftypetot(:) = 0
  massoftype(:)  = 0.
 !--initialise point mass arrays to zero
  xyzmh_ptmass = 0.
@@ -1802,5 +1804,12 @@ real function Omega_k(i)
  endif
 
 end function Omega_k
+
+subroutine update_npartoftypetot
+   use mpiutils, only:reduceall_mpi
+
+   npartoftypetot = reduceall_mpi('+',npartoftype)
+
+end subroutine
 
 end module part

--- a/src/main/readwrite_dumps_fortran.F90
+++ b/src/main/readwrite_dumps_fortran.F90
@@ -212,7 +212,7 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
  use eos,   only:ieos,eos_is_non_ideal,eos_outputs_mu
  use io,    only:idump,iprint,real4,id,master,error,warning,nprocs
  use part,  only:xyzh,xyzh_label,vxyzu,vxyzu_label,Bevol,Bevol_label,Bxyz,Bxyz_label,npart,maxtypes, &
-                 npartoftypetot,update_npartoftypetot, &
+                 npartoftype,npartoftypetot,update_npartoftypetot, &
                  alphaind,rhoh,divBsymm,maxphase,iphase,iamtype_int1,iamtype_int11, &
                  nptmass,nsinkproperties,xyzmh_ptmass,xyzmh_ptmass_label,vxyz_ptmass,vxyz_ptmass_label,&
                  maxptmass,get_pmass,h2chemistry,nabundances,abundance,abundance_label,mhd,&

--- a/src/main/readwrite_dumps_fortran.F90
+++ b/src/main/readwrite_dumps_fortran.F90
@@ -211,7 +211,8 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
                  lightcurve,store_temperature,use_dustgrowth,store_dust_temperature,gr
  use eos,   only:ieos,eos_is_non_ideal,eos_outputs_mu
  use io,    only:idump,iprint,real4,id,master,error,warning,nprocs
- use part,  only:xyzh,xyzh_label,vxyzu,vxyzu_label,Bevol,Bevol_label,Bxyz,Bxyz_label,npart,npartoftype,maxtypes, &
+ use part,  only:xyzh,xyzh_label,vxyzu,vxyzu_label,Bevol,Bevol_label,Bxyz,Bxyz_label,npart,maxtypes, &
+                 npartoftypetot,update_npartoftypetot, &
                  alphaind,rhoh,divBsymm,maxphase,iphase,iamtype_int1,iamtype_int11, &
                  nptmass,nsinkproperties,xyzmh_ptmass,xyzmh_ptmass_label,vxyz_ptmass,vxyz_ptmass_label,&
                  maxptmass,get_pmass,h2chemistry,nabundances,abundance,abundance_label,mhd,&
@@ -256,7 +257,7 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
  integer            :: ipass,k,l
  integer            :: ierr,ierrs(29)
  integer            :: nblocks,nblockarrays,narraylengths
- integer(kind=8)    :: nparttot,npartoftypetot(maxtypes)
+ integer(kind=8)    :: nparttot
  logical            :: sphNGdump,write_itype,use_gas
  character(len=lenid)  :: fileid
  type(dump_h)          :: hdr
@@ -267,7 +268,7 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
 !--allow non-MPI calls to create MPI dump files
 #ifdef MPI
  nparttot = reduceall_mpi('+',npart)
- npartoftypetot = reduceall_mpi('+',npartoftype)
+ call update_npartoftypetot
 #else
  if (present(ntotal)) then
     nparttot = ntotal
@@ -503,7 +504,8 @@ end subroutine write_fulldump_fortran
 subroutine write_smalldump_fortran(t,dumpfile)
  use dim,        only:maxp,maxtypes,use_dust,lightcurve,use_dustgrowth
  use io,         only:idump,iprint,real4,id,master,error,warning,nprocs
- use part,       only:xyzh,xyzh_label,npart,npartoftype,Bxyz,Bxyz_label,&
+ use part,       only:xyzh,xyzh_label,npart,Bxyz,Bxyz_label,&
+                      npartoftypetot,update_npartoftypetot,&
                       maxphase,iphase,h2chemistry,nabundances,&
                       nptmass,nsinkproperties,xyzmh_ptmass,xyzmh_ptmass_label,&
                       abundance,abundance_label,mhd,dustfrac,iamtype_int11,&
@@ -521,14 +523,14 @@ subroutine write_smalldump_fortran(t,dumpfile)
  integer         :: nums(ndatatypes,4)
  integer         :: ierr,ipass,k
  integer         :: nblocks,nblockarrays,narraylengths
- integer(kind=8) :: nparttot,npartoftypetot(maxtypes)
+ integer(kind=8) :: nparttot
  logical         :: write_itype
  type(dump_h)    :: hdr
 !
 !--collect global information from MPI threads
 !
  nparttot = reduceall_mpi('+',npart)
- npartoftypetot = reduceall_mpi('+',npartoftype)
+ call update_npartoftypetot
  nblocks = nprocs
 
  narraylengths = 2
@@ -1352,7 +1354,8 @@ subroutine unfill_header(hdr,phantomdump,got_tags,nparttot, &
  use dim,        only:maxdustlarge,use_dust
  use io,         only:master ! check this
  use eos,        only:isink
- use part,       only:maxtypes,igas,idust,ndustsmall,ndustlarge,ndusttypes
+ use part,       only:maxtypes,igas,idust,ndustsmall,ndustlarge,ndusttypes,&
+                      npartoftypetot
  use units,      only:udist,umass,utime,set_units_extra,set_units
  use dump_utils, only:extract,dump_h
  use fileutils,  only:make_tags_unique
@@ -1365,7 +1368,7 @@ subroutine unfill_header(hdr,phantomdump,got_tags,nparttot, &
  integer,         intent(out) :: ierr
  integer         :: nparttoti,npartoftypetoti(maxtypes),ntypesinfile,nptinfile
  integer         :: ierr1,ierrs(3),i,counter
- integer(kind=8) :: npartoftypetot(maxtypes),ntypesinfile8
+ integer(kind=8) :: ntypesinfile8
  character(len=10) :: dust_label(maxdustlarge)
 
  ierr = 0

--- a/src/main/readwrite_dumps_fortran.F90
+++ b/src/main/readwrite_dumps_fortran.F90
@@ -272,13 +272,13 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
 #else
  if (present(ntotal)) then
     nparttot = ntotal
-    npartoftypetot = npartoftype
+    call update_npartoftypetot
     if (all(npartoftypetot==0)) then
        npartoftypetot(1) = ntotal
     endif
  else
     nparttot = npart
-    npartoftypetot = npartoftype
+    call update_npartoftypetot
  endif
 #endif
  nblocks = nprocs

--- a/src/main/readwrite_dumps_hdf5.F90
+++ b/src/main/readwrite_dumps_hdf5.F90
@@ -109,7 +109,8 @@ subroutine write_dump_hdf5(t,dumpfile,fulldump,ntotal,dtind)
                           Bextz,ndustlarge,idust,idustbound,grainsize,         &
                           graindens,h2chemistry,lightcurve,ndivcurlB,          &
                           ndivcurlv,pxyzu,dens,gamma_chem,mu_chem,T_gas_cool,  &
-                          dust_temp,rad,radprop,itemp,igasP,eos_vars,iorig
+                          dust_temp,rad,radprop,itemp,igasP,eos_vars,iorig,    &
+                          npartoftypetot,update_npartoftypetot
 #ifdef NUCLEATION
  use part,           only:nucleation
 #endif
@@ -135,7 +136,7 @@ subroutine write_dump_hdf5(t,dumpfile,fulldump,ntotal,dtind)
 
  integer            :: i
  integer            :: ierr
- integer(kind=8)    :: nparttot,npartoftypetot(maxtypes)
+ integer(kind=8)    :: nparttot
  logical            :: ind_timesteps,const_av,prdrag,isothermal
  real, allocatable  :: dtin(:),beta_pr(:)
  character(len=200) :: fileid,fstr,sstr
@@ -167,7 +168,7 @@ subroutine write_dump_hdf5(t,dumpfile,fulldump,ntotal,dtind)
 !--allow non-MPI calls to create MPI dump files
 #ifdef MPI
  nparttot = reduceall_mpi('+',npart)
- npartoftypetot = reduceall_mpi('+',npartoftype)
+ call update_npartoftypetot
 #else
  if (present(ntotal)) then
     nparttot = ntotal

--- a/src/main/step_leapfrog.F90
+++ b/src/main/step_leapfrog.F90
@@ -101,7 +101,7 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
  use part,           only:xyzh,vxyzu,fxyzu,fext,divcurlv,divcurlB,Bevol,dBevol, &
                           rad,drad,radprop,isdead_or_accreted,rhoh,dhdrho,&
                           iphase,iamtype,massoftype,maxphase,igas,idust,mhd,&
-                          iamboundary,get_ntypes,npartoftype,&
+                          iamboundary,get_ntypes,npartoftypetot,&
                           dustfrac,dustevol,ddustevol,eos_vars,alphaind,nptmass,&
                           dustprop,ddustprop,dustproppred,ndustsmall,pxyzu,dens,metrics,ics
  use cooling,        only:cooling_implicit,ufloor
@@ -172,7 +172,7 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
 ! velocity predictor step, using dtsph
 !--------------------------------------
  itype   = igas
- ntypes  = get_ntypes(reduceall_mpi('+',npartoftype))
+ ntypes  = get_ntypes(npartoftypetot)
  pmassi  = massoftype(itype)
  store_itype = (maxphase==maxp .and. ntypes > 1)
  ialphaloc = 2
@@ -422,7 +422,7 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
     np      = 0
     itype   = igas
     pmassi  = massoftype(igas)
-    ntypes  = get_ntypes(npartoftype)
+    ntypes  = get_ntypes(npartoftypetot)
     store_itype = (maxphase==maxp .and. ntypes > 1)
 !$omp parallel default(none) &
 !$omp shared(xyzh,vxyzu,vpred,fxyzu,npart,hdtsph,store_itype) &

--- a/src/main/writeheader.F90
+++ b/src/main/writeheader.F90
@@ -15,8 +15,8 @@ module writeheader
 ! :Runtime parameters: None
 !
 ! :Dependencies: boundary, cooling, dim, dust, eos, gitinfo, growth, io,
-!   kernel, metric_tools, options, part, physcon, readwrite_infile, units,
-!   viscosity
+!   kernel, metric_tools, mpiutils, options, part, physcon,
+!   readwrite_infile, units, viscosity
 !
  implicit none
  public :: write_header,write_codeinfo
@@ -82,6 +82,7 @@ subroutine write_header(icall,infile,evfile,logfile,dumpfile,ntot)
  use part,             only:hfact,massoftype,mhd,&
                             gravity,h2chemistry,periodic,npartoftype,massoftype,&
                             labeltype,maxtypes
+ use mpiutils,         only:reduceall_mpi
  use eos,              only:eosinfo
  use cooling,          only:cooling_implicit,cooling_explicit,Tfloor,ufloor
  use readwrite_infile, only:write_infile
@@ -94,7 +95,7 @@ subroutine write_header(icall,infile,evfile,logfile,dumpfile,ntot)
 #ifdef GR
  use metric_tools,     only:print_metricinfo
 #endif
- integer                      :: Nneigh,i
+ integer                      :: Nneigh,i,npartoftypetoti
  integer,          intent(in) :: icall
  character(len=*), intent(in) :: infile,evfile,logfile,dumpfile
  integer(kind=8),  intent(in), optional :: ntot
@@ -133,9 +134,10 @@ subroutine write_header(icall,infile,evfile,logfile,dumpfile,ntot)
     if (present(ntot)) then
        write(iprint,"(/,' Number of particles = ',i12)") ntot
        do i = 1,maxtypes
-          if (npartoftype(i) > 0) then
+          npartoftypetoti = reduceall_mpi('+', npartoftype(i))
+          if (npartoftypetoti > 0) then
              write(iprint,"(1x,3a,i12,a,es14.6)") &
-                "Number & mass of ",labeltype(i)," particles: ", npartoftype(i),", ",massoftype(i)
+                "Number & mass of ",labeltype(i)," particles: ", npartoftypetoti,", ",massoftype(i)
           endif
        enddo
        write(iprint,"(a)") " "

--- a/src/main/writeheader.F90
+++ b/src/main/writeheader.F90
@@ -81,6 +81,7 @@ subroutine write_header(icall,infile,evfile,logfile,dumpfile,ntot)
  use options,          only:tolh,alpha,alphau,alphaB,ieos,alphamax,use_dustfrac
  use part,             only:hfact,massoftype,mhd,&
                             gravity,h2chemistry,periodic,npartoftype,massoftype,&
+                            npartoftypetot,&
                             labeltype,maxtypes
  use mpiutils,         only:reduceall_mpi
  use eos,              only:eosinfo
@@ -134,10 +135,9 @@ subroutine write_header(icall,infile,evfile,logfile,dumpfile,ntot)
     if (present(ntot)) then
        write(iprint,"(/,' Number of particles = ',i12)") ntot
        do i = 1,maxtypes
-          npartoftypetoti = reduceall_mpi('+', npartoftype(i))
-          if (npartoftypetoti > 0) then
+          if (npartoftypetot(i) > 0) then
              write(iprint,"(1x,3a,i12,a,es14.6)") &
-                "Number & mass of ",labeltype(i)," particles: ", npartoftypetoti,", ",massoftype(i)
+                "Number & mass of ",labeltype(i)," particles: ", npartoftypetot(i),", ",massoftype(i)
           endif
        enddo
        write(iprint,"(a)") " "


### PR DESCRIPTION
Type of PR: 
modification to existing code

Description:
`npartoftypetopt=reduceall_mpi('+',npartoftype)` is used in many places in the code, but it is always calculated on the fly. It only needs to be calculated after the number of any particle type on a task has changed. This PR stores it as a global variable in `part`, and defines a subroutine to recalculate it from `npartoftype`.

Testing:
`make test`

Did you run the bots? yes, pre-commit
