### PR TITLE
Fixes to the bots.sh pre-commit action

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
+repos:
 -   repo: local
     hooks:
     -   id: bots
         name: Run bots
-        entry: scripts/bots.sh --apply --file
+        entry: scripts/bots.sh --apply --files
         language: script
+        require_serial: true

--- a/scripts/bots.sh
+++ b/scripts/bots.sh
@@ -158,7 +158,7 @@ for edittype in $bots_to_run; do
              myfiles=`get_only_files_in_git "$files"`
            fi
            for file in $myfiles; do
-               if [[ "$input_files" != "" && "$input_files" != *"$dir/$file"* ]]; then
+               if [[ "$input_files" != "" && "$input_files" != *"$dir/$file"* && "$edittype" != "authors" ]]; then
                  continue
                fi
                out="$tmpdir/$file"

--- a/scripts/bots.sh
+++ b/scripts/bots.sh
@@ -69,6 +69,12 @@ while [[ "$1" == --* ]]; do
       break;
       ;;
 
+   --files)
+      shift
+      input_files="$*"
+      break;
+      ;;
+
     *)
       badflag=$1
       ;;
@@ -152,6 +158,9 @@ for edittype in $bots_to_run; do
              myfiles=`get_only_files_in_git "$files"`
            fi
            for file in $myfiles; do
+               if [[ "$input_files" != "" && "$input_files" != *"$dir/$file"* ]]; then
+                 continue
+               fi
                out="$tmpdir/$file"
 #               echo "FILE=$file OUT=$out";
                case $edittype in

--- a/scripts/bots.sh
+++ b/scripts/bots.sh
@@ -154,6 +154,10 @@ for edittype in $bots_to_run; do
              else
                myfiles=""
              fi
+           elif [[ "$input_files" != "" ]]; then
+             # if using pre-commit to pass in a list of files, then there is no need to check
+             # if these files are in git
+             myfiles="$files"
            else
              myfiles=`get_only_files_in_git "$files"`
            fi


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
- Creation of the AUTHORS file is not threadsafe, so parallel pre-commit cannot be used. Set `require_serial: true`
- Update `.pre-commit-config.yaml` formatting
- Only the first file being passed through using the `--file` option was being processed. Now takes a list of files
- Only run with the subset of files that would be run if the full `bots.sh` script was being run
- Optimisation to remove unnecessary calls to `get_only_files_in_git()`, because files are already in git (or will be in git) if they are being handled by pre-commit.

Testing:
Source files were manually changed to violate the bots rules, and confirmed that this blocked the commit. Run time is only a few seconds, which shows that the script is only being run on the relevant files.

Did you run the bots? yes
