### PR TITLE
bugfix: initialise npartx

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,9 +22,9 @@ Elisabeth Borchert <elisabeth.borchert@monash.edu>
 Fangyi (Fitz) Hu <fhuu0005@student.monash.edu>
 Sergei Biriukov <svbiriukov@gmail.com>
 Giovanni Dipierro <giovanni.dipierro@leicester.ac.uk>
+Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Enrico Ragusa <enr.ragusa@gmail.com>
 Hauke Worpel <hworpel@aip.de>
-Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Roberto Iaconi <robertoiaconi1@gmail.com>
 Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
 Simon Glover <glover@uni-heidelberg.de>
@@ -43,14 +43,14 @@ fitzHu <54089891+Fitz-Hu@users.noreply.github.com>
 Chris Nixon <cjn@leicester.ac.uk>
 Nicolas Cuello <cuellonicolas@gmail.com>
 Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
-Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
+Joe Fisher <jwfis1@student.monash.edu>
 Cristiano Longarini <cristiano.longarini@unimi.it>
 David Trevascus <dtre10@student.monash.edu>
 Benoit Commercon <benoit.commercon@gmail.com>
 Zachary Pellow <zpel1@student.monash.edu>
-Joe Fisher <jwfis1@student.monash.edu>
-Orsola De Marco <orsola.demarco@mq.edu.au>
 dliptai <31463304+dliptai@users.noreply.github.com>
+Orsola De Marco <orsola.demarco@mq.edu.au>
+Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
 Maxime Lombart <maxime.lombart@ens-lyon.fr>
 Alison Young <ayoung@astro.ex.ac.uk>
 Jorge Cuadra <jcuadra@astro.puc.cl>

--- a/src/setup/setup_blob.f90
+++ b/src/setup/setup_blob.f90
@@ -93,6 +93,11 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
             "'          tau_kh = ',f10.3,',      v_0 = ',f6.3,/)") &
        denscloud,rcloud,denszero,przero,vzero/spsound,spsound,taukh,vzero
 
+ !
+ ! default value of npartx = 100
+ !
+ npartx = 100
+
  call prompt('enter number of particles in x dir',npartx,8)
  deltax = dxbound/npartx
 


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
Fixes #264

`npartx` is not initialised, so the default number of particles takes on a garbage value, resulting in non-deterministic behaviour. This is often larger than `maxp`, causing the setup to fail in the build suite.

Default value set to 100.

Testing:
Run `./phantomsetup` repeatedly and ensure the same output is created.

Did you run the bots? yes, pre-commit
