### PR TITLE
(datafiles) fix broken url; use curl not wget to get around certifica…

### DIFF
--- a/src/main/datafiles.f90
+++ b/src/main/datafiles.f90
@@ -20,7 +20,7 @@ module datafiles
 !
  implicit none
  character(len=*), parameter :: data_url = &
-  'http://data.phantom.cloud.edu.au/'
+  'https://users.monash.edu.au/~dprice/phantom/'
 
 contains
 

--- a/src/main/utils_datafiles.f90
+++ b/src/main/utils_datafiles.f90
@@ -147,6 +147,7 @@ subroutine retrieve_remote_file(url,file,dir,localfile,ierr)
  integer,          intent(out) :: ierr
  integer :: ilen,iunit!,ierr1
  logical :: iexist
+ character(len=*), parameter :: cmd = 'curl'
 
  print "(80('-'))"
  print "(a)",'  Downloading '//trim(file)//' from '//trim(url)
@@ -155,19 +156,19 @@ subroutine retrieve_remote_file(url,file,dir,localfile,ierr)
  ierr = 0
  ! check that wget utility exists
  !call execute_command_line('type -p wget > /dev/null',wait=.true.,exitstat=ierr,cmdstat=ierr1)
- call system('type -p wget > /dev/null')
+ call system('type -p curl > /dev/null')
 
  if (ierr /= 0) then
-    print "(a)",' ERROR: wget utility does not exist'
+    print "(a)",' ERROR: curl utility does not exist'
  else
     if (len_trim(dir) > 0) then
-       !call execute_command_line('wget '//trim(url)//trim(file)//' -O '//trim(dir)//trim(file),wait=.true.,&
+       !call execute_command_line(trim(cmd)//' '//trim(url)//trim(file)//' -O '//trim(dir)//trim(file),wait=.true.,&
        !                          exitstat=ierr,cmdstat=ierr1)
-       call system('wget '//trim(url)//trim(file)//' -O '//trim(dir)//trim(file))
+       call system(trim(cmd)//' '//trim(url)//trim(file)//' -o '//trim(dir)//trim(file))
        localfile = trim(dir)//trim(file)
     else
-       !call execute_command_line('wget '//trim(url)//trim(file),wait=.true.,exitstat=ierr,cmdstat=ierr1)
-       call system('wget '//trim(url)//trim(file))
+       !call execute_command_line(trim(cmd)//' '//trim(url)//trim(file),wait=.true.,exitstat=ierr,cmdstat=ierr1)
+       call system(trim(cmd)//' '//trim(url)//trim(file)//' -o '//trim(file))
        localfile = trim(file)
     endif
  endif


### PR DESCRIPTION
some functionality in phantom (e.g. MESA equation of state) relies on downloading data files from a web server, but this was shut down because running a server on vanilla http is insecure. Switching this back to my webpage is ok (since https) but then wget would not download from https server without --no-check-certificate which is again insecure. 

Type of PR: 
Bug fix #335 see also #275

Description:
The solution here is to use curl instead of wget to download files, which correctly handles certificate checking and https. The server address has been changed back to my webpage.

Testing:
```
export PHANTOM_DIR=~/phantom
make SETUP=test phantomtest && ./bin/phantomtest eos
```
Did you run the bots? no
