### PR TITLE
remove accradius1_hard hack

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,9 +25,9 @@ Giovanni Dipierro <giovanni.dipierro@leicester.ac.uk>
 Enrico Ragusa <enr.ragusa@gmail.com>
 Hauke Worpel <hworpel@aip.de>
 Roberto Iaconi <robertoiaconi1@gmail.com>
+Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Simon Glover <glover@uni-heidelberg.de>
 Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
-Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
 Martina Toscani <mtoscani94@gmail.com>
 Benedetta Veronesi <benedetta.veronesi@unimi.it>

--- a/src/main/externalforces.F90
+++ b/src/main/externalforces.F90
@@ -575,7 +575,7 @@ end subroutine update_externalforce
 !   add checks to see if particle is bound etc. here)
 !+
 !-----------------------------------------------------------------------
-subroutine accrete_particles(iexternalforce,xi,yi,zi,hi,mi,ti,accreted,i)
+subroutine accrete_particles(iexternalforce,xi,yi,zi,hi,mi,ti,accreted)
  use extern_binary, only:binary_accreted,accradius1
  use part,          only:set_particle_type,iboundary,maxphase,maxp,igas
  !use part,          only:npartoftype
@@ -583,7 +583,6 @@ subroutine accrete_particles(iexternalforce,xi,yi,zi,hi,mi,ti,accreted,i)
  real,    intent(in)    :: xi,yi,zi,mi,ti
  real,    intent(inout) :: hi
  logical, intent(out)   :: accreted
- integer, intent(in), optional :: i
  real :: r2
 
  accreted = .false.
@@ -591,12 +590,7 @@ subroutine accrete_particles(iexternalforce,xi,yi,zi,hi,mi,ti,accreted,i)
  case(iext_star,iext_prdrag,iext_lensethirring,iext_einsteinprec,iext_gnewton)
 
     r2 = xi*xi + yi*yi + zi*zi
-    if (r2 < accradius1**2 .and. maxphase==maxp .and. present(i)) then
-       call set_particle_type(i,iboundary)
-       !npartoftype(igas) = npartoftype(igas) - 1
-       !npartoftype(iboundary) = npartoftype(iboundary) + 1
-    endif
-    if (r2 < (accradius1_hard)**2) accreted = .true.
+    if (r2 < (accradius1)**2) accreted = .true.
 
  case(iext_binary,iext_corot_binary)
 

--- a/src/main/step_leapfrog.F90
+++ b/src/main/step_leapfrog.F90
@@ -1404,7 +1404,7 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
 
           if (iexternalforce > 0) then
              call accrete_particles(iexternalforce,xyzh(1,i),xyzh(2,i), &
-                                    xyzh(3,i),xyzh(4,i),pmassi,timei,accreted,i)
+                                    xyzh(3,i),xyzh(4,i),pmassi,timei,accreted)
              if (accreted) accretedmass = accretedmass + pmassi
           endif
           !


### PR DESCRIPTION
Type of PR: 
modification to existing code

Description:
This hard accretion radius hack was introduced in https://github.com/danieljprice/phantom/commit/e54d7350c10c88c7e957227e995b2ff50cb3e3fe to test a scenario in response to a referee's request. It was merged into master, but is not useful in general. It also causes issues elsewhere because boundary particles can be created with no `massoftype set`. @dliptai and @danieljprice have agreed that it should be removed.

Testing:
Full test suite

Did you run the bots? yes, pre-commit
