### PR TITLE
change default NMPI to 4 in Makefile

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,18 +43,18 @@ fitzHu <54089891+Fitz-Hu@users.noreply.github.com>
 Chris Nixon <cjn@leicester.ac.uk>
 Nicolas Cuello <cuellonicolas@gmail.com>
 Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
-Joe Fisher <jwfis1@student.monash.edu>
+dliptai <31463304+dliptai@users.noreply.github.com>
+Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
 Cristiano Longarini <cristiano.longarini@unimi.it>
 David Trevascus <dtre10@student.monash.edu>
 Benoit Commercon <benoit.commercon@gmail.com>
 Zachary Pellow <zpel1@student.monash.edu>
-dliptai <31463304+dliptai@users.noreply.github.com>
+Joe Fisher <jwfis1@student.monash.edu>
 Orsola De Marco <orsola.demarco@mq.edu.au>
-Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
-Maxime Lombart <maxime.lombart@ens-lyon.fr>
-Alison Young <ayoung@astro.ex.ac.uk>
+Stéven Toupin <steven.toupin@gmail.com>
 Jorge Cuadra <jcuadra@astro.puc.cl>
 James <jhw5@st-andrews.ac.uk>
 Steven Rieder <steven@rieder.nl>
-Stéven Toupin <steven.toupin@gmail.com>
+Alison Young <ayoung@astro.ex.ac.uk>
 Cox, Samuel <sc676@leicester.ac.uk>
+Maxime Lombart <maxime.lombart@ens-lyon.fr>

--- a/build/Makefile_qscripts
+++ b/build/Makefile_qscripts
@@ -30,7 +30,7 @@ ifeq ($(OPENMP),yes)
 endif
 ifeq ($(USEMPI),yes)
     ifndef NMPI
-        NMPI=8
+        NMPI=4
     endif
     ifndef QPE
         QPE=mpi


### PR DESCRIPTION
Type of PR: 
other

Description:
`make MPI=yes test` runs with `NMPI` tasks. Changing the default to 4, since that is the typical number of cores on a laptop workstation. Running with 8 tasks on machines that have less than 8 cores will require oversubscribing tasks.

Testing:
`make MPI=yes test`

Did you run the bots? yes
