### PR TITLE
disable benchmarks action

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,18 +1,18 @@
 name: bench
 
 on:
-  push:
-    branches: [ master ]
-    paths-ignore:
-      - 'docs/**'
-      - 'README.md'
-  pull_request:
-    branches: [ master ]
-    paths-ignore:
-      - 'docs/**'
-      - 'README.md'
-  schedule:
-    - cron: "0 0 * * *"
+  # push:
+  #   branches: [ master ]
+  #   paths-ignore:
+  #     - 'docs/**'
+  #     - 'README.md'
+  # pull_request:
+  #   branches: [ master ]
+  #   paths-ignore:
+  #     - 'docs/**'
+  #     - 'README.md'
+  # schedule:
+  #   - cron: "0 0 * * *"
 
 env:
   OMP_STACKSIZE: 512M


### PR DESCRIPTION
Type of PR: 
other

Description:
The phantom-dev Nectar project has not been renewed, so the custom runners for performing benchmarks are not available. This causes checks to hang until they time out. Although benchmarks are not required to merge PRs, this creates confusing behaviour. The benchmark triggers have been disabled until the project is renewed.

Testing:
No testing

Did you run the bots? no
