### PR TITLE
Gas+rad+rec EoS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,18 +43,18 @@ fitzHu <54089891+Fitz-Hu@users.noreply.github.com>
 Chris Nixon <cjn@leicester.ac.uk>
 Nicolas Cuello <cuellonicolas@gmail.com>
 Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
-Joe Fisher <jwfis1@student.monash.edu>
+dliptai <31463304+dliptai@users.noreply.github.com>
+Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
 Cristiano Longarini <cristiano.longarini@unimi.it>
 David Trevascus <dtre10@student.monash.edu>
 Benoit Commercon <benoit.commercon@gmail.com>
 Zachary Pellow <zpel1@student.monash.edu>
-dliptai <31463304+dliptai@users.noreply.github.com>
+Joe Fisher <jwfis1@student.monash.edu>
 Orsola De Marco <orsola.demarco@mq.edu.au>
-Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
-Maxime Lombart <maxime.lombart@ens-lyon.fr>
-Alison Young <ayoung@astro.ex.ac.uk>
+Stéven Toupin <steven.toupin@gmail.com>
 Jorge Cuadra <jcuadra@astro.puc.cl>
 James <jhw5@st-andrews.ac.uk>
 Steven Rieder <steven@rieder.nl>
-Stéven Toupin <steven.toupin@gmail.com>
+Alison Young <ayoung@astro.ex.ac.uk>
 Cox, Samuel <sc676@leicester.ac.uk>
+Maxime Lombart <maxime.lombart@ens-lyon.fr>

--- a/src/main/eos.F90
+++ b/src/main/eos.F90
@@ -30,15 +30,15 @@ module eos
 ! :Owner: Daniel Price
 !
 ! :Runtime parameters:
-!   - X           : *hydrogen mass fraction*
+!   - X           : *H mass fraction (ignored if variable composition)*
+!   - Z           : *metallicity (ignored if variable composition)*
 !   - ieos        : *eqn of state (1=isoth;2=adiab;3=locally iso;8=barotropic)*
-!   - irecomb     : *recombination energy to include. 0=H2+H+He, 1=H+He, 2=He*
 !   - metallicity : *metallicity*
 !   - mu          : *mean molecular weight*
 !
 ! :Dependencies: dim, eos_barotropic, eos_gasradrec, eos_helmholtz,
 !   eos_idealplusrad, eos_mesa, eos_piecewise, eos_shen, infile_utils, io,
-!   ionization_mod, mesa_microphysics, part, physcon, units
+!   mesa_microphysics, options, part, physcon, units
 !
  implicit none
  integer, parameter, public :: maxeos = 20

--- a/src/main/eos_gasradrec.f90
+++ b/src/main/eos_gasradrec.f90
@@ -154,7 +154,7 @@ end subroutine init_eos_gasradrec
 !----------------------------------------------------------------
 subroutine eos_info_gasradrec(iprint)
  integer, intent(in) :: iprint
- 
+
  write(iprint,"(/,a,i1)") ' Gas+rad+rec EoS: irecomb = ',irecomb
 
 end subroutine eos_info_gasradrec

--- a/src/main/eos_gasradrec.f90
+++ b/src/main/eos_gasradrec.f90
@@ -18,7 +18,9 @@ module eos_gasradrec
 ! :Dependencies: ionization_mod, physcon
 !
  implicit none
- public :: equationofstate_gasradrec,calc_uT_from_rhoP_gasradrec
+ integer, public :: irecomb = 0 ! types of recombination energy to include for ieos=20
+ public :: equationofstate_gasradrec,calc_uT_from_rhoP_gasradrec,read_options_eos_gasradrec,&
+           write_options_eos_gasradrec,eos_info_gasradrec,init_eos_gasradrec
  private
 
 contains
@@ -116,5 +118,86 @@ subroutine calc_uT_from_rhoP_gasradrec(rhoi,presi,X,Y,T,eni,mui,ierr)
  mui = 1./imu
 
 end subroutine calc_uT_from_rhoP_gasradrec
+
+
+!-----------------------------------------------------------------------
+!+
+!  Initialise eos by setting ionisation energy array according to
+!  irecomb option
+!+
+!-----------------------------------------------------------------------
+subroutine init_eos_gasradrec(ierr)
+ use ionization_mod, only:ionization_setup,eion
+ integer, intent(out) :: ierr
+
+ ierr = 0
+ call ionization_setup
+ if (irecomb == 1) then
+    eion(1) = 0.  ! H and He recombination only (no recombination to H2)
+ elseif (irecomb == 2) then
+    eion(1:2) = 0.  ! He recombination only
+ elseif (irecomb == 3) then
+    eion(1:4) = 0.  ! No recombination energy
+ else
+    ierr = 1
+ endif
+ write(*,'(1x,a,i1,a)') 'Initialising gas+rad+rec EoS (irecomb = ',irecomb,')'
+
+end subroutine init_eos_gasradrec
+
+
+!----------------------------------------------------------------
+!+
+!  print eos information
+!+
+!----------------------------------------------------------------
+subroutine eos_info_gasradrec(iprint)
+ integer, intent(in) :: iprint
+ 
+ write(iprint,"(/,a,i1)") ' Gas+rad+rec EoS: irecomb = ',irecomb
+
+end subroutine eos_info_gasradrec
+
+
+!-----------------------------------------------------------------------
+!+
+!  reads equation of state options from the input file
+!+
+!-----------------------------------------------------------------------
+subroutine read_options_eos_gasradrec(name,valstring,imatch,igotall,ierr)
+ use io, only:fatal
+ character(len=*),  intent(in)  :: name,valstring
+ logical,           intent(out) :: imatch,igotall
+ integer,           intent(out) :: ierr
+ integer,           save        :: ngot  = 0
+ character(len=30), parameter   :: label = 'eos_gasradrec'
+
+ imatch  = .true.
+ select case(trim(name))
+ case('irecomb')
+    read(valstring,*,iostat=ierr) irecomb
+    if ((irecomb < 0) .or. (irecomb > 2)) call fatal(label,'irecomb = 0,1,2')
+    ngot = ngot + 1
+ case default
+    imatch = .false.
+ end select
+
+ igotall = (ngot >= 1)
+
+end subroutine read_options_eos_gasradrec
+
+
+!-----------------------------------------------------------------------
+!+
+!  writes equation of state options to the input file
+!+
+!-----------------------------------------------------------------------
+subroutine write_options_eos_gasradrec(iunit)
+ use infile_utils, only:write_inopt
+ integer, intent(in) :: iunit
+
+ call write_inopt(irecomb,'irecomb','recombination energy to include. 0=H2+H+He, 1=H+He, 2=He',iunit)
+
+end subroutine write_options_eos_gasradrec
 
 end module eos_gasradrec

--- a/src/main/eos_gasradrec.f90
+++ b/src/main/eos_gasradrec.f90
@@ -13,9 +13,10 @@ module eos_gasradrec
 !
 ! :Owner: Mike Lau
 !
-! :Runtime parameters: None
+! :Runtime parameters:
+!   - irecomb : *recombination energy to include. 0=H2+H+He, 1=H+He, 2=He*
 !
-! :Dependencies: ionization_mod, physcon
+! :Dependencies: infile_utils, io, ionization_mod, physcon
 !
  implicit none
  integer, public :: irecomb = 0 ! types of recombination energy to include for ieos=20


### PR DESCRIPTION
Type of PR: 
Bug fix and cleanup of gas+rad+rec EoS.

Description:
- Read composition (X and Z) from infile when using gas+rad+rec EoS with fixed composition. 
- Move `irecomb` option to `eos_gasradrec`
- Create subroutines read_options_eos_gasradrec, write_options_eos_gasradrec, eos_info_gasradrec, init_eos_gasradrec.
 
Testing:
Compiled with SETUP=star and wrote infile.

Did you run the bots? yes/no
Yes.
