### PR TITLE
bugfix: safety factor for stacksize calculation

### DIFF
--- a/src/main/mpi_memory.F90
+++ b/src/main/mpi_memory.F90
@@ -159,7 +159,7 @@ subroutine calculate_stacksize(npart)
  ! number of particles per cell, divided by number of tasks
  if (mpi .and. nprocs > 1) then
     ! assume that every cell will be exported, with some safety factor
-    stacksize = (npart / minpart / nprocs) * 4
+    stacksize = (npart / minpart / nprocs) * safety
 
     if (id == master) then
        write(iprint, *) 'MPI memory stack size = ', stacksize


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
Safety factor was hardcoded as `4` instead of being used from the parameter value. This fix does not change results.

Testing:
No tests

Did you run the bots? no
