### PR TITLE
(timestep) turing off auto-decrease of dtmax if wall time between dum…

### DIFF
--- a/src/main/checksetup.F90
+++ b/src/main/checksetup.F90
@@ -345,7 +345,7 @@ subroutine check_setup(nerror,nwarn,restart)
     endif
     if (mhd_nonideal) then
        if (n_nden /= n_nden_phantom) then
-          print*,'Error in setup: n_nden in nicil.f90 needs to match n_nden_phantom in config.F90'
+          print*,'Error in setup: n_nden in nicil.f90 needs to match n_nden_phantom in config.F90; n_nden = ',n_nden
           nerror = nerror + 1
        endif
     endif

--- a/src/main/timestep.F90
+++ b/src/main/timestep.F90
@@ -53,7 +53,7 @@ subroutine set_defaults_timestep
  nmax    = -1
  nout    = -1
 
- dtwallmax = 43200.0         ! maximum wall time between dumps (seconds); default = 12h
+ dtwallmax = 0.              ! maximum wall time between dumps (seconds)
 
  ! Values to control dtmax changing with increasing densities
  dtmax_dratio =  0.          ! dtmax will change if this ratio is exceeded in a timestep (recommend 1.258)


### PR DESCRIPTION
Type of PR: 
other

Description:
Changing the default setting of dtwallmax to zero; a non-zero value has been causing more issues than it's worth.  Might re-activate once we have changed names for the intermediary dumps

Testing:
None; trivial parameter change

Did you run the bots? no
