### PR TITLE
Adjust tolerance of angmom test for circumbinary disc

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,8 +24,8 @@ Fangyi (Fitz) Hu <fhuu0005@student.monash.edu>
 Giovanni Dipierro <giovanni.dipierro@leicester.ac.uk>
 Enrico Ragusa <enr.ragusa@gmail.com>
 Hauke Worpel <hworpel@aip.de>
-Roberto Iaconi <robertoiaconi1@gmail.com>
 Conrad Chan <8309215+conradtchan@users.noreply.github.com>
+Roberto Iaconi <robertoiaconi1@gmail.com>
 Simon Glover <glover@uni-heidelberg.de>
 Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
 Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
@@ -33,10 +33,9 @@ Martina Toscani <mtoscani94@gmail.com>
 Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Simone Ceppi <simo.ceppi@gmail.com>
 Christopher Russell <crussell@udel.edu>
+Megha Sharma <msha0023@student.monash.edu>
 Alessia Franchini <alessia.franchini@unlv.edu>
 Alex Pettitt <alex@astro1.sci.hokudai.ac.jp>
-Megha Sharma <msha0023@student.monash.edu>
-Kieran Hirsh <kieran.hirsh1@monash.edu>
 Nicole Rodrigues <nicole.rodrigues@monash.edu>
 Kieran Hirsh <kieran.hirsh1@monash.edu>
 Chris Nixon <cjn@leicester.ac.uk>
@@ -54,8 +53,5 @@ James <jhw5@st-andrews.ac.uk>
 Steven Rieder <steven@rieder.nl>
 Stéven Toupin <steven.toupin@gmail.com>
 Cox, Samuel <sc676@leicester.ac.uk>
-James <jhw5@st-andrews.ac.uk>
-Jorge Cuadra <jcuadra@astro.puc.cl>
 Maxime Lombart <maxime.lombart@ens-lyon.fr>
-Steven Rieder <steven@rieder.nl>
-Stéven Toupin <steven.toupin@gmail.com>
+Jorge Cuadra <jcuadra@astro.puc.cl>

--- a/src/tests/test_ptmass.f90
+++ b/src/tests/test_ptmass.f90
@@ -290,7 +290,7 @@ subroutine test_binary(ntests,npass)
        endif
        call checkval(etotin+errmax,etotin,1.2e-2,nfailed(1),'total energy')
     case(2)
-       call checkval(angtot,angmomin,3.e-7,nfailed(3),'angular momentum')
+       call checkval(angtot,angmomin,4.e-7,nfailed(3),'angular momentum')
        call checkval(totmom,totmomin,6.e-14,nfailed(2),'linear momentum')
        tolen = 2.e-3
        if (gravity) tolen = 3.1e-3


### PR DESCRIPTION
Type of PR: 
other

Description:
The tolerance of the angular momentum check for the circumbinary disc was set very close to the actual error value. Due to roundoff errors accumulated by MPI, this test can sometimes fail, e.g. https://github.com/danieljprice/phantom/runs/5383936672

The tolerance was adjusted from `3.e-7` to `4.e-7`.

Testing:
None; the change only loosens test suite tolerance.

Did you run the bots? yes, pre-commit
