### PR TITLE
fix bug in implicit cooling when du/dt goes to zero

### DIFF
--- a/src/main/cooling_solver.f90
+++ b/src/main/cooling_solver.f90
@@ -22,7 +22,7 @@ module cooling_solver
 !   - bowen_Cprime   : *radiative cooling rate (g.s/cm³)*
 !   - dust_collision : *dust collision (1=on/0=off)*
 !   - excitation_HI  : *cooling via electron excitation of HI (1=on/0=off)*
-!   - lambda_shock   : *Cooling rate parmaeter for analytic shock solution*
+!   - lambda_shock   : *Cooling rate parameter for analytic shock solution*
 !   - relax_bowen    : *Bowen (diffusive) relaxation (1=on/0=off)*
 !   - relax_stefan   : *radiative relaxation (1=on/0=off)*
 !   - shock_problem  : *piecewise formulation for analytic shock solution (1=on/0=off)*
@@ -473,7 +473,7 @@ subroutine write_options_cooling_solver(iunit)
  call write_inopt(dust_collision,'dust_collision','dust collision (1=on/0=off)',iunit)
  call write_inopt(shock_problem,'shock_problem','piecewise formulation for analytic shock solution (1=on/0=off)',iunit)
  if (shock_problem == 1) then
-    call write_inopt(lambda_shock_cgs,'lambda_shock','Cooling rate parmaeter for analytic shock solution',iunit)
+    call write_inopt(lambda_shock_cgs,'lambda_shock','Cooling rate parameter for analytic shock solution',iunit)
     call write_inopt(T1_factor,'T1_factor','factor by which T0 is increased (T1= T1_factor*T0)',iunit)
     call write_inopt(T0_value,'T0','temperature to cool towards (do not modify! set by setup)',iunit)
  endif

--- a/src/setup/setup_shock.F90
+++ b/src/setup/setup_shock.F90
@@ -104,7 +104,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use setshock,        only:set_shock,adjust_shock_boundaries,fsmooth
  use radiation_utils, only:radiation_and_gas_temperature_equal
  use eos_idealplusrad,only:get_idealgasplusrad_tempfrompres,get_idealplusrad_enfromtemp
- use eos,             only:gmw,temperature_coef,init_eos
+ use eos,             only:temperature_coef,init_eos
  use cooling,         only:T0_value
 #ifdef NONIDEALMHD
  use nicil,           only:eta_constant,eta_const_type,icnstsemi
@@ -739,7 +739,8 @@ subroutine write_setupfile(filename,iprint,numstates,gamma,polyk,dtg)
  call write_inopt(tmax,'tmax','maximum runtime',lu,ierr1)
  call write_inopt(dtmax,'dtmax','time between dumps',lu,ierr1)
  call write_inopt(ieos,'ieos','equation of state option',lu,ierr1)
- if (do_radiation) call write_inopt(gmw,'gmw','mean molecular weight',lu,ierr1)
+ call write_inopt(gmw,'gmw','mean molecular weight',lu,ierr1)
+ !if (do_radiation) call write_inopt(gmw,'gmw','mean molecular weight',lu,ierr1)
 #ifdef NONIDEALMHD
  call write_inopt(use_ohm,'use_ohm','include Ohmic resistivity',lu,ierr1)
  call write_inopt(use_hall,'use_hall','include the Hall effect',lu,ierr1)
@@ -799,7 +800,8 @@ subroutine read_setupfile(filename,iprint,numstates,gamma,polyk,dtg,ierr)
  call read_inopt(tmax,'tmax',db,errcount=nerr)
  call read_inopt(dtmax,'dtmax',db,errcount=nerr)
  call read_inopt(ieos,'ieos',db,errcount=nerr)
- if (do_radiation) call read_inopt(gmw,'gmw',db,errcount=nerr)
+ call read_inopt(gmw,'gmw',db,errcount=nerr)
+ !if (do_radiation) call read_inopt(gmw,'gmw',db,errcount=nerr)
 #ifdef NONIDEALMHD
  call read_inopt(use_ohm,'use_ohm',db,errcount=nerr)
  call read_inopt(use_hall,'use_hall',db,errcount=nerr)


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
when cooling is zero, e.g. using the piecewise cooling function, variables in implicit cooling become undefined

Testing:
tested on shock tube

Did you run the bots? no need, just been done