### PR TITLE
(phantomsetup) Bug fix when using MPI

### DIFF
--- a/src/setup/phantomsetup.F90
+++ b/src/setup/phantomsetup.F90
@@ -57,7 +57,7 @@ program phantomsetup
  real                        :: time,pmassi
  logical                     :: iexist
 
- nprocs = 1    ! for MPI, this is not initialised until init_mpi, but an initialised value is required for init_part
+! nprocs = 1    ! for MPI, this is not initialised until init_mpi, but an initialised value is required for init_part
  call set_io_unit_numbers
  call set_units
  call set_boundary

--- a/src/setup/phantomsetup.F90
+++ b/src/setup/phantomsetup.F90
@@ -57,7 +57,7 @@ program phantomsetup
  real                        :: time,pmassi
  logical                     :: iexist
 
- nprocs = 1 ! for MPI, this is not initialised until init_mpi, but is required for init_part
+ nprocs = 1    ! for MPI, this is not initialised until init_mpi, but an initialised value is required for init_part
  call set_io_unit_numbers
  call set_units
  call set_boundary

--- a/src/setup/phantomsetup.F90
+++ b/src/setup/phantomsetup.F90
@@ -57,7 +57,7 @@ program phantomsetup
  real                        :: time,pmassi
  logical                     :: iexist
 
- nprocs = 1 ! for MPI, this is not initialised until init_mpi, but required in init_part
+ nprocs = 1 ! for MPI, this is not initialised until init_mpi, but is required for init_part
  call set_io_unit_numbers
  call set_units
  call set_boundary

--- a/src/setup/phantomsetup.F90
+++ b/src/setup/phantomsetup.F90
@@ -57,6 +57,7 @@ program phantomsetup
  real                        :: time,pmassi
  logical                     :: iexist
 
+ nprocs = 1 ! for MPI, this is not initialised until init_mpi, but required in init_part
  call set_io_unit_numbers
  call set_units
  call set_boundary

--- a/src/setup/phantomsetup.F90
+++ b/src/setup/phantomsetup.F90
@@ -57,7 +57,7 @@ program phantomsetup
  real                        :: time,pmassi
  logical                     :: iexist
 
-! nprocs = 1    ! for MPI, this is not initialised until init_mpi, but an initialised value is required for init_part
+ nprocs = 1    ! for MPI, this is not initialised until init_mpi, but an initialised value is required for init_part
  call set_io_unit_numbers
  call set_units
  call set_boundary


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
As per tbdrstl on Slack, this is a bug patch when running phantomsetup using MPI.  @danieljprice , is there a reason that init_mpi and associated commands are so far down in phantomsetup?  The other patch would be to move the init_mpi commands to the top above set_io_unit_numbers, but I am unsure if this would cause other issues... 

Testing:
Compiled & test ran phantomsetup

Did you run the bots? no
