### PR TITLE
Name every omp critical section

### DIFF
--- a/src/main/dens.F90
+++ b/src/main/dens.F90
@@ -472,14 +472,6 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
           cell = stack_waiting%cells(i)
 
           if (any(cell%remote_export(1:nprocs))) then
-             print*,id,cell%remote_export(1:nprocs)
-             print*,id,'mpiits',mpiits
-             print*,id,'owner',cell%owner
-             print*,id,'icell',cell%icell
-             print*,id,'npcell',cell%npcell
-             print*,id,'xpos',cell%xpos
-             print*,id,'stackpos',i
-             print*,id,'waitindex',cell%waiting_index
              call fatal('dens', 'not all results returned from remote processor')
           endif
 

--- a/src/main/dens.F90
+++ b/src/main/dens.F90
@@ -329,18 +329,18 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
     call get_hmaxcell(icell,cell%hmax)
 
 #ifdef MPI
-!$omp critical (recv_remote)
+!$omp critical (send_and_recv_remote)
     call recv_cells(stack_remote,xrecvbuf,irequestrecv)
-!$omp end critical (recv_remote)
+!$omp end critical (send_and_recv_remote)
 
     if (do_export) then
-!$omp critical (reserve_waiting)
+!$omp critical (send_and_recv_remote)
        if (stack_waiting%n > 0) call check_send_finished(stack_remote,irequestsend,irequestrecv,xrecvbuf)
        ! make a reservation on the stack
        call reserve_stack(stack_waiting,cell%waiting_index)
        ! export the cell: direction 0 for exporting
        call send_cell(cell,0,irequestsend,xsendbuf)
-!$omp end critical (reserve_waiting)
+!$omp end critical (send_and_recv_remote)
     endif
 #endif
 
@@ -371,12 +371,12 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
                 cell%remote_export(1:nprocs) = remote_export
                 if (any(remote_export)) then
                    do_export = .true.
-!$omp critical (reserve_waiting)
+!$omp critical (send_and_recv_remote)
                    if (stack_waiting%n > 0) call check_send_finished(stack_remote,irequestsend,irequestrecv,xrecvbuf)
                    call reserve_stack(stack_waiting,cell%waiting_index)
                    ! direction export (0)
                    call send_cell(cell,0,irequestsend,xsendbuf)
-!$omp end critical (reserve_waiting)
+!$omp end critical (send_and_recv_remote)
                 endif
 #endif
                 nrelink = nrelink + 1
@@ -445,12 +445,12 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
           cell%remote_export(id+1) = .false.
 
           ! communication happened while computing contributions to remote cells
-!$omp critical (recv_waiting)
+!$omp critical (send_and_recv_waiting)
           call recv_cells(stack_waiting,xrecvbuf,irequestrecv)
           call check_send_finished(stack_waiting,irequestsend,irequestrecv,xrecvbuf)
           ! direction return (1)
           call send_cell(cell,1,irequestsend,xsendbuf)
-!$omp end critical (recv_waiting)
+!$omp end critical (send_and_recv_waiting)
        enddo over_remote
 !$omp enddo
 !$omp barrier
@@ -483,21 +483,21 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
           endif
 
           ! communication happened while finishing cell
-!$omp critical (recv_remote)
+!$omp critical (send_and_recv_remote)
           call recv_cells(stack_remote,xrecvbuf,irequestrecv)
-!$omp end critical (recv_remote)
+!$omp end critical (send_and_recv_remote)
           if (.not. converged) then
              call set_hmaxcell(cell%icell,cell%hmax)
              call get_neighbour_list(-1,listneigh,nneigh,xyzh,xyzcache,isizecellcache,getj=.false., &
                                     cell_xpos=cell%xpos,cell_xsizei=cell%xsizei,cell_rcuti=cell%rcuti, &
                                     remote_export=remote_export)
              cell%remote_export(1:nprocs) = remote_export
-!$omp critical (reserve_redo)
+!$omp critical (send_and_recv_remote)
              call check_send_finished(stack_remote,irequestsend,irequestrecv,xrecvbuf)
              call reserve_stack(stack_redo,cell%waiting_index)
              ! direction export (0)
              call send_cell(cell,0,irequestsend,xsendbuf)
-!$omp end critical (reserve_redo)
+!$omp end critical (send_and_recv_remote)
              call compute_cell(cell,listneigh,nneigh,getdv,getdB,Bevol,xyzh,vxyzu,fxyzu,fext,xyzcache,rad)
 
              stack_redo%cells(cell%waiting_index) = cell

--- a/src/main/dens.F90
+++ b/src/main/dens.F90
@@ -329,18 +329,18 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
     call get_hmaxcell(icell,cell%hmax)
 
 #ifdef MPI
-!$omp critical
+!$omp critical (recv_remote)
     call recv_cells(stack_remote,xrecvbuf,irequestrecv)
-!$omp end critical
+!$omp end critical (recv_remote)
 
     if (do_export) then
-!$omp critical
+!$omp critical (reserve_waiting)
        if (stack_waiting%n > 0) call check_send_finished(stack_remote,irequestsend,irequestrecv,xrecvbuf)
        ! make a reservation on the stack
        call reserve_stack(stack_waiting,cell%waiting_index)
        ! export the cell: direction 0 for exporting
        call send_cell(cell,0,irequestsend,xsendbuf)
-!$omp end critical
+!$omp end critical (reserve_waiting)
     endif
 #endif
 
@@ -371,12 +371,12 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
                 cell%remote_export(1:nprocs) = remote_export
                 if (any(remote_export)) then
                    do_export = .true.
-!$omp critical
+!$omp critical (reserve_waiting)
                    if (stack_waiting%n > 0) call check_send_finished(stack_remote,irequestsend,irequestrecv,xrecvbuf)
                    call reserve_stack(stack_waiting,cell%waiting_index)
                    ! direction export (0)
                    call send_cell(cell,0,irequestsend,xsendbuf)
-!$omp end critical
+!$omp end critical (reserve_waiting)
                 endif
 #endif
                 nrelink = nrelink + 1
@@ -445,12 +445,12 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
           cell%remote_export(id+1) = .false.
 
           ! communication happened while computing contributions to remote cells
-!$omp critical
+!$omp critical (recv_waiting)
           call recv_cells(stack_waiting,xrecvbuf,irequestrecv)
           call check_send_finished(stack_waiting,irequestsend,irequestrecv,xrecvbuf)
           ! direction return (1)
           call send_cell(cell,1,irequestsend,xsendbuf)
-!$omp end critical
+!$omp end critical (recv_waiting)
        enddo over_remote
 !$omp enddo
 !$omp barrier
@@ -491,21 +491,21 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
           endif
 
           ! communication happened while finishing cell
-!$omp critical
+!$omp critical (recv_remote)
           call recv_cells(stack_remote,xrecvbuf,irequestrecv)
-!$omp end critical
+!$omp end critical (recv_remote)
           if (.not. converged) then
              call set_hmaxcell(cell%icell,cell%hmax)
              call get_neighbour_list(-1,listneigh,nneigh,xyzh,xyzcache,isizecellcache,getj=.false., &
                                     cell_xpos=cell%xpos,cell_xsizei=cell%xsizei,cell_rcuti=cell%rcuti, &
                                     remote_export=remote_export)
              cell%remote_export(1:nprocs) = remote_export
-!$omp critical
+!$omp critical (reserve_redo)
              call check_send_finished(stack_remote,irequestsend,irequestrecv,xrecvbuf)
              call reserve_stack(stack_redo,cell%waiting_index)
              ! direction export (0)
              call send_cell(cell,0,irequestsend,xsendbuf)
-!$omp end critical
+!$omp end critical (reserve_redo)
              call compute_cell(cell,listneigh,nneigh,getdv,getdB,Bevol,xyzh,vxyzu,fxyzu,fext,xyzcache,rad)
 
              stack_redo%cells(cell%waiting_index) = cell

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -574,7 +574,6 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
        cell = stack_waiting%cells(i)
 
        if (any(cell%remote_export(1:nprocs))) then
-          print*,id,cell%remote_export(1:nprocs)
           call fatal('force', 'not all results returned from remote processor')
        endif
 

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -474,17 +474,17 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
     cell%remote_export(1:nprocs) = remote_export
     do_export = any(remote_export)
 
-!$omp critical
+!$omp critical (recv_remote)
     call recv_cells(stack_remote,xrecvbuf,irequestrecv)
-!$omp end critical
+!$omp end critical (recv_remote)
 
     if (do_export) then
-!$omp critical
+!$omp critical (reserve_waiting)
        if (stack_waiting%n > 0) call check_send_finished(stack_remote,irequestsend,irequestrecv,xrecvbuf)
        call reserve_stack(stack_waiting,cell%waiting_index)
        ! export the cell: direction 0 for exporting
        call send_cell(cell,0,irequestsend,xsendbuf)
-!$omp end critical
+!$omp end critical (reserve_waiting)
     endif
 #endif
 
@@ -550,11 +550,11 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
 
        cell%remote_export(id+1) = .false.
 
-!$omp critical
+!$omp critical (recv_waiting)
        call recv_cells(stack_waiting,xrecvbuf,irequestrecv)
        call check_send_finished(stack_waiting,irequestsend,irequestrecv,xrecvbuf)
        call send_cell(cell,1,irequestsend,xsendbuf)
-!$omp end critical
+!$omp end critical (recv_waiting)
     enddo over_remote
 !$omp enddo
 !$omp barrier

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -474,17 +474,17 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
     cell%remote_export(1:nprocs) = remote_export
     do_export = any(remote_export)
 
-!$omp critical (recv_remote)
+!$omp critical (send_and_recv_remote)
     call recv_cells(stack_remote,xrecvbuf,irequestrecv)
-!$omp end critical (recv_remote)
+!$omp end critical (send_and_recv_remote)
 
     if (do_export) then
-!$omp critical (reserve_waiting)
+!$omp critical (send_and_recv_remote)
        if (stack_waiting%n > 0) call check_send_finished(stack_remote,irequestsend,irequestrecv,xrecvbuf)
        call reserve_stack(stack_waiting,cell%waiting_index)
        ! export the cell: direction 0 for exporting
        call send_cell(cell,0,irequestsend,xsendbuf)
-!$omp end critical (reserve_waiting)
+!$omp end critical (send_and_recv_remote)
     endif
 #endif
 
@@ -550,11 +550,11 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
 
        cell%remote_export(id+1) = .false.
 
-!$omp critical (recv_waiting)
+!$omp critical (send_and_recv_waiting)
        call recv_cells(stack_waiting,xrecvbuf,irequestrecv)
        call check_send_finished(stack_waiting,irequestsend,irequestrecv,xrecvbuf)
        call send_cell(cell,1,irequestsend,xsendbuf)
-!$omp end critical (recv_waiting)
+!$omp end critical (send_and_recv_waiting)
     enddo over_remote
 !$omp enddo
 !$omp barrier

--- a/src/main/io.F90
+++ b/src/main/io.F90
@@ -297,9 +297,9 @@ subroutine buffer_warning(wherefrom,string,ncount,level)
         .and. warningdb(j)%message(1:ls) == string(1:ls)) then
        !--if warning matches an existing warning in the database
        !  just increase the reference count
-!$omp critical
+!$omp critical (warning_count)
        warningdb(j)%ncount = warningdb(j)%ncount + 1_8
-!$omp end critical
+!$omp end critical (warning_count)
        ncount = warningdb(j)%ncount
        exit over_db
     elseif (len_trim(warningdb(j)%message)==0) then

--- a/src/main/linklist_kdtree.F90
+++ b/src/main/linklist_kdtree.F90
@@ -107,9 +107,9 @@ subroutine set_hmaxcell(inode,hmaxcell)
  ! walk tree up
  do while (node(n)%parent /= 0)
     n = node(n)%parent
-!$omp critical (hmax)
+!$omp critical (node_hmax)
     node(n)%hmax = max(node(n)%hmax, hmaxcell)
-!$omp end critical (hmax)
+!$omp end critical (node_hmax)
  enddo
 
 end subroutine set_hmaxcell

--- a/src/main/mpi_balance.F90
+++ b/src/main/mpi_balance.F90
@@ -173,9 +173,9 @@ subroutine recv_part(replace)
  call MPI_TEST(irequestrecv(1),igotpart,status,mpierr)
 
  if (igotpart) then
-!$omp critical (nrecv)
+!$omp critical (nrecv_add)
     nrecv(status(MPI_SOURCE)+1) = nrecv(status(MPI_SOURCE)+1) + 1
-!$omp end critical (nrecv)
+!$omp end critical (nrecv_add)
     if (present(replace)) then
        if (replace) then
           inew = ideadhead
@@ -197,17 +197,17 @@ subroutine recv_part(replace)
        !--assume that this particle landed in the right place
        !
        ibelong(inew) = id
-!$omp critical (ideadhead)
+!$omp critical (ideadhead_ll)
        ideadhead = ll(inew)
-!$omp end critical (ideadhead)
+!$omp end critical (ideadhead_ll)
     else
        if (inew /= 0) call fatal('balance','error in dead particle list',inew)
        !
        !--make a new particle
        !
-!$omp critical (npartnew)
+!$omp critical (npartnew_add)
        npartnew = npartnew + 1
-!$omp end critical (npartnew)
+!$omp end critical (npartnew_add)
        if (npartnew > maxp) call fatal('recv_part','npartnew > maxp',npartnew)
        call unfill_buffer(npartnew,xbuffer)
        ibelong(npartnew) = id

--- a/src/main/mpi_balance.F90
+++ b/src/main/mpi_balance.F90
@@ -173,9 +173,9 @@ subroutine recv_part(replace)
  call MPI_TEST(irequestrecv(1),igotpart,status,mpierr)
 
  if (igotpart) then
-!$omp critical
+!$omp critical (nrecv)
     nrecv(status(MPI_SOURCE)+1) = nrecv(status(MPI_SOURCE)+1) + 1
-!$omp end critical
+!$omp end critical (nrecv)
     if (present(replace)) then
        if (replace) then
           inew = ideadhead
@@ -197,17 +197,17 @@ subroutine recv_part(replace)
        !--assume that this particle landed in the right place
        !
        ibelong(inew) = id
-!$omp critical
+!$omp critical (ideadhead)
        ideadhead = ll(inew)
-!$omp end critical
+!$omp end critical (ideadhead)
     else
        if (inew /= 0) call fatal('balance','error in dead particle list',inew)
        !
        !--make a new particle
        !
-!$omp critical
+!$omp critical (npartnew)
        npartnew = npartnew + 1
-!$omp end critical
+!$omp end critical (npartnew)
        if (npartnew > maxp) call fatal('recv_part','npartnew > maxp',npartnew)
        call unfill_buffer(npartnew,xbuffer)
        ibelong(npartnew) = id

--- a/src/main/ptmass_radiation.F90
+++ b/src/main/ptmass_radiation.F90
@@ -246,10 +246,10 @@ subroutine get_Teq_from_Lucy(npart,xyzh,xa,ya,za,R_star,T_star,dust_temp)
        !d2_axis = sq_distance_to_z(r)
        d2_axis = sq_distance_to_line(r,u)
        if (d2_axis < 4.*xyzh(4,i)*xyzh(4,i)) then
-          !$omp critical
+          !$omp critical (naxis)
           naxis = naxis+1
           idx_axis(naxis) = i
-          !$omp end critical
+          !$omp end critical (naxis)
        endif
     endif
  enddo

--- a/src/main/ptmass_radiation.F90
+++ b/src/main/ptmass_radiation.F90
@@ -246,10 +246,10 @@ subroutine get_Teq_from_Lucy(npart,xyzh,xa,ya,za,R_star,T_star,dust_temp)
        !d2_axis = sq_distance_to_z(r)
        d2_axis = sq_distance_to_line(r,u)
        if (d2_axis < 4.*xyzh(4,i)*xyzh(4,i)) then
-          !$omp critical (naxis)
+          !$omp critical (naxis_add)
           naxis = naxis+1
           idx_axis(naxis) = i
-          !$omp end critical (naxis)
+          !$omp end critical (naxis_add)
        endif
     endif
  enddo

--- a/src/main/quitdump.f90
+++ b/src/main/quitdump.f90
@@ -31,7 +31,7 @@ subroutine quit
  use part,            only:nptmass
  integer  :: i
 
-!$omp critical
+!$omp critical (quit)
  call summary_printout(iprint,nptmass)
  write(iprint,10)
 10 format(/, &
@@ -43,7 +43,7 @@ subroutine quit
 
  write(iprint,*) 'run terminated abnormally'
  call write_fulldump(time,'phantom.debugdump')
-!$omp end critical
+!$omp end critical (quit)
 !
 ! close ev, log& ptmass-related files
  close(unit=ievfile)

--- a/src/main/quitdump.f90
+++ b/src/main/quitdump.f90
@@ -31,7 +31,7 @@ subroutine quit
  use part,            only:nptmass
  integer  :: i
 
-!$omp critical (quit)
+!$omp critical (quit_summary)
  call summary_printout(iprint,nptmass)
  write(iprint,10)
 10 format(/, &
@@ -43,7 +43,7 @@ subroutine quit
 
  write(iprint,*) 'run terminated abnormally'
  call write_fulldump(time,'phantom.debugdump')
-!$omp end critical (quit)
+!$omp end critical (quit_summary)
 !
 ! close ev, log& ptmass-related files
  close(unit=ievfile)

--- a/src/utils/adaptivemesh.f90
+++ b/src/utils/adaptivemesh.f90
@@ -217,7 +217,7 @@ recursive subroutine refine_mesh(xyzhi,imesh,level,xminl,dxmax,nmesh,ierr)
              !  criterion is satisfied (here if h < 0.5*dx)
              !
 
-             !$omp critical
+             !$omp critical (nmesh)
              nmesh = nmesh + 1
              if (nmesh > maxmeshes) then
                 !print*,'ERROR: nmesh > maxmeshes (',maxmeshes,'): change parameter and recompile'
@@ -239,7 +239,7 @@ recursive subroutine refine_mesh(xyzhi,imesh,level,xminl,dxmax,nmesh,ierr)
                 isublevel = level + 1
                 isubmesh  = nmesh      ! be careful to pass by value here, not by reference...
              endif
-             !$omp end critical
+             !$omp end critical (nmesh)
 
              if (ierr /= 0) return
 

--- a/src/utils/adaptivemesh.f90
+++ b/src/utils/adaptivemesh.f90
@@ -217,7 +217,7 @@ recursive subroutine refine_mesh(xyzhi,imesh,level,xminl,dxmax,nmesh,ierr)
              !  criterion is satisfied (here if h < 0.5*dx)
              !
 
-             !$omp critical (nmesh)
+             !$omp critical (nmesh_add)
              nmesh = nmesh + 1
              if (nmesh > maxmeshes) then
                 !print*,'ERROR: nmesh > maxmeshes (',maxmeshes,'): change parameter and recompile'
@@ -239,7 +239,7 @@ recursive subroutine refine_mesh(xyzhi,imesh,level,xminl,dxmax,nmesh,ierr)
                 isublevel = level + 1
                 isubmesh  = nmesh      ! be careful to pass by value here, not by reference...
              endif
-             !$omp end critical (nmesh)
+             !$omp end critical (nmesh_add)
 
              if (ierr /= 0) return
 

--- a/src/utils/analysis_dustywind.F90
+++ b/src/utils/analysis_dustywind.F90
@@ -96,10 +96,10 @@ subroutine get_Teq_from_Lucy(npart,xyzh,xa,ya,za,R_star,T_star,dust_temp)
        !d2_axis = sq_distance_to_z(r)
        d2_axis = sq_distance_to_line(r,u)
        if (d2_axis < 4.*xyzh(4,i)*xyzh(4,i)) then
-          !$omp critical (naxis)
+          !$omp critical (naxis_add)
           naxis = naxis+1
           idx_axis(naxis) = i
-          !$omp end critical (naxis)
+          !$omp end critical (naxis_add)
        endif
     endif
  enddo

--- a/src/utils/analysis_dustywind.F90
+++ b/src/utils/analysis_dustywind.F90
@@ -96,10 +96,10 @@ subroutine get_Teq_from_Lucy(npart,xyzh,xa,ya,za,R_star,T_star,dust_temp)
        !d2_axis = sq_distance_to_z(r)
        d2_axis = sq_distance_to_line(r,u)
        if (d2_axis < 4.*xyzh(4,i)*xyzh(4,i)) then
-          !$omp critical
+          !$omp critical (naxis)
           naxis = naxis+1
           idx_axis(naxis) = i
-          !$omp end critical
+          !$omp end critical (naxis)
        endif
     endif
  enddo


### PR DESCRIPTION
Type of PR: 
other

Description:
Performance optimisation: name every OMP critical section. There are many critical sections in MPI communication routines that can be run simultaneously. Because none of them are named, they block each other unnecessarily. Giving them names will prevent that.

Testing:
Full test suite

Did you run the bots? no, not required
