### PR TITLE
MPI fixes

### DIFF
--- a/src/main/dtype_kdtree.F90
+++ b/src/main/dtype_kdtree.F90
@@ -84,7 +84,6 @@ subroutine get_mpitype_of_kdnode(dtype)
  integer, parameter              :: ndata = 20
 
  integer, intent(out)            :: dtype
- integer                         :: dtype_old
  integer                         :: nblock, blens(ndata), mpitypes(ndata)
  integer(kind=MPI_ADDRESS_KIND)  :: disp(ndata)
 

--- a/src/main/evolve.F90
+++ b/src/main/evolve.F90
@@ -174,7 +174,7 @@ subroutine evol(infile,logfile,evfile,dumpfile)
  endif
 #else
  use_global_dt = .true.
- nskip   = npart
+ nskip   = ntot
  nactive = npart
  istepfrac = 0 ! dummy values
  nbinmax   = 0
@@ -251,6 +251,10 @@ subroutine evol(infile,logfile,evfile,dumpfile)
 
     !--print summary of timestep bins
     if (iverbose >= 2) call write_binsummary(npart,nbinmax,dtmax,timeperbin,iphase,ibin,xyzh)
+#else
+    !--If not using individual timestepping, set nskip to the total number of particles
+    !  across all nodes
+    nskip = int(ntot)
 #endif
 
     if (gravity .and. icreate_sinks > 0 .and. ipart_rhomax /= 0) then

--- a/src/main/evolve.F90
+++ b/src/main/evolve.F90
@@ -174,7 +174,7 @@ subroutine evol(infile,logfile,evfile,dumpfile)
  endif
 #else
  use_global_dt = .true.
- nskip   = ntot
+ nskip   = int(ntot)
  nactive = npart
  istepfrac = 0 ! dummy values
  nbinmax   = 0

--- a/src/main/evolve.F90
+++ b/src/main/evolve.F90
@@ -311,7 +311,7 @@ subroutine evol(infile,logfile,evfile,dumpfile)
     if (abs(tcheck-time) > 1.e-4) call warning('evolve','time out of sync',var='error',val=abs(tcheck-time))
 
     if (id==master .and. (iverbose >= 1 .or. inbin <= 3)) &
-       call print_dtlog_ind(iprint,istepfrac,2**nbinmaxprev,time,dt,nactivetot,tcpu2-tcpu1,npart)
+       call print_dtlog_ind(iprint,istepfrac,2**nbinmaxprev,time,dt,nactivetot,tcpu2-tcpu1,ntot)
 
     !--if total number of bins has changed, adjust istepfrac and dt accordingly
     !  (ie., decrease or increase the timestep)
@@ -337,7 +337,7 @@ subroutine evol(infile,logfile,evfile,dumpfile)
 !
 !--write log every step (NB: must print after dt has been set in order to identify timestep constraint)
 !
-    if (id==master) call print_dtlog(iprint,time,dt,dtforce,dtcourant,dterr,dtmax,dtrad,dtprint,dtinject,npart)
+    if (id==master) call print_dtlog(iprint,time,dt,dtforce,dtcourant,dterr,dtmax,dtrad,dtprint,dtinject,ntot)
 #endif
 
 !   check that MPI threads are synchronised in time

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -131,7 +131,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
  use readwrite_infile, only:read_infile,write_infile
  use readwrite_dumps,  only:read_dump,write_fulldump
  use part,             only:npart,xyzh,vxyzu,fxyzu,fext,divcurlv,divcurlB,Bevol,dBevol,&
-                            npartoftype,maxtypes,ndusttypes,alphaind,ntot,ndim, &
+                            npartoftype,maxtypes,ndusttypes,alphaind,ntot,ndim,update_npartoftypetot,&
                             maxphase,iphase,isetphase,iamtype, &
                             nptmass,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,igas,idust,massoftype,&
                             epot_sinksink,get_ntypes,isdead_or_accreted,dustfrac,ddustevol,&
@@ -225,7 +225,6 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
  character(len=*), intent(out) :: logfile,evfile,dumpfile
  logical,          intent(in), optional :: noread
  integer         :: ierr,i,j,nerr,nwarn,ialphaloc,merge_n,merge_ij(maxptmass)
- integer(kind=8) :: npartoftypetot(maxtypes)
  real            :: poti,dtf,hfactfile,fextv(3)
  real            :: hi,pmassi,rhoi1
  real            :: dtsinkgas,dtsinksink,fonrmax,dtphi2,dtnew_first,dtinject
@@ -305,7 +304,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
 !--get total number of particles (on all processors)
 !
  ntot           = reduceall_mpi('+',npart)
- npartoftypetot = reduce_mpi('+',npartoftype)
+ call update_npartoftypetot
  if (id==master) write(iprint,"(a,i12)") ' npart total   = ',ntot
  if (npart > 0) then
     if (id==master .and. maxalpha==maxp)  write(iprint,*) 'mean alpha  initial: ',sum(alphaind(1,1:npart))/real(npart)

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -646,6 +646,14 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
     endif
  enddo
  !$omp end parallel do
+
+ xmin = reduceall_mpi('min',xmin)
+ ymin = reduceall_mpi('min',ymin)
+ zmin = reduceall_mpi('min',zmin)
+ xmax = reduceall_mpi('max',xmax)
+ ymax = reduceall_mpi('max',ymax)
+ zmax = reduceall_mpi('max',zmax)
+
  dx = abs(xmax - xmin)
  dy = abs(ymax - ymin)
  dz = abs(zmax - zmin)

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -429,7 +429,6 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
     call initialise_externalforces(iexternalforce,ierr)
     if (ierr /= 0) call fatal('initial','error in external force settings/initialisation')
     call get_grforce_all(npart,xyzh,metrics,metricderivs,vxyzu,dens,fext,dtextforce)
-    write(iprint,*) 'dt(extforce)  = ',dtextforce
  endif
 #else
  if (iexternalforce > 0) then
@@ -451,9 +450,13 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
        endif
     enddo
     !$omp end parallel do
-    write(iprint,*) 'dt(extforce)  = ',dtextforce
  endif
 #endif
+
+ if (iexternalforce > 0) then
+    dtextforce = reduceall_mpi('min',dtextforce)
+    if (id==master) write(iprint,*) 'dt(extforce)  = ',dtextforce
+ endif
 
 !
 !-- Set external force to zero on boundary particles

--- a/src/main/mpi_balance.F90
+++ b/src/main/mpi_balance.F90
@@ -96,7 +96,7 @@ end subroutine balance_init
 !----------------------------------------------------------------
 subroutine balancedomains(npart)
  use io,     only:id,master,iverbose,fatal
- use part,   only:shuffle_part,count_dead_particles,ibelong
+ use part,   only:shuffle_part,count_dead_particles,ibelong,update_npartoftypetot
  use timing, only:getused,printused
  use mpiutils, only:barrier_mpi
  implicit none
@@ -144,6 +144,10 @@ subroutine balancedomains(npart)
     print*,id,'ntot_start',ntot_start
     call fatal('balance','number of particles before and after balance not equal')
  endif
+
+ !  Update particle types
+ call update_npartoftypetot
+
  if (id==master .and. iverbose >= 3) call printused(tstart)
 
  return

--- a/src/main/mpi_dens.F90
+++ b/src/main/mpi_dens.F90
@@ -67,13 +67,13 @@ contains
 #ifdef MPI
 subroutine get_mpitype_of_celldens(dtype)
  use mpi
+ use io, only:error
 
  integer, parameter              :: ndata = 20
 
  integer, intent(out)            :: dtype
- integer                         :: dtype_old
  integer                         :: nblock, blens(ndata), mpitypes(ndata)
- integer(kind=4)                 :: disp(ndata)
+ integer(kind=MPI_ADDRESS_KIND)  :: disp(ndata)
 
  type(celldens)                 :: cell
  integer(kind=MPI_ADDRESS_KIND)  :: addr,start,lb,extent
@@ -196,20 +196,14 @@ subroutine get_mpitype_of_celldens(dtype)
  call MPI_GET_ADDRESS(cell%pad,addr,mpierr)
  disp(nblock) = addr - start
 
- call MPI_TYPE_STRUCT(nblock,blens(1:nblock),disp(1:nblock),mpitypes(1:nblock),dtype,mpierr)
+ call MPI_TYPE_CREATE_STRUCT(nblock,blens(1:nblock),disp(1:nblock),mpitypes(1:nblock),dtype,mpierr)
  call MPI_TYPE_COMMIT(dtype,mpierr)
 
  ! check extent okay
  call MPI_TYPE_GET_EXTENT(dtype,lb,extent,mpierr)
  if (extent /= sizeof(cell)) then
-    dtype_old = dtype
-    lb = 0
-    extent = sizeof(cell)
-    call MPI_TYPE_CREATE_RESIZED(dtype_old,lb,extent,dtype,mpierr)
-    call MPI_TYPE_COMMIT(dtype,mpierr)
-    call MPI_TYPE_FREE(dtype_old,mpierr)
+    call error('mpi_dens','MPI_TYPE_GET_EXTENT has calculated the extent incorrectly')
  endif
-
 end subroutine get_mpitype_of_celldens
 #endif
 

--- a/src/main/mpi_force.F90
+++ b/src/main/mpi_force.F90
@@ -68,13 +68,13 @@ contains
 #ifdef MPI
 subroutine get_mpitype_of_cellforce(dtype)
  use mpi
+ use io, only:error
 
  integer, parameter              :: ndata = 20
 
  integer, intent(out)            :: dtype
- integer                         :: dtype_old
  integer                         :: nblock, blens(ndata), mpitypes(ndata)
- integer(kind=4)                 :: disp(ndata)
+ integer(kind=MPI_ADDRESS_KIND)  :: disp(ndata)
 
  type(cellforce)                 :: cell
  integer(kind=MPI_ADDRESS_KIND)  :: addr,start,lb,extent
@@ -203,18 +203,13 @@ subroutine get_mpitype_of_cellforce(dtype)
  call MPI_GET_ADDRESS(cell%pad,addr,mpierr)
  disp(nblock) = addr - start
 
- call MPI_TYPE_STRUCT(nblock,blens(1:nblock),disp(1:nblock),mpitypes(1:nblock),dtype,mpierr)
+ call MPI_TYPE_CREATE_STRUCT(nblock,blens(1:nblock),disp(1:nblock),mpitypes(1:nblock),dtype,mpierr)
  call MPI_TYPE_COMMIT(dtype,mpierr)
 
  ! check extent okay
  call MPI_TYPE_GET_EXTENT(dtype,lb,extent,mpierr)
  if (extent /= sizeof(cell)) then
-    dtype_old = dtype
-    lb = 0
-    extent = sizeof(cell)
-    call MPI_TYPE_CREATE_RESIZED(dtype_old,lb,extent,dtype,mpierr)
-    call MPI_TYPE_COMMIT(dtype,mpierr)
-    call MPI_TYPE_FREE(dtype_old,mpierr)
+   call error('mpi_force','MPI_TYPE_GET_EXTENT has calculated the extent incorrectly')
  endif
 
 end subroutine get_mpitype_of_cellforce

--- a/src/main/mpi_force.F90
+++ b/src/main/mpi_force.F90
@@ -209,7 +209,7 @@ subroutine get_mpitype_of_cellforce(dtype)
  ! check extent okay
  call MPI_TYPE_GET_EXTENT(dtype,lb,extent,mpierr)
  if (extent /= sizeof(cell)) then
-   call error('mpi_force','MPI_TYPE_GET_EXTENT has calculated the extent incorrectly')
+    call error('mpi_force','MPI_TYPE_GET_EXTENT has calculated the extent incorrectly')
  endif
 
 end subroutine get_mpitype_of_cellforce

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -1806,10 +1806,10 @@ real function Omega_k(i)
 end function Omega_k
 
 subroutine update_npartoftypetot
-   use mpiutils, only:reduceall_mpi
+ use mpiutils, only:reduceall_mpi
 
-   npartoftypetot = reduceall_mpi('+',npartoftype)
+ npartoftypetot = reduceall_mpi('+',npartoftype)
 
-end subroutine
+end subroutine update_npartoftypetot
 
 end module part

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -361,8 +361,9 @@ module part
  integer(kind=8) :: ntot
  integer         :: ideadhead = 0
 
- integer :: npartoftype(maxtypes)
- real    :: massoftype(maxtypes)
+ integer         :: npartoftype(maxtypes)
+ integer(kind=8) :: npartoftypetot(maxtypes)
+ real            :: massoftype(maxtypes)
 
  integer :: ndustsmall,ndustlarge,ndusttypes
 !
@@ -564,6 +565,7 @@ subroutine init_part
  npart = 0
  nptmass = 0
  npartoftype(:) = 0
+ npartoftypetot(:) = 0
  massoftype(:)  = 0.
 !--initialise point mass arrays to zero
  xyzmh_ptmass = 0.
@@ -1802,5 +1804,12 @@ real function Omega_k(i)
  endif
 
 end function Omega_k
+
+subroutine update_npartoftypetot
+   use mpiutils, only:reduceall_mpi
+
+   npartoftypetot = reduceall_mpi('+',npartoftype)
+
+end subroutine
 
 end module part

--- a/src/main/readwrite_dumps_common.F90
+++ b/src/main/readwrite_dumps_common.F90
@@ -118,7 +118,7 @@ end subroutine get_options_from_fileid
 !  and perform basic sanity checks
 !+
 !---------------------------------------------------------------
-subroutine check_arrays(i1,i2,npartoftype,npartread,nptmass,nsinkproperties,massoftype,&
+subroutine check_arrays(i1,i2,noffset,npartoftype,npartread,nptmass,nsinkproperties,massoftype,&
                         alphafile,tfile,phantomdump,got_iphase,got_xyzh,got_vxyzu,got_alpha, &
                         got_krome_mols,got_krome_gamma,got_krome_mu,got_krome_T,got_x,got_z,got_mu, &
                         got_abund,got_dustfrac,got_sink_data,got_sink_vels,got_Bxyz,got_psi,got_dustprop,got_pxyzu,got_VrelVf, &
@@ -132,7 +132,7 @@ subroutine check_arrays(i1,i2,npartoftype,npartread,nptmass,nsinkproperties,mass
  use io,   only:warning,id,master
  use options,    only:alpha,use_dustfrac,use_var_comp
  use sphNGutils, only:itype_from_sphNG_iphase,isphNG_accreted
- integer,         intent(in)    :: i1,i2,npartoftype(:),npartread,nptmass,nsinkproperties
+ integer,         intent(in)    :: i1,i2,noffset,npartoftype(:),npartread,nptmass,nsinkproperties
  real,            intent(in)    :: massoftype(:),alphafile,tfile
  logical,         intent(in)    :: phantomdump,got_iphase,got_xyzh(:),got_vxyzu(:),got_alpha,got_dustprop(:)
  logical,         intent(in)    :: got_VrelVf,got_dustgasprop(:),got_x,got_z,got_mu
@@ -372,7 +372,7 @@ subroutine check_arrays(i1,i2,npartoftype,npartread,nptmass,nsinkproperties,mass
 !
  if (.not.got_iorig) then
     do i=i1,i2
-       iorig(i) = i
+       iorig(i) = i + noffset
     enddo
     norig = i2
     if (id==master .and. i1==1) write(*,*) 'WARNING: Particle IDs not in dump; resetting IDs'

--- a/src/main/readwrite_dumps_fortran.F90
+++ b/src/main/readwrite_dumps_fortran.F90
@@ -1275,7 +1275,7 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
  !
  ! check for errors
  !
- call check_arrays(i1,i2,npartoftype,npartread,nptmass,nsinkproperties,massoftype,&
+ call check_arrays(i1,i2,noffset,npartoftype,npartread,nptmass,nsinkproperties,massoftype,&
                    alphafile,tfile,phantomdump,got_iphase,got_xyzh,got_vxyzu,got_alpha, &
                    got_krome_mols,got_krome_gamma,got_krome_mu,got_krome_T,got_x,got_z,got_mu, &
                    got_abund,got_dustfrac,got_sink_data,got_sink_vels,got_Bxyz,got_psi,got_dustprop,got_pxyzu,got_VrelVf, &

--- a/src/main/readwrite_dumps_fortran.F90
+++ b/src/main/readwrite_dumps_fortran.F90
@@ -211,7 +211,8 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
                  lightcurve,store_temperature,use_dustgrowth,store_dust_temperature,gr
  use eos,   only:ieos,eos_is_non_ideal,eos_outputs_mu
  use io,    only:idump,iprint,real4,id,master,error,warning,nprocs
- use part,  only:xyzh,xyzh_label,vxyzu,vxyzu_label,Bevol,Bevol_label,Bxyz,Bxyz_label,npart,npartoftype,maxtypes, &
+ use part,  only:xyzh,xyzh_label,vxyzu,vxyzu_label,Bevol,Bevol_label,Bxyz,Bxyz_label,npart,maxtypes, &
+                 npartoftype,npartoftypetot,update_npartoftypetot, &
                  alphaind,rhoh,divBsymm,maxphase,iphase,iamtype_int1,iamtype_int11, &
                  nptmass,nsinkproperties,xyzmh_ptmass,xyzmh_ptmass_label,vxyz_ptmass,vxyz_ptmass_label,&
                  maxptmass,get_pmass,h2chemistry,nabundances,abundance,abundance_label,mhd,&
@@ -256,7 +257,7 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
  integer            :: ipass,k,l
  integer            :: ierr,ierrs(29)
  integer            :: nblocks,nblockarrays,narraylengths
- integer(kind=8)    :: nparttot,npartoftypetot(maxtypes)
+ integer(kind=8)    :: nparttot
  logical            :: sphNGdump,write_itype,use_gas
  character(len=lenid)  :: fileid
  type(dump_h)          :: hdr
@@ -267,17 +268,17 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
 !--allow non-MPI calls to create MPI dump files
 #ifdef MPI
  nparttot = reduceall_mpi('+',npart)
- npartoftypetot = reduceall_mpi('+',npartoftype)
+ call update_npartoftypetot
 #else
  if (present(ntotal)) then
     nparttot = ntotal
-    npartoftypetot = npartoftype
+    call update_npartoftypetot
     if (all(npartoftypetot==0)) then
        npartoftypetot(1) = ntotal
     endif
  else
     nparttot = npart
-    npartoftypetot = npartoftype
+    call update_npartoftypetot
  endif
 #endif
  nblocks = nprocs
@@ -503,7 +504,8 @@ end subroutine write_fulldump_fortran
 subroutine write_smalldump_fortran(t,dumpfile)
  use dim,        only:maxp,maxtypes,use_dust,lightcurve,use_dustgrowth
  use io,         only:idump,iprint,real4,id,master,error,warning,nprocs
- use part,       only:xyzh,xyzh_label,npart,npartoftype,Bxyz,Bxyz_label,&
+ use part,       only:xyzh,xyzh_label,npart,Bxyz,Bxyz_label,&
+                      npartoftypetot,update_npartoftypetot,&
                       maxphase,iphase,h2chemistry,nabundances,&
                       nptmass,nsinkproperties,xyzmh_ptmass,xyzmh_ptmass_label,&
                       abundance,abundance_label,mhd,dustfrac,iamtype_int11,&
@@ -521,14 +523,14 @@ subroutine write_smalldump_fortran(t,dumpfile)
  integer         :: nums(ndatatypes,4)
  integer         :: ierr,ipass,k
  integer         :: nblocks,nblockarrays,narraylengths
- integer(kind=8) :: nparttot,npartoftypetot(maxtypes)
+ integer(kind=8) :: nparttot
  logical         :: write_itype
  type(dump_h)    :: hdr
 !
 !--collect global information from MPI threads
 !
  nparttot = reduceall_mpi('+',npart)
- npartoftypetot = reduceall_mpi('+',npartoftype)
+ call update_npartoftypetot
  nblocks = nprocs
 
  narraylengths = 2
@@ -1352,7 +1354,8 @@ subroutine unfill_header(hdr,phantomdump,got_tags,nparttot, &
  use dim,        only:maxdustlarge,use_dust
  use io,         only:master ! check this
  use eos,        only:isink
- use part,       only:maxtypes,igas,idust,ndustsmall,ndustlarge,ndusttypes
+ use part,       only:maxtypes,igas,idust,ndustsmall,ndustlarge,ndusttypes,&
+                      npartoftypetot
  use units,      only:udist,umass,utime,set_units_extra,set_units
  use dump_utils, only:extract,dump_h
  use fileutils,  only:make_tags_unique
@@ -1365,7 +1368,7 @@ subroutine unfill_header(hdr,phantomdump,got_tags,nparttot, &
  integer,         intent(out) :: ierr
  integer         :: nparttoti,npartoftypetoti(maxtypes),ntypesinfile,nptinfile
  integer         :: ierr1,ierrs(3),i,counter
- integer(kind=8) :: npartoftypetot(maxtypes),ntypesinfile8
+ integer(kind=8) :: ntypesinfile8
  character(len=10) :: dust_label(maxdustlarge)
 
  ierr = 0

--- a/src/main/readwrite_dumps_fortran.F90
+++ b/src/main/readwrite_dumps_fortran.F90
@@ -779,7 +779,7 @@ subroutine read_dump_fortran(dumpfile,tfile,hfactfile,idisk1,iprint,id,nprocs,ie
 #ifdef INJECT_PARTICLES
        call allocate_memory(maxp_hard)
 #else
-       call allocate_memory(int(min(nprocs,3)*nparttot/nprocs))
+       call allocate_memory(int(min(nprocs,4)*nparttot/nprocs))
 #endif
     endif
 !

--- a/src/main/readwrite_dumps_hdf5.F90
+++ b/src/main/readwrite_dumps_hdf5.F90
@@ -708,6 +708,7 @@ subroutine read_any_dump_hdf5(                                                  
  if (.not.smalldump) then
     call check_arrays(1,                          &
                       npart,                      &
+                      0,                          &
                       npartoftype,                &
                       npart,                      &
                       nptmass,                    &

--- a/src/main/readwrite_dumps_hdf5.F90
+++ b/src/main/readwrite_dumps_hdf5.F90
@@ -109,7 +109,8 @@ subroutine write_dump_hdf5(t,dumpfile,fulldump,ntotal,dtind)
                           Bextz,ndustlarge,idust,idustbound,grainsize,         &
                           graindens,h2chemistry,lightcurve,ndivcurlB,          &
                           ndivcurlv,pxyzu,dens,gamma_chem,mu_chem,T_gas_cool,  &
-                          dust_temp,rad,radprop,itemp,igasP,eos_vars,iorig
+                          dust_temp,rad,radprop,itemp,igasP,eos_vars,iorig,    &
+                          npartoftypetot,update_npartoftypetot
 #ifdef NUCLEATION
  use part,           only:nucleation
 #endif
@@ -135,7 +136,7 @@ subroutine write_dump_hdf5(t,dumpfile,fulldump,ntotal,dtind)
 
  integer            :: i
  integer            :: ierr
- integer(kind=8)    :: nparttot,npartoftypetot(maxtypes)
+ integer(kind=8)    :: nparttot
  logical            :: ind_timesteps,const_av,prdrag,isothermal
  real, allocatable  :: dtin(:),beta_pr(:)
  character(len=200) :: fileid,fstr,sstr
@@ -167,7 +168,7 @@ subroutine write_dump_hdf5(t,dumpfile,fulldump,ntotal,dtind)
 !--allow non-MPI calls to create MPI dump files
 #ifdef MPI
  nparttot = reduceall_mpi('+',npart)
- npartoftypetot = reduceall_mpi('+',npartoftype)
+ call update_npartoftypetot
 #else
  if (present(ntotal)) then
     nparttot = ntotal

--- a/src/main/readwrite_dumps_hdf5.F90
+++ b/src/main/readwrite_dumps_hdf5.F90
@@ -620,7 +620,7 @@ subroutine read_any_dump_hdf5(                                                  
 #ifdef INJECT_PARTICLES
  call allocate_memory(maxp_hard)
 #else
- call allocate_memory(int(npart / nprocs) + 1)
+   call allocate_memory(int(min(nprocs,4)*nparttot/nprocs))
 #endif
 
  if (periodic) then

--- a/src/main/readwrite_dumps_hdf5.F90
+++ b/src/main/readwrite_dumps_hdf5.F90
@@ -620,7 +620,7 @@ subroutine read_any_dump_hdf5(                                                  
 #ifdef INJECT_PARTICLES
  call allocate_memory(maxp_hard)
 #else
-   call allocate_memory(int(min(nprocs,4)*nparttot/nprocs))
+ call allocate_memory(int(min(nprocs,4)*nparttot/nprocs))
 #endif
 
  if (periodic) then

--- a/src/main/step_leapfrog.F90
+++ b/src/main/step_leapfrog.F90
@@ -101,7 +101,7 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
  use part,           only:xyzh,vxyzu,fxyzu,fext,divcurlv,divcurlB,Bevol,dBevol, &
                           rad,drad,radprop,isdead_or_accreted,rhoh,dhdrho,&
                           iphase,iamtype,massoftype,maxphase,igas,idust,mhd,&
-                          iamboundary,get_ntypes,npartoftype,&
+                          iamboundary,get_ntypes,npartoftypetot,&
                           dustfrac,dustevol,ddustevol,eos_vars,alphaind,nptmass,&
                           dustprop,ddustprop,dustproppred,ndustsmall,pxyzu,dens,metrics,ics
  use cooling,        only:cooling_implicit,ufloor
@@ -172,7 +172,7 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
 ! velocity predictor step, using dtsph
 !--------------------------------------
  itype   = igas
- ntypes  = get_ntypes(reduceall_mpi('+',npartoftype))
+ ntypes  = get_ntypes(npartoftypetot)
  pmassi  = massoftype(itype)
  store_itype = (maxphase==maxp .and. ntypes > 1)
  ialphaloc = 2
@@ -422,7 +422,7 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
     np      = 0
     itype   = igas
     pmassi  = massoftype(igas)
-    ntypes  = get_ntypes(npartoftype)
+    ntypes  = get_ntypes(npartoftypetot)
     store_itype = (maxphase==maxp .and. ntypes > 1)
 !$omp parallel default(none) &
 !$omp shared(xyzh,vxyzu,vpred,fxyzu,npart,hdtsph,store_itype) &

--- a/src/main/step_leapfrog.F90
+++ b/src/main/step_leapfrog.F90
@@ -663,6 +663,13 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
        if (gr) vxyzu = vpred ! May need primitive variables elsewhere?
     endif
  enddo iterations
+
+ ! MPI reduce summary variables
+ nwake     = int(reduceall_mpi('+', nwake))
+ nvfloorp  = int(reduceall_mpi('+', nvfloorp))
+ nvfloorps = int(reduceall_mpi('+', nvfloorps))
+ nvfloorc  = int(reduceall_mpi('+', nvfloorc))
+
  ! Summary statements & crash if velocity is not converged
  if (nwake    > 0) call summary_variable('wake', iowake,    0,real(nwake)    )
  if (nvfloorp > 0) call summary_variable('floor',iosumflrp, 0,real(nvfloorp) )

--- a/src/main/timestep.F90
+++ b/src/main/timestep.F90
@@ -68,10 +68,10 @@ end subroutine set_defaults_timestep
 !-----------------------------------------------------------------
 subroutine print_dtlog(iprint,time,dt,dtforce,dtcourant,dterr,dtmax,&
                        dtrad,dtprint,dtinj,np)
- integer, intent(in) :: iprint
- real,    intent(in) :: time,dt,dtforce,dtcourant,dterr,dtmax,dtrad
- real,    intent(in), optional :: dtprint,dtinj
- integer, intent(in) :: np
+ integer,         intent(in) :: iprint
+ real,            intent(in) :: time,dt,dtforce,dtcourant,dterr,dtmax,dtrad
+ real,            intent(in), optional :: dtprint,dtinj
+ integer(kind=8), intent(in) :: np
  character(len=20) :: str
  integer, save :: nplast = 0
 

--- a/src/main/utils_indtimesteps.F90
+++ b/src/main/utils_indtimesteps.F90
@@ -463,7 +463,7 @@ subroutine print_dtlog_ind(iprint,ifrac,nfrac,time,dt,nactive,tcpu,np)
  real,            intent(in) :: time,dt
  integer(kind=8), intent(in) :: nactive
  real(kind=4),    intent(in) :: tcpu
- integer,         intent(in) :: np
+ integer(kind=8), intent(in) :: np
  character(len=120) :: string
  character(len=14) :: tmp
  integer, save :: nplast = 0

--- a/src/main/writeheader.F90
+++ b/src/main/writeheader.F90
@@ -15,8 +15,8 @@ module writeheader
 ! :Runtime parameters: None
 !
 ! :Dependencies: boundary, cooling, dim, dust, eos, gitinfo, growth, io,
-!   kernel, metric_tools, options, part, physcon, readwrite_infile, units,
-!   viscosity
+!   kernel, metric_tools, mpiutils, options, part, physcon,
+!   readwrite_infile, units, viscosity
 !
  implicit none
  public :: write_header,write_codeinfo
@@ -81,7 +81,9 @@ subroutine write_header(icall,infile,evfile,logfile,dumpfile,ntot)
  use options,          only:tolh,alpha,alphau,alphaB,ieos,alphamax,use_dustfrac
  use part,             only:hfact,massoftype,mhd,&
                             gravity,h2chemistry,periodic,npartoftype,massoftype,&
+                            npartoftypetot,&
                             labeltype,maxtypes
+ use mpiutils,         only:reduceall_mpi
  use eos,              only:eosinfo
  use cooling,          only:cooling_implicit,cooling_explicit,Tfloor,ufloor
  use readwrite_infile, only:write_infile
@@ -94,7 +96,7 @@ subroutine write_header(icall,infile,evfile,logfile,dumpfile,ntot)
 #ifdef GR
  use metric_tools,     only:print_metricinfo
 #endif
- integer                      :: Nneigh,i
+ integer                      :: Nneigh,i,npartoftypetoti
  integer,          intent(in) :: icall
  character(len=*), intent(in) :: infile,evfile,logfile,dumpfile
  integer(kind=8),  intent(in), optional :: ntot
@@ -133,9 +135,9 @@ subroutine write_header(icall,infile,evfile,logfile,dumpfile,ntot)
     if (present(ntot)) then
        write(iprint,"(/,' Number of particles = ',i12)") ntot
        do i = 1,maxtypes
-          if (npartoftype(i) > 0) then
+          if (npartoftypetot(i) > 0) then
              write(iprint,"(1x,3a,i12,a,es14.6)") &
-                "Number & mass of ",labeltype(i)," particles: ", npartoftype(i),", ",massoftype(i)
+                "Number & mass of ",labeltype(i)," particles: ", npartoftypetot(i),", ",massoftype(i)
           endif
        enddo
        write(iprint,"(a)") " "

--- a/src/tests/test_growth.F90
+++ b/src/tests/test_growth.F90
@@ -107,7 +107,8 @@ subroutine test_farmingbox(ntests,npass,frag,onefluid)
                           fxyzu,fext,Bevol,dBevol,dustprop,ddustprop,&
                           dustfrac,dustevol,ddustevol,iphase,maxtypes,&
                           VrelVf,dustgasprop,Omega_k,alphaind,iamtype,&
-                          ndustlarge,ndustsmall,rhoh,deltav,this_is_a_test,periodic
+                          ndustlarge,ndustsmall,rhoh,deltav,this_is_a_test,periodic, &
+                          npartoftypetot,update_npartoftypetot
  use step_lf_global, only:step,init_step
  use deriv,          only:get_derivs_global
  use energies,       only:compute_energies
@@ -129,8 +130,6 @@ subroutine test_farmingbox(ntests,npass,frag,onefluid)
 
  integer, intent(inout) :: ntests,npass
  logical, intent(in)    :: frag,onefluid
-
- integer(kind=8) :: npartoftypetot(maxtypes)
 
  integer :: nx,nerror,nwarn
  integer :: itype,npart_previous,i,j,nsteps,modu,noutputs
@@ -242,7 +241,7 @@ subroutine test_farmingbox(ntests,npass,frag,onefluid)
     call set_particle_type(i,itype)
  enddo
  npartoftype(itype)    = npart - npart_previous
- npartoftypetot(itype) = reduceall_mpi('+',npartoftype(itype))
+ call update_npartoftypetot
  massoftype(itype)     = totmass/npartoftypetot(itype)
 
  !- setting dust particles if not one fluid

--- a/src/tests/test_nonidealmhd.F90
+++ b/src/tests/test_nonidealmhd.F90
@@ -377,6 +377,12 @@ subroutine test_standingshock(ntests,npass)
        Bevol(1:3,i) = leftstate(6:8)/leftstate(1)
     endif
  enddo
+
+ !
+ ! reduce types across MPI tasks
+ !
+ call update_npartoftypetot
+
  !
  ! initialise runtime parameters
  !

--- a/src/tests/test_nonidealmhd.F90
+++ b/src/tests/test_nonidealmhd.F90
@@ -277,7 +277,7 @@ subroutine test_standingshock(ntests,npass)
  use kernel,         only:hfact_default,radkern
  use part,           only:init_part,npart,xyzh,vxyzu,npartoftype,massoftype,set_particle_type,hrho,rhoh,&
                           Bevol,fext,igas,iboundary,set_boundaries_to_active,alphaind,maxalpha,maxp,iphase,Bxyz,&
-                          iamtype,iamboundary
+                          iamtype,iamboundary,update_npartoftypetot
  use step_lf_global, only:step,init_step
  use deriv,          only:get_derivs_global
  use testutils,      only:checkval


### PR DESCRIPTION
Type of PR: 
Bug fix, modifications to existing code

Description:
This PR includes several bugfixes. 3 fixes have been bundled from other PRs to reduce the testing load once the phantom benchmarks suite has been fixed.

#239: 
Bug introduced in #96 , particles are assigned new IDs if a file without ID is read. IDs are erroneously duplicated across MPI tasks. This is fixed by using an offset to ensure all IDs are unique.

#240:
`npartoftypetopt=reduceall_mpi('+',npartoftype)` is used in many places in the code, but it is always calculated on the fly. It only needs to be calculated after the number of any particle type on a task has changed. This PR stores it as a global variable in `part`, and defines a subroutine to recalculate it from `npartoftype`.

#241:
The summary variables `wake`, `floor`, and `tolv` were not reduced across MPI tasks, resulting in incorrect printout. This did not seem to have any effect on the actual results.

Other small bugfixes:
- replace `MPI_TYPE_STRUCT` with `MPI_TYPE_CREATE_STRUCT`: `MPI_TYPE_STRUCT` was deprecated since MPI 2.0 and replaced with `MPI_TYPE_CREATE_STRUCT`. It has exactly the same interface and does exactly the same thing. And then `MPI_TYPE_STRUCT` was removed from the standard in MPI 3.0 But `MPI_TYPE_STRUCT` still works, but gives the incorrect result
- reduce `dtextforce` across mpi tasks, and only print to log from the master task
- remove unused variable declaration (`dtype_old`)
- reduce box size across MPI tasks in `initial`
- use `ntot` instead of `npart` for `nskip`, since `npart` is only the local particle count
- use `ntot` instead of `npart` to print dtlog
- change particle memory allocation ratio, and make consistent between fortran and hdf5 outputs
- optimisations to step leapfrog: don't reduce ptmass variables unless necessary
- use kind=8 for `np` in timestep routines

Testing:
Full test suite

Did you run the bots? yes, pre-commit
