### PR TITLE
Optimisations for single task MPI

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,39 +19,42 @@ Rebecca Nealon <rebecca.nealon@warwick.ac.uk>
 Christophe Pinte <christophe.pinte@univ-grenoble-alpes.fr>
 Ward Homan <ward.homan@kuleuven.be>
 Elisabeth Borchert <elisabeth.borchert@monash.edu>
-Sergei Biriukov <svbiriukov@gmail.com>
 Fangyi (Fitz) Hu <fhuu0005@student.monash.edu>
+Sergei Biriukov <svbiriukov@gmail.com>
 Giovanni Dipierro <giovanni.dipierro@leicester.ac.uk>
 Enrico Ragusa <enr.ragusa@gmail.com>
 Hauke Worpel <hworpel@aip.de>
 Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Roberto Iaconi <robertoiaconi1@gmail.com>
-Simon Glover <glover@uni-heidelberg.de>
 Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
-Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
+Simon Glover <glover@uni-heidelberg.de>
 Martina Toscani <mtoscani94@gmail.com>
+Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
 Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Simone Ceppi <simo.ceppi@gmail.com>
+Fitz Hu <fhuu0005@student.monash.edu>
 Christopher Russell <crussell@udel.edu>
 Megha Sharma <msha0023@student.monash.edu>
 Alessia Franchini <alessia.franchini@unlv.edu>
 Alex Pettitt <alex@astro1.sci.hokudai.ac.jp>
-Nicole Rodrigues <nicole.rodrigues@monash.edu>
 Kieran Hirsh <kieran.hirsh1@monash.edu>
+Nicole Rodrigues <nicole.rodrigues@monash.edu>
+fitzHu <54089891+Fitz-Hu@users.noreply.github.com>
 Chris Nixon <cjn@leicester.ac.uk>
 Nicolas Cuello <cuellonicolas@gmail.com>
 Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
+Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
 Cristiano Longarini <cristiano.longarini@unimi.it>
+David Trevascus <dtre10@student.monash.edu>
+Benoit Commercon <benoit.commercon@gmail.com>
 Zachary Pellow <zpel1@student.monash.edu>
 Joe Fisher <jwfis1@student.monash.edu>
 Orsola De Marco <orsola.demarco@mq.edu.au>
-Benoit Commercon <benoit.commercon@gmail.com>
-Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
-David Trevascus <dtre10@student.monash.edu>
+dliptai <31463304+dliptai@users.noreply.github.com>
+Maxime Lombart <maxime.lombart@ens-lyon.fr>
 Alison Young <ayoung@astro.ex.ac.uk>
+Jorge Cuadra <jcuadra@astro.puc.cl>
 James <jhw5@st-andrews.ac.uk>
 Steven Rieder <steven@rieder.nl>
 Stéven Toupin <steven.toupin@gmail.com>
 Cox, Samuel <sc676@leicester.ac.uk>
-Maxime Lombart <maxime.lombart@ens-lyon.fr>
-Jorge Cuadra <jcuadra@astro.puc.cl>

--- a/src/main/linklist_kdtree.F90
+++ b/src/main/linklist_kdtree.F90
@@ -157,6 +157,7 @@ subroutine get_distance_from_centre_of_mass(inode,xi,yi,zi,dx,dy,dz,xcen)
 end subroutine get_distance_from_centre_of_mass
 
 subroutine set_linklist(npart,nactive,xyzh,vxyzu)
+ use io,           only:nprocs
  use dtypekdtree,  only:ndimtree
  use kdtree,       only:maketree,maketreeglobal
  use dim,          only:mpi
@@ -166,7 +167,7 @@ subroutine set_linklist(npart,nactive,xyzh,vxyzu)
  real,    intent(inout) :: xyzh(:,:)
  real,    intent(in)    :: vxyzu(:,:)
 
- if (mpi) then
+ if (mpi .and. nprocs > 1) then
     call maketreeglobal(nodeglobal,node,nodemap,globallevel,refinelevels,xyzh,npart,ndimtree,cellatid,ifirstincell,ncells)
  else
     call maketree(node,xyzh,npart,ndimtree,ifirstincell,ncells)
@@ -185,6 +186,7 @@ end subroutine set_linklist
 subroutine get_neighbour_list(inode,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesize, &
                               getj,f,remote_export, &
                               cell_xpos,cell_xsizei,cell_rcuti)
+ use io,     only:nprocs
  use dim,    only:mpi
  use kdtree, only:getneigh,lenfgrav
  use kernel, only:radkern
@@ -216,7 +218,7 @@ subroutine get_neighbour_list(inode,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesi
     call get_cell_location(inode,xpos,xsizei,rcuti)
  endif
 
- if (present(remote_export)) then
+ if (present(remote_export) .and. nprocs > 1) then
     global_search = .true.
     remote_export = .false.
  else

--- a/src/main/linklist_kdtree.F90
+++ b/src/main/linklist_kdtree.F90
@@ -218,8 +218,8 @@ subroutine get_neighbour_list(inode,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesi
     call get_cell_location(inode,xpos,xsizei,rcuti)
  endif
 
- if (present(remote_export) .and. nprocs > 1) then
-    global_search = .true.
+ if (present(remote_export)) then
+    if (nprocs > 1) global_search = .true.
     remote_export = .false.
  else
     global_search = .false.


### PR DESCRIPTION
Type of PR: 
modification to existing code

Description:
Optimisations to reduce unnecessary calls when compiling with `MPI=yes` but running with only 1 MPI task. This will allow the code to always be compiled with MPI enabled, even for pure OMP runs, with no loss of performance.

- Don't loop over all particles when balancing
- Don't build or walk global tree

Testing:
test suite

Did you run the bots? yes, pre-commit
