### PR TITLE
Fix MPI support for GR

### DIFF
--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -405,9 +405,9 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
  fext(:,:)  = 0.
 
 #ifdef GR
-! COMPUTE METRIC HERE
- call init_metric(npart,xyzh,metrics,metricderivs)
 #ifdef PRIM2CONS_FIRST
+ ! COMPUTE METRIC HERE
+ call init_metric(npart,xyzh,metrics,metricderivs)
  ! -- The conserved quantites (momentum and entropy) are being computed
  ! -- directly from the primitive values in the starting dumpfile.
  call prim2consall(npart,xyzh,metrics,vxyzu,dens,pxyzu,use_dens=.false.)
@@ -423,6 +423,8 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
                               fxyzu,fext,alphaind,gradh,rad,radprop,dvdx)
  endif
 #ifndef PRIM2CONS_FIRST
+! COMPUTE METRIC HERE
+ call init_metric(npart,xyzh,metrics,metricderivs)
  call prim2consall(npart,xyzh,metrics,vxyzu,dens,pxyzu,use_dens=.false.)
 #endif
  if (iexternalforce > 0 .and. imetric /= imet_minkowski) then

--- a/src/main/metric_tools.F90
+++ b/src/main/metric_tools.F90
@@ -181,19 +181,29 @@ subroutine print_metricinfo(iprint)
 end subroutine print_metricinfo
 
 subroutine init_metric(npart,xyzh,metrics,metricderivs)
- integer, intent(in)  :: npart
- real,    intent(in)  :: xyzh(:,:)
- real,    intent(out) :: metrics(:,:,:,:), metricderivs(:,:,:,:)
+ integer,         intent(in)  :: npart
+ real,            intent(in)  :: xyzh(:,:)
+ real,            intent(out) :: metrics(:,:,:,:)
+ real, optional,  intent(out) :: metricderivs(:,:,:,:)
  integer :: i
 
  !$omp parallel do default(none) &
- !$omp shared(npart,xyzh,metrics,metricderivs) &
+ !$omp shared(npart,xyzh,metrics) &
  !$omp private(i)
  do i=1,npart
     call pack_metric(xyzh(1:3,i),metrics(:,:,:,i))
-    call pack_metricderivs(xyzh(1:3,i),metricderivs(:,:,:,i))
  enddo
  !omp end parallel do
+
+ if (present(metricderivs)) then
+   !$omp parallel do default(none) &
+   !$omp shared(npart,xyzh,metricderivs) &
+   !$omp private(i)
+   do i=1,npart
+      call pack_metricderivs(xyzh(1:3,i),metricderivs(:,:,:,i))
+   enddo
+   !omp end parallel do
+ endif
 
 end subroutine init_metric
 

--- a/src/main/metric_tools.F90
+++ b/src/main/metric_tools.F90
@@ -196,13 +196,13 @@ subroutine init_metric(npart,xyzh,metrics,metricderivs)
  !omp end parallel do
 
  if (present(metricderivs)) then
-   !$omp parallel do default(none) &
-   !$omp shared(npart,xyzh,metricderivs) &
-   !$omp private(i)
-   do i=1,npart
-      call pack_metricderivs(xyzh(1:3,i),metricderivs(:,:,:,i))
-   enddo
-   !omp end parallel do
+    !$omp parallel do default(none) &
+    !$omp shared(npart,xyzh,metricderivs) &
+    !$omp private(i)
+    do i=1,npart
+       call pack_metricderivs(xyzh(1:3,i),metricderivs(:,:,:,i))
+    enddo
+    !omp end parallel do
  endif
 
 end subroutine init_metric

--- a/src/main/mpi_dens.F90
+++ b/src/main/mpi_dens.F90
@@ -16,7 +16,7 @@ module mpidens
 !
 ! :Dependencies: dim, io, mpi, mpiutils
 !
- use io,       only:nprocs,fatal
+ use io,       only:nprocs,fatal,error
  use dim,      only:minpart,maxrhosum,maxprocs,stacksize,maxxpartvecidens
 #ifdef MPI
  use mpiutils, only:mpierr
@@ -202,7 +202,7 @@ subroutine get_mpitype_of_celldens(dtype)
  ! check extent okay
  call MPI_TYPE_GET_EXTENT(dtype,lb,extent,mpierr)
  if (extent /= sizeof(cell)) then
-   call error('mpi_dens','MPI_TYPE_GET_EXTENT has calculated the extent incorrectly')
+    call error('mpi_dens','MPI_TYPE_GET_EXTENT has calculated the extent incorrectly')
  endif
 
 end subroutine get_mpitype_of_celldens

--- a/src/main/mpi_dens.F90
+++ b/src/main/mpi_dens.F90
@@ -202,12 +202,7 @@ subroutine get_mpitype_of_celldens(dtype)
  ! check extent okay
  call MPI_TYPE_GET_EXTENT(dtype,lb,extent,mpierr)
  if (extent /= sizeof(cell)) then
-    dtype_old = dtype
-    lb = 0
-    extent = sizeof(cell)
-    call MPI_TYPE_CREATE_RESIZED(dtype_old,lb,extent,dtype,mpierr)
-    call MPI_TYPE_COMMIT(dtype,mpierr)
-    call MPI_TYPE_FREE(dtype_old,mpierr)
+   call error('mpi_dens','MPI_TYPE_GET_EXTENT has calculated the extent incorrectly')
  endif
 
 end subroutine get_mpitype_of_celldens

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -288,13 +288,18 @@ module part
  integer(kind=1), allocatable :: istsactive(:)
  integer(kind=1), allocatable :: ibin_sts(:)
 !
-!--size of the buffer required for transferring particle <<<< FIX THIS FOR GR MPI
+!--size of the buffer required for transferring particle
 !  information between MPI threads
 !
  integer, parameter, private :: usedivcurlv = min(ndivcurlv,1)
  integer, parameter :: ipartbufsize = 4 &  ! xyzh
    +maxvxyzu                            &  ! vxyzu
    +maxvxyzu                            &  ! vpred
+#ifdef GR
+   +maxvxyzu                            &  ! pxyzu
+   +maxvxyzu                            &  ! ppred
+   +1                                   &  ! dens
+#endif
    +maxvxyzu                            &  ! fxyzu
    +3                                   &  ! fext
    +usedivcurlv                         &  ! divcurlv
@@ -306,7 +311,7 @@ module part
 #endif
 #ifdef MHD
  +maxBevol                            &  ! Bevol
- +maxBevol                            &  ! Bpred
+   +maxBevol                            &  ! Bpred
 #endif
 #ifdef RADIATION
  +3*maxirad + maxradprop              &  ! rad,radpred,drad,radprop
@@ -329,29 +334,29 @@ module part
 #endif
 #ifdef NUCLEATION
  +1                                   &  ! nucleation rate
- +4                                   &  ! moments
- +1                                   &  ! mean molecular weight
+   +4                                   &  ! moments
+   +1                                   &  ! mean molecular weight
 #endif
 #ifdef KROME
  +krome_nmols                         &  ! abundance
- +1                                   &  ! variable gamma
- +1                                   &  ! variable mu
- +1                                   &  ! temperature
- +1                                   &  ! cooling rate
+   +1                                   &  ! variable gamma
+   +1                                   &  ! variable mu
+   +1                                   &  ! temperature
+   +1                                   &  ! cooling rate
 #endif
- +maxeosvars                          &  ! eos_vars
+   +maxeosvars                          &  ! eos_vars
+#ifdef SINK_RADIATION
+   +1                                   &  ! dust temperature
+#endif
 #ifdef GRAVITY
  +1                                   &  ! poten
 #endif
-#ifdef SINK_RADIATION
- +1                                   &  ! dust temperature
-#endif
 #ifdef IND_TIMESTEPS
  +1                                   &  ! ibin
- +1                                   &  ! ibin_old
- +1                                   &  ! ibin_wake
- +1                                   &  ! dt_in
- +1                                   &  ! twas
+   +1                                   &  ! ibin_old
+   +1                                   &  ! ibin_wake
+   +1                                   &  ! dt_in
+   +1                                   &  ! twas
 #endif
  +1                                   &  ! iorig
  +0
@@ -1194,7 +1199,14 @@ subroutine copy_particle_all(src,dst,new_part)
     radprop(:,dst) = radprop(:,src)
     drad(:,dst) = drad(:,src)
  endif
- if (gr) pxyzu(:,dst) = pxyzu(:,src)
+ if (gr) then
+    pxyzu(:,dst) = pxyzu(:,src)
+    if (maxgran==maxp) then
+       ppred(:,dst) = ppred(:,src)
+    endif
+    dens(dst) = dens(src)
+ endif
+
  if (ndivcurlv > 0) divcurlv(:,dst) = divcurlv(:,src)
  if (ndivcurlB > 0) divcurlB(:,dst) = divcurlB(:,src)
  if (maxdvdx ==maxp)  dvdx(:,dst) = dvdx(:,src)
@@ -1401,6 +1413,11 @@ subroutine fill_sendbuf(i,xtemp)
     call fill_buffer(xtemp,xyzh(:,i),nbuf)
     call fill_buffer(xtemp,vxyzu(:,i),nbuf)
     call fill_buffer(xtemp,vpred(:,i),nbuf)
+    if (gr) then
+       call fill_buffer(xtemp,pxyzu(:,i),nbuf)
+       call fill_buffer(xtemp,ppred(:,i),nbuf)
+       call fill_buffer(xtemp,dens(i),nbuf)
+    endif
     call fill_buffer(xtemp,fxyzu(:,i),nbuf)
     call fill_buffer(xtemp,fext(:,i),nbuf)
     if (ndivcurlv > 0) then
@@ -1475,6 +1492,11 @@ subroutine unfill_buffer(ipart,xbuf)
  xyzh(:,ipart)          = unfill_buf(xbuf,j,4)
  vxyzu(:,ipart)         = unfill_buf(xbuf,j,maxvxyzu)
  vpred(:,ipart)         = unfill_buf(xbuf,j,maxvxyzu)
+ if (gr) then
+    pxyzu(:,ipart)       = unfill_buf(xbuf,j,maxvxyzu)
+    ppred(:,ipart)       = unfill_buf(xbuf,j,maxvxyzu)
+    dens(ipart)          = unfill_buf(xbuf,j)
+ endif
  fxyzu(:,ipart)         = unfill_buf(xbuf,j,maxvxyzu)
  fext(:,ipart)          = unfill_buf(xbuf,j,3)
  if (ndivcurlv > 0) then


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
- Recalculate the metric after moving particles to their new tasks
- Compute metric before prim2consall
- Make metricderivs an optional output of init_metric
- Transport GR variables using MPI

Testing:
Running full test suite via PR

Did you run the bots? yes, pre-commit
