### PR TITLE
(#275) download files from data.phantom.cloud.edu.au not users.monash…

### DIFF
--- a/src/main/datafiles.f90
+++ b/src/main/datafiles.f90
@@ -20,7 +20,7 @@ module datafiles
 !
  implicit none
  character(len=*), parameter :: data_url = &
-  'http://users.monash.edu.au/~dprice/phantom/'
+  'http://data.phantom.cloud.edu.au/'
 
 contains
 


### PR DESCRIPTION
…, closes #275

Type of PR: 
Bug fix/ other

Description:
phantom will now try to download data files from http://data.phantom.cloud.edu.au/data/ instead of from my personal web page

Testing:
```
cd
git clone git@github.com:danieljprice/phantom
export PHANTOM_DIR=~/phantom
cd phantom
make SETUP=test phantomtest && ./bin/phantomtest eos
```
works successfully to initialise the tabulated equations of state.

Did you run the bots? no
