### PR TITLE
Refactor gravity switch for force and getneigh

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,12 +26,12 @@ Conrad Chan <8309215+conradtchan@users.noreply.github.com>
 Enrico Ragusa <enr.ragusa@gmail.com>
 Hauke Worpel <hworpel@aip.de>
 Roberto Iaconi <robertoiaconi1@gmail.com>
-Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
 Simon Glover <glover@uni-heidelberg.de>
+Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
 Martina Toscani <mtoscani94@gmail.com>
 Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
-Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Simone Ceppi <simo.ceppi@gmail.com>
+Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Fitz Hu <fhuu0005@student.monash.edu>
 Christopher Russell <crussell@udel.edu>
 Megha Sharma <msha0023@student.monash.edu>
@@ -39,22 +39,23 @@ Alessia Franchini <alessia.franchini@unlv.edu>
 Alex Pettitt <alex@astro1.sci.hokudai.ac.jp>
 Kieran Hirsh <kieran.hirsh1@monash.edu>
 Nicole Rodrigues <nicole.rodrigues@monash.edu>
+dliptai <31463304+dliptai@users.noreply.github.com>
 fitzHu <54089891+Fitz-Hu@users.noreply.github.com>
 Chris Nixon <cjn@leicester.ac.uk>
 Nicolas Cuello <cuellonicolas@gmail.com>
 Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
-dliptai <31463304+dliptai@users.noreply.github.com>
-Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
+Joe Fisher <jwfis1@student.monash.edu>
 Cristiano Longarini <cristiano.longarini@unimi.it>
 David Trevascus <dtre10@student.monash.edu>
-Benoit Commercon <benoit.commercon@gmail.com>
+Caitlyn Hardiman <caitlyn.hardiman1@monash.edu>
 Zachary Pellow <zpel1@student.monash.edu>
-Joe Fisher <jwfis1@student.monash.edu>
+Benoit Commercon <benoit.commercon@gmail.com>
 Orsola De Marco <orsola.demarco@mq.edu.au>
-Stéven Toupin <steven.toupin@gmail.com>
+Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
+Maxime Lombart <maxime.lombart@ens-lyon.fr>
+Alison Young <ayoung@astro.ex.ac.uk>
 Jorge Cuadra <jcuadra@astro.puc.cl>
 James <jhw5@st-andrews.ac.uk>
 Steven Rieder <steven@rieder.nl>
-Alison Young <ayoung@astro.ex.ac.uk>
+Stéven Toupin <steven.toupin@gmail.com>
 Cox, Samuel <sc676@leicester.ac.uk>
-Maxime Lombart <maxime.lombart@ens-lyon.fr>

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -452,11 +452,8 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
     !--get the neighbour list and fill the cell cache
     !
 
-    call get_neighbour_list(icell,listneigh,nneigh,xyzh,xyzcache,maxcellcache,getj=.true., &
-#ifdef GRAVITY
-                           f=cell%fgrav, &
-#endif
-                           remote_export=remote_export)
+    call get_neighbour_list(icell,listneigh,nneigh,xyzh,xyzcache,maxcellcache, &
+                           getj=.true.,f=cell%fgrav,remote_export=remote_export)
 
     cell%owner                   = id
     cell%remote_export(1:nprocs) = remote_export
@@ -516,11 +513,9 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
     over_remote: do i = 1,stack_remote%n
        cell = stack_remote%cells(i)
 
-       call get_neighbour_list(-1,listneigh,nneigh,xyzh,xyzcache,maxcellcache,getj=.true., &
-#ifdef GRAVITY
-                         f=cell%fgrav, &
-#endif
-                         cell_xpos=cell%xpos,cell_xsizei=cell%xsizei,cell_rcuti=cell%rcuti)
+       call get_neighbour_list(-1,listneigh,nneigh,xyzh,xyzcache,maxcellcache, &
+                               getj=.true.,f=cell%fgrav,&
+                               cell_xpos=cell%xpos,cell_xsizei=cell%xsizei,cell_rcuti=cell%rcuti)
 
        call compute_cell(cell,listneigh,nneigh,Bevol,xyzh,vxyzu,fxyzu, &
                          iphase,divcurlv,divcurlB,alphaind,eta_nimhd,eos_vars, &

--- a/src/main/kdtree.F90
+++ b/src/main/kdtree.F90
@@ -900,7 +900,7 @@ end subroutine sort_particles_in_cell
 !+
 !----------------------------------------------------------------
 subroutine getneigh(node,xpos,xsizei,rcuti,ndim,listneigh,nneigh,xyzh,xyzcache,ixyzcachesize,ifirstincell,&
-& get_hj,fnode,remote_export)
+& get_hj,get_f,fnode,remote_export)
 #ifdef PERIODIC
  use boundary, only:dxbound,dybound,dzbound
 #endif
@@ -920,6 +920,7 @@ subroutine getneigh(node,xpos,xsizei,rcuti,ndim,listneigh,nneigh,xyzh,xyzcache,i
  real,    intent(out)               :: xyzcache(:,:)
  integer, intent(in)                :: ifirstincell(:)
  logical, intent(in)                :: get_hj
+ logical, intent(in)                :: get_f
  real,    intent(out),    optional  :: fnode(lenfgrav)
  logical, intent(out),    optional  :: remote_export(:)
  integer, parameter :: istacksize = 300
@@ -943,7 +944,7 @@ subroutine getneigh(node,xpos,xsizei,rcuti,ndim,listneigh,nneigh,xyzh,xyzcache,i
  hdlz = 0.5*dzbound
 #endif
  tree_acc2 = tree_accuracy*tree_accuracy
- if (present(fnode)) fnode(:) = 0.
+ if (get_f) fnode(:) = 0.
  rcut     = rcuti
 
  if (ixyzcachesize > 0) then
@@ -1070,7 +1071,7 @@ subroutine getneigh(node,xpos,xsizei,rcuti,ndim,listneigh,nneigh,xyzh,xyzcache,i
           endif
        endif if_leaf
 #ifdef GRAVITY
-    elseif (present(fnode)) then ! if_open_node
+    elseif (get_f) then ! if_open_node
 ! When searching for neighbours of this node, the tree walk may encounter
 ! nodes on the global tree that it does not need to open, so it should
 ! just add the contribution to fnode. However, when walking a different

--- a/src/main/linklist_kdtree.F90
+++ b/src/main/linklist_kdtree.F90
@@ -190,6 +190,7 @@ subroutine get_neighbour_list(inode,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesi
  use dim,    only:mpi
  use kdtree, only:getneigh,lenfgrav
  use kernel, only:radkern
+ use part,   only:gravity
 #ifdef PERIODIC
  use io,       only:warning
  use boundary, only:dxbound,dybound,dzbound
@@ -206,7 +207,7 @@ subroutine get_neighbour_list(inode,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesi
  real :: xpos(3)
  real :: fgrav(lenfgrav),fgrav_global(lenfgrav)
  real :: xsizei,rcuti
- logical :: get_j,global_search
+ logical :: get_j,global_search,get_f
 !
 !--retrieve geometric centre of the node and the search radius (e.g. 2*hmax)
 !
@@ -239,30 +240,22 @@ subroutine get_neighbour_list(inode,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesi
  get_j = .false.
  if (present(getj)) get_j = getj
 
- if (present(f)) then
-    fgrav_global = 0.0
+ get_f = (gravity .and. present(f))
 
-    if (mpi .and. global_search) then
-       call getneigh(nodeglobal,xpos,xsizei,rcuti,3,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesize,&
-                cellatid,get_j,fgrav_global,remote_export=remote_export)
-    endif
-
-    call getneigh(node,xpos,xsizei,rcuti,3,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesize,&
-              ifirstincell,get_j,fgrav)
-
-    f = fgrav + fgrav_global
-
- else
-
-    if (mpi .and. global_search) then
-       remote_export = .false.
-       call getneigh(nodeglobal,xpos,xsizei,rcuti,3,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesize,&
-              cellatid,get_j,remote_export=remote_export)
-    endif
-
-    call getneigh(node,xpos,xsizei,rcuti,3,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesize,&
-               ifirstincell,get_j)
+ if (mpi .and. global_search) then
+   ! Find MPI tasks that have neighbours of this cell, output to remote_export
+   call getneigh(nodeglobal,xpos,xsizei,rcuti,3,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesize,&
+            cellatid,get_j,get_f,fgrav_global,remote_export)
+ elseif (get_f) then
+   ! Set fgrav to zero, which matters if gravity is enabled but global search is not
+   fgrav_global = 0.0
  endif
+
+ ! Find neighbours of this cell on this node
+ call getneigh(node,xpos,xsizei,rcuti,3,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesize,&
+              ifirstincell,get_j,get_f,fgrav)
+
+ if (get_f) f = fgrav + fgrav_global
 
 end subroutine get_neighbour_list
 
@@ -278,7 +271,7 @@ subroutine getneigh_pos(xpos,xsizei,rcuti,ndim,mylistneigh,nneigh,xyzh,xyzcache,
  integer, intent(in)  :: ifirstincell(:) !ncellsmax+1)
 
  call getneigh(node,xpos,xsizei,rcuti,ndim,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesize, &
-               ifirstincell,.false.)
+               ifirstincell,.false.,.false.)
 
 end subroutine getneigh_pos
 

--- a/src/main/linklist_kdtree.F90
+++ b/src/main/linklist_kdtree.F90
@@ -243,12 +243,12 @@ subroutine get_neighbour_list(inode,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesi
  get_f = (gravity .and. present(f))
 
  if (mpi .and. global_search) then
-   ! Find MPI tasks that have neighbours of this cell, output to remote_export
-   call getneigh(nodeglobal,xpos,xsizei,rcuti,3,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesize,&
+    ! Find MPI tasks that have neighbours of this cell, output to remote_export
+    call getneigh(nodeglobal,xpos,xsizei,rcuti,3,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesize,&
             cellatid,get_j,get_f,fgrav_global,remote_export)
  elseif (get_f) then
-   ! Set fgrav to zero, which matters if gravity is enabled but global search is not
-   fgrav_global = 0.0
+    ! Set fgrav to zero, which matters if gravity is enabled but global search is not
+    fgrav_global = 0.0
  endif
 
  ! Find neighbours of this cell on this node


### PR DESCRIPTION
Type of PR: 
modification to existing code

Description:
The switch for determining whether f_grav needs to be calculated is convoluted and depends on the GRAVITY pp flag. This makes the code hard to understand. This change simplifies the logic, without affecting performance.

Testing:
Test suite with and without MPI

Did you run the bots? yes
