### PR TITLE
Fixed phantom2hdf5 not compiling

### DIFF
--- a/src/main/readwrite_dumps_hdf5.F90
+++ b/src/main/readwrite_dumps_hdf5.F90
@@ -36,7 +36,7 @@ module readwrite_dumps_hdf5
 
  implicit none
  character(len=80), parameter, public :: &    ! module version
-   modid="$Id: 8606a6c35a6fd309c2822227d547da960496083c $"
+   modid="$Id$"
 
  public :: read_dump_hdf5,read_smalldump_hdf5
  public :: write_smalldump_hdf5,write_fulldump_hdf5,write_dump_hdf5

--- a/src/main/readwrite_dumps_hdf5.F90
+++ b/src/main/readwrite_dumps_hdf5.F90
@@ -36,7 +36,7 @@ module readwrite_dumps_hdf5
 
  implicit none
  character(len=80), parameter, public :: &    ! module version
-   modid="$Id$"
+   modid="$Id: 8606a6c35a6fd309c2822227d547da960496083c $"
 
  public :: read_dump_hdf5,read_smalldump_hdf5
  public :: write_smalldump_hdf5,write_fulldump_hdf5,write_dump_hdf5
@@ -496,6 +496,7 @@ subroutine read_any_dump_hdf5(                                                  
  real,              intent(out) :: tfile,hfactfile
  integer,           intent(in)  :: idisk1,iprint,id,nprocs
  integer,           intent(out) :: ierr
+ integer(kind=8)                :: nparttot
  logical, optional, intent(in)  :: headeronly
  logical, optional, intent(in)  :: dustydisc
  logical, optional, intent(in)  :: acceptsmall
@@ -603,7 +604,7 @@ subroutine read_any_dump_hdf5(                                                  
 #ifdef INJECT_PARTICLES
  call allocate_memory(maxp_hard)
 #else
- call allocate_memory(int(min(nprocs,4)*nparttot/nprocs))
+ call allocate_memory(int(min(nprocs,4)*nparttot/nprocs,8))
 #endif
 
  if (periodic) then
@@ -703,6 +704,9 @@ subroutine read_any_dump_hdf5(                                                  
                       got_arrays%got_krome_gamma, &
                       got_arrays%got_krome_mu,    &
                       got_arrays%got_krome_T,     &
+                      .false.,                    &
+                      .false.,                    &
+                      .false.,                    &
                       got_arrays%got_abund,       &
                       got_arrays%got_dustfrac,    &
                       got_arrays%got_sink_data,   &

--- a/src/main/utils_dumpfiles_hdf5.f90
+++ b/src/main/utils_dumpfiles_hdf5.f90
@@ -18,7 +18,7 @@ module utils_dumpfiles_hdf5
 !
  use dim,        only:maxtypes,maxdustsmall,maxdustlarge,nabundances,nsinkproperties
  use part,       only:eos_vars_label,igasP,itemp,maxirad
- use eos,        only:ieos,eos_is_nonideal,eos_outputs_gasP
+ use eos,        only:ieos,eos_is_non_ideal,eos_outputs_gasP
  use utils_hdf5, only:write_to_hdf5,    &
                       read_from_hdf5,   &
                       create_hdf5file,  &
@@ -401,7 +401,7 @@ subroutine write_hdf5_arrays( &
  if (eos_outputs_gasP(ieos)) then
     call write_to_hdf5(eos_vars(igasP,1:npart), eos_vars_label(igasP), group_id, error)
  endif
- if (eos_is_nonideal(ieos)) then
+ if (eos_is_non_ideal(ieos)) then
     call write_to_hdf5(eos_vars(itemp,1:npart), eos_vars_label(itemp), group_id, error)
  endif
  if (array_options%lightcurve) then
@@ -884,7 +884,7 @@ subroutine read_hdf5_arrays( &
     call read_from_hdf5(vxyzu(4,:), 'u', group_id, got, error)
     if (.not.got) got_arrays%got_vxyzu = .false.
  endif
- if (eos_is_nonideal(ieos)) then
+ if (eos_is_non_ideal(ieos)) then
     call read_from_hdf5(eos_vars(itemp,:), eos_vars_label(itemp), group_id, got_arrays%got_temp, error)
  endif
 


### PR DESCRIPTION
Type of PR: 
Fixed some files that were preventing phantom2hdf5 from being compiled.

Testing:
I successfully compiled phantom2hdf5 and was able to use it to turn PHANTOM dumps into usable .hdf5 files

Did you run the bots?
Yes.
