### PR TITLE
(star) set up star in simulation with radiation

### DIFF
--- a/src/setup/set_star.f90
+++ b/src/setup/set_star.f90
@@ -76,7 +76,7 @@ subroutine read_star_profile(iprofile,ieos,input_profile,gamma,polyk,ui_coef,r,d
  real, allocatable, intent(out)   :: r(:),den(:),pres(:),temp(:),en(:),mtab(:)
  real, allocatable, intent(out)   :: Xfrac(:),Yfrac(:),mu(:)
  integer,           intent(out)   :: npts
- real,              intent(out)   :: rmin,Rstar,Mstar,rhocentre,hsoft
+ real,              intent(inout) :: rmin,Rstar,Mstar,rhocentre,hsoft
  integer,           intent(in)    :: isoftcore,isofteningopt
  real,              intent(in)    :: rcore
  integer :: ierr,i
@@ -87,7 +87,6 @@ subroutine read_star_profile(iprofile,ieos,input_profile,gamma,polyk,ui_coef,r,d
  ! set up tabulated density profile
  !
  calc_polyk = .true.
- hsoft = 0.
  allocate(r(ng_max),den(ng_max),pres(ng_max),temp(ng_max),en(ng_max),mtab(ng_max))
 
  print "(/,a,/)",' Using '//trim(profile_opt(iprofile))

--- a/src/setup/setup_star.f90
+++ b/src/setup/setup_star.f90
@@ -87,6 +87,7 @@ contains
 !-----------------------------------------------------------------------
 subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,time,fileprefix)
  use centreofmass,    only:reset_centreofmass
+ use dim,             only:do_radiation
  use units,           only:set_units,select_unit,utime,unit_density
  use kernel,          only:hfact_default
  use extern_densprofile, only:write_rhotab,rhotabfile,read_rhotab_wrapper
@@ -94,7 +95,8 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use eos_piecewise,   only:init_eos_piecewise_preset
  use setstar,         only:set_stellar_core,read_star_profile,set_star_density, &
                            set_star_composition,set_star_thermalenergy
- use part,            only:nptmass,xyzmh_ptmass,vxyz_ptmass,eos_vars,rad,igas
+ use part,            only:nptmass,xyzmh_ptmass,vxyz_ptmass,eos_vars,rad,igas,imu
+ use radiation_utils, only:set_radiation_and_gas_temperature_equal
  use relaxstar,       only:relax_star
  use mpiutils,        only:reduceall_mpi
  use mpidomain,       only:i_belong
@@ -255,6 +257,14 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  !
  if (maxvxyzu==4) call set_star_thermalenergy(ieos,den,pres,r,npart,xyzh,vxyzu,rad,&
                                               eos_vars,relax_star_in_setup,use_var_comp,initialtemp)
+
+ if (do_radiation) then
+    if (eos_outputs_mu(ieos)) then
+       call set_radiation_and_gas_temperature_equal(npart,xyzh,vxyzu,massoftype,rad,eos_vars(imu,:))
+    else
+       call set_radiation_and_gas_temperature_equal(npart,xyzh,vxyzu,massoftype,rad)
+    endif
+ endif
 
  call finish_eos(ieos,ierr)
  !


### PR DESCRIPTION
Type of PR: 
Bug fix & modification to existing code

Description:
Add line in setup_star to set gas and radiation temperatures to be equal when do_radiation=.true.
Also, removed hard-wiring hsoft = 0 despite non-zero value specified in .setup file.

Testing:
Set up stars both using SETUP=star and SETUP=radstar

Did you run the bots? yes/no
No