### PR TITLE
give --maxp as flag to phantomsetup

### DIFF
--- a/src/utils/moddump_sink.f90
+++ b/src/utils/moddump_sink.f90
@@ -40,30 +40,33 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
            'hacc = ',xyzmh_ptmass(ihacc,i)
  enddo
  isinkpart = 2
- call prompt('Enter the sink particle number to modify:',isinkpart,1,nptmass)
+ do while (isinkpart /= 0)
+    call prompt('Enter the sink particle number to modify:',isinkpart,0,nptmass)
+    if (isinkpart <= 0) exit
+ 
+    mass = xyzmh_ptmass(4,isinkpart)
+    mass_old = mass
+    call prompt('Enter new mass for the sink:',mass,0.)
+    print*,'Mass changed to ',mass
+    xyzmh_ptmass(4,isinkpart) = mass
 
- mass = xyzmh_ptmass(4,isinkpart)
- mass_old = mass
- call prompt('Enter new mass for the sink:',mass,0.)
- print*,'Mass changed to ',mass
- xyzmh_ptmass(4,isinkpart) = mass
+    racc = xyzmh_ptmass(ihacc,isinkpart)
+    ! rescaling accretion radius for updated mass
+    racc = racc * (mass/mass_old)**(1./3)
+    call prompt('Enter new accretion radius for the sink:',racc,0.)
+    print*,'Accretion radius changed to ',racc
+    xyzmh_ptmass(ihacc,isinkpart) = racc
 
- racc = xyzmh_ptmass(ihacc,isinkpart)
- ! rescaling accretion radius for updated mass
- racc = racc * (mass/mass_old)**(1./3)
- call prompt('Enter new accretion radius for the sink:',racc,0.)
- print*,'Accretion radius changed to ',racc
- xyzmh_ptmass(ihacc,isinkpart) = racc
+    hsoft = xyzmh_ptmass(ihsoft,isinkpart)
+    call prompt('Enter new softening length for the sink:',hsoft,0.)
+    print*,'Softening length changed to ',hsoft
+    xyzmh_ptmass(ihsoft,isinkpart) = hsoft
 
- hsoft = xyzmh_ptmass(ihsoft,isinkpart)
- call prompt('Enter new softening length for the sink:',hsoft,0.)
- print*,'Softening length changed to ',hsoft
- xyzmh_ptmass(ihsoft,isinkpart) = hsoft
-
- newx = xyzmh_ptmass(1,isinkpart)
- call prompt('Enter new x-coordinate for the sink in code units:',newx,0.)
- xyzmh_ptmass(1,isinkpart) = newx
- print*,'x-coordinate changed to ',xyzmh_ptmass(1,isinkpart)
+    newx = xyzmh_ptmass(1,isinkpart)
+    call prompt('Enter new x-coordinate for the sink in code units:',newx,0.)
+    xyzmh_ptmass(1,isinkpart) = newx
+    print*,'x-coordinate changed to ',xyzmh_ptmass(1,isinkpart)
+ enddo
 
  iresetCM = .false.
  call prompt('Reset centre of mass?',iresetCM)


### PR DESCRIPTION
Type of PR: 
other

Description:
small change to allow giving of --maxp=2000000 as a command line flag to phantomsetup, avoiding the need to recompile to allocate memory

Testing:
./phantomsetup --maxp=2000000 works

Did you run the bots? no
