### PR TITLE
Test benchmark suite with MPI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -47,6 +47,9 @@ jobs:
       fail-fast: false
       matrix:
         setup: ${{fromJson(needs.extract.outputs.setups)}}
+        mpi:
+          - yes
+          - no
 
     name: bench (SETUP=${{ matrix.setup }})
     runs-on: self-hosted
@@ -83,7 +86,7 @@ jobs:
         systems="gfortran ifort"
         for SYSTEM in $systems; do
           echo ::group::SYSTEM=$SYSTEM
-          SYSTEM=${SYSTEM} ./run-benchmarks.sh  ${{ matrix.setup }}
+          SYSTEM=${SYSTEM} MPI=${{ matrix.mpi }} STACKSIZE=5000000 ./run-benchmarks.sh  ${{ matrix.setup }}
           echo ::endgroup::
         done
       env:

--- a/AUTHORS
+++ b/AUTHORS
@@ -25,9 +25,9 @@ Giovanni Dipierro <giovanni.dipierro@leicester.ac.uk>
 Enrico Ragusa <enr.ragusa@gmail.com>
 Hauke Worpel <hworpel@aip.de>
 Roberto Iaconi <robertoiaconi1@gmail.com>
+Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Simon Glover <glover@uni-heidelberg.de>
 Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
-Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
 Martina Toscani <mtoscani94@gmail.com>
 Benedetta Veronesi <benedetta.veronesi@unimi.it>


### PR DESCRIPTION
Type of PR: 
other

Description:
Currently, the benchmark suite is only run in non-MPI mode. This PR adds a matrix option for `MPI=yes`

Testing:
Not all benchmarks currently pass. Benchmarks should be fixed before merging this PR, even though it is not a requirement to merge. #166 needs to be resolved before this can be merged, because some benchmarks use individual timesteps.

Did you run the bots? yes, pre-commit
