### PR TITLE
reduce summary variables using MPI

### DIFF
--- a/src/main/step_leapfrog.F90
+++ b/src/main/step_leapfrog.F90
@@ -663,6 +663,13 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
        if (gr) vxyzu = vpred ! May need primitive variables elsewhere?
     endif
  enddo iterations
+
+ ! MPI reduce summary variables
+ nwake     = int(reduceall_mpi('+', nwake))
+ nvfloorp  = int(reduceall_mpi('+', nvfloorp))
+ nvfloorps = int(reduceall_mpi('+', nvfloorps))
+ nvfloorc  = int(reduceall_mpi('+', nvfloorc))
+
  ! Summary statements & crash if velocity is not converged
  if (nwake    > 0) call summary_variable('wake', iowake,    0,real(nwake)    )
  if (nvfloorp > 0) call summary_variable('floor',iosumflrp, 0,real(nvfloorp) )


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
The summary variables `wake`, `floor`, and `tolv` were not reduced across MPI tasks, resulting in incorrect printout. This did not seem to have any effect on the actual results.

Testing:
Ran test problem to make sure summary variables were the same across all tasks

Did you run the bots? no, not required
