### PR TITLE
Damping bcs

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -540,7 +540,8 @@ SOURCES= physcon.f90 ${CONFIG} ${SRCKERNEL} io.F90 units.f90 boundary.f90 \
          partinject.F90 utils_inject.f90 dust_formation.F90 ptmass_radiation.F90 ptmass_heating.F90 \
          mpi_dens.F90 mpi_force.F90 mpi_memory.F90 mpi_derivs.F90 kdtree.F90 linklist_kdtree.F90 \
          radiation_implicit.f90 ${SRCTURB} \
-         ${SRCPHOTO} ${SRCINJECT} utils_healpix.f90 utils_raytracer.f90 ${SRCKROME} memory.F90 ${SRCREADWRITE_DUMPS}  \
+         ${SRCPHOTO} ${SRCINJECT_DEPS} ${SRCINJECT} \
+         utils_healpix.f90 utils_raytracer.f90 ${SRCKROME} memory.F90 ${SRCREADWRITE_DUMPS}  \
          quitdump.f90 ptmass.F90 \
          readwrite_infile.F90 dens.F90 force.F90 utils_deriv.f90 deriv.F90 energies.F90 sort_particles.F90 \
          utils_shuffleparticles.F90 evwrite.F90 step_leapfrog.F90 writeheader.F90 ${SRCAN} step_supertimestep.F90 \

--- a/build/Makefile
+++ b/build/Makefile
@@ -623,7 +623,7 @@ SRCDUMP= physcon.f90 ${CONFIG} ${SRCKERNEL} io.F90 units.f90 boundary.f90 mpi_ut
          memory.F90 \
          utils_sphNG.f90 \
          setup_params.f90 ${SRCFASTMATH} checkoptions.F90 \
-         viscosity.f90 options.f90 checkconserved.f90 prompting.f90 ${SRCDUST} \
+         viscosity.f90 damping.f90 options.f90 checkconserved.f90 prompting.f90 ${SRCDUST} \
          ${SRCREADWRITE_DUMPS} \
          utils_sort.f90 sort_particles.F90
 OBJDUMP1= $(SRCDUMP:.f90=.o)
@@ -659,7 +659,7 @@ SRCSETUP= utils_omp.F90 utils_summary.F90 utils_gravwave.f90 \
           set_cubic_core.f90 set_fixedentropycore.f90 set_softened_core.f90 set_star.f90 relax_star.f90 \
           set_vfield.f90 ptmass_radiation.F90 ${SRCINJECT} \
           ${SETUPFILE} checksetup.F90 \
-          set_Bfield.f90 damping.f90 readwrite_infile.f90 ${SRCKROME}
+          set_Bfield.f90 readwrite_infile.f90 ${SRCKROME}
 
 OBJSETUP1= $(SRCSETUP:.f90=.o)
 ifeq ($(KROME), krome)

--- a/build/Makefile
+++ b/build/Makefile
@@ -534,8 +534,8 @@ SOURCES= physcon.f90 ${CONFIG} ${SRCKERNEL} io.F90 units.f90 boundary.f90 \
          utils_sort.f90 utils_supertimestep.F90 utils_tables.f90 utils_gravwave.f90 \
          utils_sphNG.f90 utils_vectors.f90 utils_datafiles.f90 datafiles.f90 \
          gitinfo.f90 ${SRCFASTMATH} random.f90 ${SRCEOS} cullendehnen.f90 ${SRCNIMHD} ${SRCGR} \
- 	 		checkoptions.F90 viscosity.f90 options.f90 cons2primsolver.f90 radiation_utils.f90 cons2prim.f90 \
-         centreofmass.f90 ${SRCPOT} damping.f90 checkconserved.f90 \
+ 	 checkoptions.F90 viscosity.f90 damping.f90 options.f90 cons2primsolver.f90 radiation_utils.f90 cons2prim.f90 \
+         centreofmass.f90 ${SRCPOT} checkconserved.f90 \
          utils_filenames.f90 utils_summary.F90 ${SRCCHEM} ${SRCDUST} \
          partinject.F90 utils_inject.f90 dust_formation.F90 ptmass_radiation.F90 ptmass_heating.F90 \
          mpi_dens.F90 mpi_force.F90 mpi_memory.F90 mpi_derivs.F90 kdtree.F90 linklist_kdtree.F90 \

--- a/build/Makefile_setups
+++ b/build/Makefile_setups
@@ -243,9 +243,9 @@ ifeq ($(SETUP), gwdisc)
     MAXP=2000000
     IND_TIMESTEPS=yes
     ISOTHERMAL=yes
-    KNOWN_SETUP=yes
     MULTIRUNFILE= multirun.f90
     SRCPOT= ${SRCPOTS:extern_binary.f90=extern_binary_gw.f90}
+    KNOWN_SETUP=yes
 endif
 
 ifeq ($(SETUP), nshwdisc)
@@ -257,8 +257,8 @@ ifeq ($(SETUP), nshwdisc)
     ISOTHERMAL=yes
     DISC_VISCOSITY=yes
     IND_TIMESTEPS=yes
-    KNOWN_SETUP=yes
     NCELLSMAX=3*maxp
+    KNOWN_SETUP=yes
 endif
 
 ifeq ($(SETUP), prtest)
@@ -277,32 +277,42 @@ ifeq ($(SETUP), binarydiscMFlow)
     MAXP=1000000
     ISOTHERMAL=yes
     CURLV=yes
-    KNOWN_SETUP=yes
     LIVE_ANALYSIS=no
     IND_TIMESTEPS=yes
     MODFILE= moddump_removeparticles_cylinder.f90 #moddump_addpartfortest.f90
+    KNOWN_SETUP=yes
 endif
 
 ifeq ($(SETUP), planetdisc)
 #   planet disc interaction with fixed planet orbit
-    FPPFLAGS=
     SETUPFILE= setup_planetdisc.f90
     ISOTHERMAL=yes
     IND_TIMESTEPS=yes
     CURLV=yes
-    KNOWN_SETUP=yes
     ANALYSIS=analysis_disc.f90
+    KNOWN_SETUP=yes
+endif
+
+ifeq ($(SETUP), exoALMA)
+#   exoALMA comparison project: planet disc interaction with fixed planet orbit
+    SETUPFILE=setup_disc.f90
+    ISOTHERMAL=yes
+    IND_TIMESTEPS=yes
+    CURLV=yes
+    ANALYSIS=analysis_disc.f90
+    SRCINJECT=inject_steadydisc.f90
+    SRCINJECT_DEPS=set_disc.F90
+    KNOWN_SETUP=yes
 endif
 
 ifeq ($(SETUP), planetatm)
 #   disc interaction with fixed planet orbit + atmosphere
-    FPPFLAGS=
     SETUPFILE= setup_disc.f90
     ISOTHERMAL=yes
     IND_TIMESTEPS=yes
     CURLV=yes
-    KNOWN_SETUP=yes
     ANALYSIS=analysis_disc.f90
+    KNOWN_SETUP=yes
 endif
 
 ifeq ($(SETUP), torus)

--- a/src/main/damping.f90
+++ b/src/main/damping.f90
@@ -14,14 +14,18 @@ module damping
 !   Reichardt et al. (2019) MNRAS 484, 631 (used idamp=2)
 !   González-Bolívar et al. (2022) MNRAS 517, 3181 (making idamp=2 obsolete)
 !
-! :Owner: Thomas Reichardt
+! :Owner: Daniel Price
 !
 ! :Runtime parameters:
-!   - damp   : *artificial damping of velocities (if on, v=0 initially)*
-!   - idamp  : *artificial damping of velocities (0=off, 1=constant, 2=star)*
+!   - damp   : *damping timescale as fraction of orbital timescale*
+!   - idamp  : *artificial damping of velocities (0=off, 1=constant, 2=star, 3=disc)*
+!   - r1in   : *inner boundary of inner disc damping zone*
+!   - r1out  : *inner boundary of outer disc damping zone*
+!   - r2in   : *outer boundary of inner disc damping zone*
+!   - r2out  : *outer boundary of outer disc damping zone*
 !   - tdyn_s : *dynamical timescale of star in seconds - damping is dependent on it*
 !
-! :Dependencies: eos_helmholtz, infile_utils, io, units
+! :Dependencies: infile_utils, io, physcon, units
 !
  implicit none
 

--- a/src/main/damping.f90
+++ b/src/main/damping.f90
@@ -6,7 +6,8 @@
 !--------------------------------------------------------------------------!
 module damping
 !
-! None
+! Various implementations for artificial damping of velocities
+! either to relax particles into equilibrium or enforce boundary conditions
 !
 ! :References: None
 !
@@ -26,29 +27,31 @@ module damping
 
  private
 
+ integer, public :: idamp    = 0
  real, public :: tdyn_s      = 0.
  real, public :: damp        = 0.
+ real, public :: r1in = 0.3
+ real, public :: r2in = 0.357
+ real, public :: r1out = 2.52
+ real, public :: r2out = 3.0
 
 contains
-
 
 !-----------------------------------------------------------------------
 !+
 !  calculates damping factor
 !+
 !-----------------------------------------------------------------------
-subroutine calc_damp(time, damp_fac, idamp)
+subroutine calc_damp(time, damp_fac)
  use units, only:utime
  real, intent(out)   :: damp_fac
  real, intent(in)    :: time
- integer, intent(in) :: idamp
  real                :: tau1, tau2, tdyn_star
 
- if (idamp == 0) then
-    damp_fac = 0.
- elseif (idamp == 1) then
+ select case(idamp)
+ case(1,3)
     damp_fac = damp
- elseif (idamp == 2) then
+ case(2)
     tdyn_star = tdyn_s / utime
     tau1 = tdyn_star * 0.1
     tau2 = tdyn_star
@@ -59,19 +62,19 @@ subroutine calc_damp(time, damp_fac, idamp)
     else
        damp_fac = tau1**(-1)
     endif
- endif
+ case default
+    damp_fac = 0.
+ end select
 
 end subroutine calc_damp
 
-subroutine apply_damp(i, fextx, fexty, fextz, vxyzu, damp_fac)
+subroutine apply_damp(fextx, fexty, fextz, vxyz, damp_fac)
  real, intent(inout) :: fextx, fexty, fextz
- real, intent(in)    :: vxyzu(:,:)
- real, intent(in)    :: damp_fac
- integer, intent(in) :: i
+ real, intent(in)    :: vxyz(3), damp_fac
 
- fextx = fextx - damp_fac*vxyzu(1,i)
- fexty = fexty - damp_fac*vxyzu(2,i)
- fextz = fextz - damp_fac*vxyzu(3,i)
+ fextx = fextx - damp_fac*vxyz(1)
+ fexty = fexty - damp_fac*vxyz(2)
+ fextz = fextz - damp_fac*vxyz(3)
 
 end subroutine apply_damp
 
@@ -80,20 +83,19 @@ end subroutine apply_damp
 !  applies damping to external force
 !+
 !-----------------------------------------------------------------------
-subroutine write_options_damping(iunit, idamp)
+subroutine write_options_damping(iunit)
  use infile_utils, only:write_inopt
- integer, intent(in) :: iunit, idamp
+ integer, intent(in) :: iunit
 
  write(iunit,"(/,a)") '# options controlling damping'
  call write_inopt(idamp,'idamp','artificial damping of velocities (0=off, 1=constant, 2=star)',iunit)
- if (idamp > 0) then
-    select case(idamp)
-    case(1)
-       call write_inopt(damp,'damp','artificial damping of velocities (if on, v=0 initially)',iunit)
-    case(2)
-       call write_inopt(tdyn_s,'tdyn_s','dynamical timescale of star in seconds - damping is dependent on it',iunit)
-    end select
- endif
+
+ select case(idamp)
+ case(1,3)
+    call write_inopt(damp,'damp','artificial damping of velocities (if on, v=0 initially)',iunit)
+ case(2)
+    call write_inopt(tdyn_s,'tdyn_s','dynamical timescale of star in seconds - damping is dependent on it',iunit)
+ end select
 
 end subroutine write_options_damping
 
@@ -104,13 +106,12 @@ end subroutine write_options_damping
 !  reads damping options from the input file
 !+
 !-----------------------------------------------------------------------
-subroutine read_options_damping(name,valstring,imatch,igotall,ierr,idamp)
+subroutine read_options_damping(name,valstring,imatch,igotall,ierr)
  use io,            only:fatal
  use eos_helmholtz, only:eos_helmholtz_set_relaxflag
  character(len=*), intent(in)    :: name,valstring
  logical,          intent(out)   :: imatch,igotall
  integer,          intent(out)   :: ierr
- integer,          intent(inout) :: idamp
  integer,          save          :: ngot  = 0
  character(len=30), parameter    :: label = 'read_options_damp'
 

--- a/src/main/damping.f90
+++ b/src/main/damping.f90
@@ -9,7 +9,10 @@ module damping
 ! Various implementations for artificial damping of velocities
 ! either to relax particles into equilibrium or enforce boundary conditions
 !
-! :References: None
+! :References:
+!   Gingold & Monaghan (1977) MNRAS 181, 375
+!   Reichardt et al. (2019) MNRAS 484, 631 (used idamp=2)
+!   González-Bolívar et al. (2022) MNRAS 517, 3181 (making idamp=2 obsolete)
 !
 ! :Owner: Thomas Reichardt
 !
@@ -27,7 +30,8 @@ module damping
 
  private
 
- integer, public :: idamp    = 0
+ integer, public    :: idamp     = 0
+ integer, parameter :: idamp_max = 3  ! maximum allowed value of idamp
  real, public :: tdyn_s      = 0.
  real, public :: damp        = 0.
  real, public :: r1in = 0.3
@@ -43,14 +47,15 @@ contains
 !+
 !-----------------------------------------------------------------------
 subroutine calc_damp(time, damp_fac)
- use units, only:utime
+ use units,   only:utime
+ use physcon, only:pi
  real, intent(out)   :: damp_fac
  real, intent(in)    :: time
  real                :: tau1, tau2, tdyn_star
 
  select case(idamp)
- case(1,3)
-    damp_fac = damp
+ case(3)
+    damp_fac = 1./(damp*2.*pi*sqrt(r1in**3)) ! fraction of orbital time at r=r1in with G=M=1
  case(2)
     tdyn_star = tdyn_s / utime
     tau1 = tdyn_star * 0.1
@@ -62,21 +67,68 @@ subroutine calc_damp(time, damp_fac)
     else
        damp_fac = tau1**(-1)
     endif
+ case(1)
+    damp_fac = damp  ! fraction per timestep
  case default
     damp_fac = 0.
  end select
 
 end subroutine calc_damp
 
-subroutine apply_damp(fextx, fexty, fextz, vxyz, damp_fac)
+!-----------------------------------------------------------------------
+!+
+!  apply damping term to velocity evolution (accelerations)
+!+
+!-----------------------------------------------------------------------
+subroutine apply_damp(fextx, fexty, fextz, vxyz, xyz, damp_fac)
  real, intent(inout) :: fextx, fexty, fextz
- real, intent(in)    :: vxyz(3), damp_fac
+ real, intent(in)    :: vxyz(3), xyz(3), damp_fac
+ real :: v0(3),fac
 
- fextx = fextx - damp_fac*vxyz(1)
- fexty = fexty - damp_fac*vxyz(2)
- fextz = fextz - damp_fac*vxyz(3)
+ v0 = 0.
+ fac = 1.
+ !
+ ! for idamp=3 damping is only applied in the boundary zones,
+ ! hence damping factor depends on spatial location
+ ! also in this case we relax to a prescribed velocity, not zero
+ !
+ if (idamp==3) fac = get_damp_fac_disc(xyz,v0)
+
+ fextx = fextx - damp_fac*(vxyz(1)-v0(1))*fac
+ fexty = fexty - damp_fac*(vxyz(2)-v0(2))*fac
+ fextz = fextz - damp_fac*(vxyz(3)-v0(3))*fac
 
 end subroutine apply_damp
+
+!-----------------------------------------------------------------------
+!+
+!  radial damping zones for inner and outer boundary of a disc
+!+
+!-----------------------------------------------------------------------
+real function get_damp_fac_disc(xyz,v0) result(fac)
+ use physcon, only:pi
+ real, intent(in) :: xyz(3)
+ real, intent(out) :: v0(3)
+ real :: rcyl,omega,vphi
+
+ rcyl = sqrt(xyz(1)**2 + xyz(2)**2)
+
+ if (rcyl < r2in) then
+    fac = 1. - (sin(0.5*pi*(rcyl - r1in)/(r2in - r1in)))**2
+ elseif (rcyl > r1out) then
+    fac = (sin(0.5*pi*(rcyl - r1out)/(r2out - r1out)))**2*sqrt((r1in/r2out)**3)
+ else
+    fac = 0.
+ endif
+
+ omega = sqrt(1./rcyl**3)
+ vphi = rcyl*omega
+
+ v0(1) = -vphi*xyz(2)/rcyl   ! sin(phi) = y/R
+ v0(2) =  vphi*xyz(1)/rcyl   ! cos(phi) = x/R
+ v0(3) = 0.
+
+end function get_damp_fac_disc
 
 !-----------------------------------------------------------------------
 !+
@@ -88,18 +140,22 @@ subroutine write_options_damping(iunit)
  integer, intent(in) :: iunit
 
  write(iunit,"(/,a)") '# options controlling damping'
- call write_inopt(idamp,'idamp','artificial damping of velocities (0=off, 1=constant, 2=star)',iunit)
+ call write_inopt(idamp,'idamp','artificial damping of velocities (0=off, 1=constant, 2=star, 3=disc)',iunit)
 
  select case(idamp)
- case(1,3)
-    call write_inopt(damp,'damp','artificial damping of velocities (if on, v=0 initially)',iunit)
+ case(1)
+    call write_inopt(damp,'damp','fraction to damp velocity each timestep (if > 0, v=0 initially)',iunit)
  case(2)
     call write_inopt(tdyn_s,'tdyn_s','dynamical timescale of star in seconds - damping is dependent on it',iunit)
+ case(3)
+    call write_inopt(damp,'damp','damping timescale as fraction of orbital timescale',iunit)
+    call write_inopt(r1in,'r1in','inner boundary of inner disc damping zone',iunit)
+    call write_inopt(r2in,'r2in','outer boundary of inner disc damping zone',iunit)
+    call write_inopt(r1out,'r1out','inner boundary of outer disc damping zone',iunit)
+    call write_inopt(r2out,'r2out','outer boundary of outer disc damping zone',iunit)
  end select
 
 end subroutine write_options_damping
-
-
 
 !-----------------------------------------------------------------------
 !+
@@ -107,8 +163,7 @@ end subroutine write_options_damping
 !+
 !-----------------------------------------------------------------------
 subroutine read_options_damping(name,valstring,imatch,igotall,ierr)
- use io,            only:fatal
- use eos_helmholtz, only:eos_helmholtz_set_relaxflag
+ use io, only:fatal
  character(len=*), intent(in)    :: name,valstring
  logical,          intent(out)   :: imatch,igotall
  integer,          intent(out)   :: ierr
@@ -120,7 +175,7 @@ subroutine read_options_damping(name,valstring,imatch,igotall,ierr)
  case('idamp')
     read(valstring,*,iostat=ierr) idamp
     ngot = ngot + 1
-    if (idamp < 0) call fatal(label,'damping form choice out of range')
+    if (idamp < 0 .or. idamp > idamp_max) call fatal(label,'damping form choice out of range')
  case('damp')
     read(valstring,*,iostat=ierr) damp
     if (damp < 0.)  call fatal(label,'damp <= 0: damping must be positive')
@@ -129,12 +184,30 @@ subroutine read_options_damping(name,valstring,imatch,igotall,ierr)
     read(valstring,*,iostat=ierr) tdyn_s
     if (tdyn_s < 0.)  call fatal(label,'tdyn_s < 0: this makes no sense')
     ngot = ngot + 1
+ case('r1in')
+    read(valstring,*,iostat=ierr) r1in
+    if (r1in <= 0.)  call fatal(label,'r1in <= 0: this makes no sense')
+    ngot = ngot + 1
+ case('r2in')
+    read(valstring,*,iostat=ierr) r2in
+    if (r2out < r1in)  call fatal(label,'r2in < r1in: this makes no sense')
+    ngot = ngot + 1
+ case('r1out')
+    read(valstring,*,iostat=ierr) r1out
+    if (r1out < r2in)  call fatal(label,'r1out < r2in: this makes no sense')
+    ngot = ngot + 1
+ case('r2out')
+    read(valstring,*,iostat=ierr) r2out
+    if (r2out < r1out)  call fatal(label,'r2out < r1out: this makes no sense')
+    ngot = ngot + 1
  case default
     imatch = .false.
  end select
 
  !--make sure we have got all compulsory options (otherwise, rewrite input file)
- if (idamp > 0) then
+ if (idamp==3) then
+    igotall = (ngot >= 6)
+ elseif (idamp > 0) then
     igotall = (ngot >= 2)
  else
     igotall = (ngot >= 1)

--- a/src/main/dust_formation.F90
+++ b/src/main/dust_formation.F90
@@ -394,6 +394,8 @@ subroutine calc_muGamma(rho_cgs, T, mu, gamma, pH, pH_tot)
     tol       = 1.d-3
     converged = .false.
     isolve    = 0
+    pH_tot    = rho_cgs*T*kboltz/(patm*mass_per_H) ! to avoid compiler warning
+    pH        = pH_tot ! arbitrary value, overwritten below, to avoid compiler warning
     !T = atomic_mass_unit*mu*(gamma-1)*u/kboltz
     i = 0
     do while (.not. converged .and. i < itermax)

--- a/src/main/eos.F90
+++ b/src/main/eos.F90
@@ -714,6 +714,7 @@ real function utherm(vxyzui,rho,gammai)
  if (gr) then
     utherm = en
  elseif (ien_type == ien_entropy) then
+    gamm1 = (gammai - 1.)
     if (gamm1 > tiny(gamm1)) then
        utherm = (en/gamm1)*rho**gamm1
     else
@@ -857,10 +858,16 @@ function entropy(rho,pres,mu_in,ientropy,eint_in,ierr)
     temp = pres * mu / (rho * kb_on_mh)
     entropy = kb_on_mh / mu * log(temp**1.5/rho)
 
+    ! check temp
+    if (temp < tiny(0.)) call warning('entropy','temperature = 0 will give minus infinity with s entropy')
+
  case(2) ! Include both gas and radiation entropy (up to additive constants)
     temp = pres * mu / (rho * kb_on_mh) ! Guess for temp
     call get_idealgasplusrad_tempfrompres(pres,rho,mu,temp) ! First solve for temp from rho and pres
     entropy = kb_on_mh / mu * log(temp**1.5/rho) + 4.*radconst*temp**3 / (3.*rho)
+
+    ! check temp
+    if (temp < tiny(0.)) call warning('entropy','temperature = 0 will give minus infinity with s entropy')
 
  case(3) ! Get entropy from MESA tables if using MESA EoS
     if (ieos /= 10 .and. ieos /= 20) call fatal('eos','Using MESA tables to calculate S from rho and pres, but not using MESA EoS')
@@ -883,9 +890,6 @@ function entropy(rho,pres,mu_in,ientropy,eint_in,ierr)
     entropy = 0.
     call fatal('eos','Unknown ientropy (can only be 1, 2, or 3)')
  end select
-
- ! check temp
- if (temp < tiny(0.)) call warning('entropy','temperature = 0 will give minus infinity with s entropy')
 
 end function entropy
 

--- a/src/main/eos_stratified.f90
+++ b/src/main/eos_stratified.f90
@@ -43,19 +43,19 @@ subroutine get_eos_stratified(istrat,xi,yi,zi,polyk,polyk2,qfacdisc,qfacdisc2,al
  cs2atm = polyk2 * r2**(-qfacdisc2)
  zq = z0 * r2**(0.5*beta_z)
 
- ! if istrat == 0 we use the MAPS prescription
- if (istrat==0) then
-    ! modified equation 6 from Law et al. (2021)
-    cs2 = (cs2mid**4 + 0.5*(1 + tanh((abs(zi) - alpha_z*zq)/zq))*cs2atm**4)**(1./4.)
-
+ select case(istrat)
+ case(1)
     ! if istrat == 1 we use the Dartois et al. (2003) prescription
- elseif (istrat==1) then
     if (zi<zq) then
        cs2 = cs2atm + (cs2mid-cs2atm)*(cos((pi/2)*(zi/zq))**2)
     else
        cs2 = cs2atm
     endif
- endif
+ case default
+    ! if istrat == 0 we use the MAPS prescription
+    ! modified equation 6 from Law et al. (2021)
+    cs2 = (cs2mid**4 + 0.5*(1 + tanh((abs(zi) - alpha_z*zq)/zq))*cs2atm**4)**(1./4.)
+ end select
 
  ponrhoi = cs2
  spsoundi = sqrt(cs2)

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -119,7 +119,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
                             die,fatal,id,master,nprocs,real4,warning
  use externalforces,   only:externalforce,initialise_externalforces,update_externalforce,&
                             externalforce_vdependent
- use options,          only:iexternalforce,idamp,icooling,use_dustfrac,rhofinal1,rhofinal_cgs
+ use options,          only:iexternalforce,icooling,use_dustfrac,rhofinal1,rhofinal_cgs
  use readwrite_infile, only:read_infile,write_infile
  use readwrite_dumps,  only:read_dump,write_fulldump
  use part,             only:npart,xyzh,vxyzu,fxyzu,fext,divcurlv,divcurlB,Bevol,dBevol,tau, &
@@ -212,6 +212,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
  use energies,         only:etot,angtot,totmom,mdust,xyzcom,mtot
  use checkconserved,   only:get_conserv,etot_in,angtot_in,totmom_in,mdust_in
  use fileutils,        only:make_tags_unique
+ use damping,          only:idamp
  character(len=*), intent(in)  :: infile
  character(len=*), intent(out) :: logfile,evfile,dumpfile
  logical,          intent(in), optional :: noread
@@ -325,7 +326,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
 !  this will initialise all cooling variables, including if h2chemistry = true
  if (icooling > 0) call init_cooling(id,master,iprint,ierr)
 
- if (idamp > 0 .and. any(abs(vxyzu(1:3,:)) > tiny(0.)) .and. abs(time) < tiny(time)) then
+ if (idamp > 0 .and. idamp < 3 .and. any(abs(vxyzu(1:3,:)) > tiny(0.)) .and. abs(time) < tiny(time)) then
     call error('setup','damping on: setting non-zero velocities to zero')
     vxyzu(1:3,:) = 0.
  endif

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -15,11 +15,11 @@ module initial
 ! :Runtime parameters: None
 !
 ! :Dependencies: analysis, boundary, centreofmass, checkconserved,
-!   checkoptions, checksetup, cons2prim, cooling, cpuinfo, densityforce,
-!   deriv, dim, dust, dust_formation, energies, eos, evwrite, extern_gr,
-!   externalforces, fastmath, fileutils, forcing, growth, inject, io,
-!   io_summary, krome_interface, linklist, metric_tools, mf_write,
-!   mpibalance, mpiderivs, mpidomain, mpimemory, mpiutils, nicil,
+!   checkoptions, checksetup, cons2prim, cooling, cpuinfo, damping,
+!   densityforce, deriv, dim, dust, dust_formation, energies, eos, evwrite,
+!   extern_gr, externalforces, fastmath, fileutils, forcing, growth,
+!   inject, io, io_summary, krome_interface, linklist, metric_tools,
+!   mf_write, mpibalance, mpiderivs, mpidomain, mpimemory, mpiutils, nicil,
 !   nicil_sup, omputils, options, part, photoevap, ptmass, radiation_utils,
 !   readwrite_dumps, readwrite_infile, timestep, timestep_ind,
 !   timestep_sts, timing, units, writeheader

--- a/src/main/inject_steadydisc.f90
+++ b/src/main/inject_steadydisc.f90
@@ -1,0 +1,257 @@
+!--------------------------------------------------------------------------!
+! The Phantom Smoothed Particle Hydrodynamics code, by Daniel Price et al. !
+! Copyright (c) 2007-2023 The Authors (see AUTHORS)                        !
+! See LICENCE file for usage and distribution conditions                   !
+! http://phantomsph.bitbucket.io/                                          !
+!--------------------------------------------------------------------------!
+module inject
+!
+! Steady disc boundary conditions
+!
+! When particles leave radial boundary zones they are re-injected
+! into the boundary zones according to the original disc profile
+! by calling the set_disc routine
+!
+! :References: None
+!
+! :Owner: Daniel Price
+!
+! :Runtime parameters:
+!   - refill_boundaries : *refill inner and outer disc?*
+!
+! :Dependencies: damping, eos, infile_utils, io, part, partinject, physcon,
+!   setdisc
+!
+ implicit none
+ character(len=*), parameter, public :: inject_type = 'steadydisc'
+
+ public :: init_inject,inject_particles,write_options_inject,read_options_inject
+
+ real, private :: R_ref,sig_ref
+ real, private :: p_index,q_index,HoverR,M_star
+
+ logical :: refill_boundaries = .true.
+ logical, private :: read_discparams = .false.
+ integer, allocatable :: listinner(:),listouter(:)
+ integer, private, parameter :: maxinj = 10000
+ integer, private, parameter :: inject_threshold = 100
+
+ private
+
+contains
+!-----------------------------------------------------------------------
+!+
+!  Initialize global variables or arrays needed for injection routine
+!  Sanity check options required for this injection procedure
+!+
+!-----------------------------------------------------------------------
+subroutine init_inject(ierr)
+ use damping, only:idamp
+ use io,      only:error
+ integer, intent(out) :: ierr
+ !
+ ! return without error
+ !
+ ierr = 0
+ allocate(listinner(maxinj),listouter(maxinj))
+
+ if (idamp /= 3) then
+    call error('init_inject','these boundary conditions require idamp=3')
+    ierr = 1
+ endif
+
+end subroutine init_inject
+
+!-----------------------------------------------------------------------
+!+
+!  Main routine handling particle (re-)injection
+!+
+!-----------------------------------------------------------------------
+subroutine inject_particles(time,dtlast,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
+                            npart,npartoftype,dtinject)
+ use io,      only:id,master
+ use damping, only:r1in,r2in,r1out,r2out
+ real,    intent(in)    :: time, dtlast
+ real,    intent(inout) :: xyzh(:,:), vxyzu(:,:), xyzmh_ptmass(:,:), vxyz_ptmass(:,:)
+ integer, intent(inout) :: npart
+ integer, intent(inout) :: npartoftype(:)
+ real,    intent(out)   :: dtinject
+ integer :: ninner,nouter,injected
+
+ !
+ !--count the number of particles with r < R_in or r > R_out
+ !
+ call count_particles_outside_bounds(npart,xyzh,r1in,r2out,ninner,nouter,listinner,listouter)
+
+ !
+ !--remove those particles and place them back according to the
+ !  original surface density profile
+ !
+ injected = 0
+ if (ninner > inject_threshold) then
+    call inject_particles_in_annulus(r1in,r2in,ninner,injected,listinner)
+ endif
+ if (nouter > inject_threshold) then
+    call inject_particles_in_annulus(r1out,r2out,nouter,injected,listouter)
+ endif
+
+ if (id==master .and. injected > 0) print "(1x,a,es10.3,a,i0,a,g0.2,a,i0,a,g0.2)", &
+      '>> t=',time,': re-injected ',ninner,' parts with R < ',r1in,' and ',nouter,' with R > ',r2out
+ !
+ !-- no constraint on timestep
+ !
+ dtinject = huge(dtinject)
+
+end subroutine inject_particles
+
+!-----------------------------------------------------------------------
+!+
+!  Writes input options to the input file
+!+
+!-----------------------------------------------------------------------
+subroutine count_particles_outside_bounds(npart,xyzh,R_in,R_out,ninner,nouter,listinner,listouter)
+ integer, intent(in) :: npart
+ real, intent(in) :: xyzh(:,:),R_in,R_out
+ integer, intent(out) :: ninner,nouter,listinner(:),listouter(:)
+ integer :: i
+ real :: r2
+
+ ninner = 0
+ nouter = 0
+ listinner(:) = 0
+ listouter(:) = 0
+ do i=1,npart
+    r2 = xyzh(1,i)**2 + xyzh(2,i)**2
+    if (r2 < R_in**2) then
+       ninner = ninner + 1
+       if (ninner < size(listinner)) listinner(ninner) = i
+    elseif (r2 > R_out**2) then
+       nouter = nouter + 1
+       if (nouter <= size(listouter)) listouter(nouter) = i
+    endif
+ enddo
+
+ if (ninner == size(listinner) .or. nouter == size(listouter)) then
+    print*,' WARNING: injection is limited by array sizes, increase maxinj and recompile...'
+ endif
+
+end subroutine count_particles_outside_bounds
+
+!-----------------------------------------------------------------------
+!+
+!  re-inject particles in a disc annulus
+!+
+!-----------------------------------------------------------------------
+subroutine inject_particles_in_annulus(r1,r2,ninject,injected,list)
+ use eos,        only:polyk,gamma
+ use io,         only:id,master
+ use part,       only:igas,xyzh,vxyzu,hfact,iunknown,set_particle_type
+ use setdisc,    only:set_disc
+ use partinject, only:updated_particle
+ use physcon,    only:pi
+
+ real,    intent(in)    :: r1,r2
+ integer, intent(inout) :: ninject,injected
+ integer, intent(in) :: list(ninject)
+ integer :: i,j
+
+ real :: xyzh_inject(4,ninject)
+ real :: vxyzu_inject(4,ninject)
+ real :: pmass_tmp
+
+ ! re-inject particles according to the original disc profile
+ ! in the damping zones
+ call set_disc(id,master  = master,       &
+               npart      = ninject,      &
+               rmin       = r1,           &
+               rmax       = r2,           &
+               rref       = R_ref,        &
+               phimax     = 2.*pi,        & ! prevents CofM adjustment
+               p_index    = p_index,      &
+               q_index    = q_index,      &
+               HoverR     = HoverR,       &
+               sig_norm   = sig_ref,      &
+               star_mass  = M_star,       &
+               polyk      = polyk,        &
+               gamma      = gamma,        &
+               particle_mass = pmass_tmp, &
+               hfact      = hfact,        &
+               xyzh       = xyzh_inject,  &
+               vxyzu      = vxyzu_inject, &
+               writefile  = .false., &
+               verbose = .false.)
+
+ ! flag that particle properties have been updated
+ if (ninject > 0) updated_particle = .true.
+
+ do i=1,ninject
+    j = list(i)
+    xyzh(1:3,j) = xyzh_inject(1:3,i)
+    xyzh(4,j) = abs(xyzh(4,j))  ! ensure not dead or accreted
+    vxyzu(1:3,j) = vxyzu_inject(1:3,i)
+    call set_particle_type(j,iunknown) ! this is reset in update_injected_particles
+ enddo
+ injected = injected + ninject
+
+end subroutine inject_particles_in_annulus
+
+!-----------------------------------------------------------------------
+!+
+!  Writes input options to the input file
+!+
+!-----------------------------------------------------------------------
+subroutine write_options_inject(iunit)
+ use infile_utils, only:write_inopt
+ integer, intent(in) :: iunit
+
+ call write_inopt(refill_boundaries,'refill_boundaries','refill inner and outer disc?',iunit)
+
+end subroutine write_options_inject
+
+!-----------------------------------------------------------------------
+!+
+!  Reads input options from the input file
+!+
+!-----------------------------------------------------------------------
+subroutine read_options_inject(name,valstring,imatch,igotall,ierr)
+ use infile_utils, only:open_db_from_file,inopts,read_inopt,close_db
+ use io,           only:error,iunit=>imflow,lenprefix,fileprefix
+ character(len=*), intent(in)  :: name,valstring
+ logical,          intent(out) :: imatch,igotall
+ integer,          intent(out) :: ierr
+ type(inopts), allocatable     :: db(:)
+ character(len=lenprefix+11)   :: filename
+ integer, save :: ngot
+ integer :: nerr
+
+ imatch  = .false.
+ igotall = .true.
+
+ select case(trim(name))
+ case('refill_boundaries')
+    read(valstring,*,iostat=ierr) refill_boundaries
+    ngot = ngot + 1
+    imatch = .true.
+ end select
+ igotall = (ngot >= 1)
+
+ ! read some additional options from the .discparams file
+ nerr = 0
+ if (.not.read_discparams) then
+    filename = trim(fileprefix)//'.discparams'
+    call open_db_from_file(db,filename,iunit,ierr)
+    if (ierr /= 0) call error('inject','could not open .discparams file')
+    call read_inopt(R_ref,'R_ref',db,errcount=nerr)
+    call read_inopt(HoverR,'H/R_ref',db,errcount=nerr)
+    call read_inopt(sig_ref,'sig_ref',db,errcount=nerr)
+    call read_inopt(M_star,'M_star',db,errcount=nerr)
+    call read_inopt(p_index,'p_index',db,errcount=nerr)
+    call read_inopt(q_index,'q_index',db,errcount=nerr)
+    if (nerr /= 0) call error('inject','missing parameters in .discparams file',var='errors',ival=nerr)
+    call close_db(db)
+    if (ierr==0 .and. nerr==0) read_discparams = .true.
+ endif
+
+end subroutine read_options_inject
+
+end module inject

--- a/src/main/io.F90
+++ b/src/main/io.F90
@@ -56,6 +56,7 @@ module io
 
  integer, parameter, private :: lenmsg = 120
  integer, parameter, private :: lenwhere = 20
+ integer, parameter, public :: lenprefix = 120
 
  type warningdb_entry
     character(len=lenwhere) :: wherefrom
@@ -63,6 +64,8 @@ module io
     integer(kind=8)         :: ncount
     integer :: level
  end type warningdb_entry
+
+ character(len=lenprefix), public :: fileprefix
 
  integer, parameter :: maxwarningdb = 20
  type(warningdb_entry) :: warningdb(maxwarningdb)
@@ -107,6 +110,7 @@ subroutine set_io_unit_numbers
  iscfile    = 32 ! for writing details of sink creation
  iskfile    =407 ! for writing details of the sink particles; opens files iskfile to iskfile+nptmass
  iverbose   = 0
+ fileprefix = '' ! blank by default, set to name of .in file
 
 end subroutine set_io_unit_numbers
 

--- a/src/main/options.f90
+++ b/src/main/options.f90
@@ -16,7 +16,8 @@ module options
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: dim, eos, kernel, part, timestep, units, viscosity
+! :Dependencies: damping, dim, eos, kernel, part, timestep, units,
+!   viscosity
 !
  use eos,     only:ieos,iopacity_type,use_var_comp ! so this is available via options module
  use damping, only:idamp ! so this is available via options module

--- a/src/main/options.f90
+++ b/src/main/options.f90
@@ -18,7 +18,8 @@ module options
 !
 ! :Dependencies: dim, eos, kernel, part, timestep, units, viscosity
 !
- use eos, only:ieos,iopacity_type,use_var_comp ! so this is available via options module
+ use eos,     only:ieos,iopacity_type,use_var_comp ! so this is available via options module
+ use damping, only:idamp ! so this is available via options module
  implicit none
 !
 ! these are parameters which may be changed by the user
@@ -55,7 +56,7 @@ module options
  logical, public :: implicit_radiation_store_drad
 
  public :: set_default_options
- public :: ieos
+ public :: ieos,idamp
  public :: iopacity_type
  public :: use_var_comp  ! use variable composition
 
@@ -118,6 +119,7 @@ subroutine set_default_options
  endif
  alphamax = 1.0
  call set_defaults_viscosity
+ idamp = 0
 
  ! artificial thermal conductivity
  alphau = 1.

--- a/src/main/options.f90
+++ b/src/main/options.f90
@@ -25,7 +25,7 @@ module options
 ! and read from the input file
 !
  real, public :: avdecayconst
- integer, public :: nfulldump,nmaxdumps,iexternalforce,idamp
+ integer, public :: nfulldump,nmaxdumps,iexternalforce
  real, public :: tolh,damp,rkill
  real(kind=4), public :: twallmax
 
@@ -87,7 +87,6 @@ subroutine set_default_options
  Bexty     = 0.
  Bextz     = 0.
  tolh      = 1.e-4           ! tolerance on h iterations
- idamp     = 0               ! damping type
  iexternalforce = 0          ! external forces
  if (gr) iexternalforce = 1
  calc_erot = .false.         ! To allow rotational energies to be printed to .ev

--- a/src/main/readwrite_dumps_fortran.F90
+++ b/src/main/readwrite_dumps_fortran.F90
@@ -776,7 +776,7 @@ subroutine read_dump_fortran(dumpfile,tfile,hfactfile,idisk1,iprint,id,nprocs,ie
 !--Allocate main arrays
 !
 #ifdef INJECT_PARTICLES
-       call allocate_memory(int(maxp_hard,kind=8))
+       call allocate_memory(max(nparttot,int(maxp_hard,kind=8)))
 #else
        call allocate_memory(nparttot)
 #endif

--- a/src/main/readwrite_infile.F90
+++ b/src/main/readwrite_infile.F90
@@ -70,7 +70,7 @@ module readwrite_infile
 !   viscosity
 !
  use timestep,  only:dtmax_dratio,dtmax_max,dtmax_min
- use options,   only:nfulldump,nmaxdumps,twallmax,iexternalforce,idamp,tolh, &
+ use options,   only:nfulldump,nmaxdumps,twallmax,iexternalforce,tolh, &
                      alpha,alphau,alphaB,beta,avdecayconst,damp,rkill, &
                      ipdv_heating,ishock_heating,iresistive_heating,ireconav, &
                      icooling,psidecayfac,overcleanfac,hdivbbmax_max,alphamax,calc_erot,rhofinal_cgs, &
@@ -216,7 +216,7 @@ subroutine write_infile(infile,logfile,evfile,dumpfile,iwritein,iprint)
  if (gr) then
     call write_inopt(ireconav,'ireconav','use reconstruction in shock viscosity (-1=off,0=no limiter,1=Van Leer)',iwritein)
  endif
- call write_options_damping(iwritein,idamp)
+ call write_options_damping(iwritein)
 
  !
  ! thermodynamics
@@ -566,7 +566,7 @@ subroutine read_infile(infile,logfile,evfile,dumpfile)
 #endif
        if (.not.imatch) call read_options_eos(name,valstring,imatch,igotalleos,ierr)
        if (.not.imatch .and. maxvxyzu >= 4) call read_options_cooling(name,valstring,imatch,igotallcooling,ierr)
-       if (.not.imatch) call read_options_damping(name,valstring,imatch,igotalldamping,ierr,idamp)
+       if (.not.imatch) call read_options_damping(name,valstring,imatch,igotalldamping,ierr)
        if (maxptmass > 0) then
           if (.not.imatch) call read_options_ptmass(name,valstring,imatch,igotallptmass,ierr)
           !

--- a/src/main/readwrite_infile.F90
+++ b/src/main/readwrite_infile.F90
@@ -321,7 +321,7 @@ subroutine read_infile(infile,logfile,evfile,dumpfile)
                            itau_alloc,store_dust_temperature
  use timestep,        only:tmax,dtmax,nmax,nout,C_cour,C_force
  use eos,             only:read_options_eos,ieos
- use io,              only:ireadin,iwritein,iprint,warn,die,error,fatal,id,master
+ use io,              only:ireadin,iwritein,iprint,warn,die,error,fatal,id,master,fileprefix
  use infile_utils,    only:read_next_inopt,contains_loop,write_infile_series
 #ifdef DRIVING
  use forcing,         only:read_options_forcing,write_options_forcing
@@ -377,6 +377,7 @@ subroutine read_infile(infile,logfile,evfile,dumpfile)
  if (idot <= 1) idot = len_trim(infile)
  logfile    = infile(1:idot)//'01.log'
  dumpfile   = infile(1:idot)//'_00000.tmp'
+ fileprefix = infile(1:idot)
  ngot            = 0
  igotallturb     = .true.
  igotalldust     = .true.

--- a/src/main/step_leapfrog.F90
+++ b/src/main/step_leapfrog.F90
@@ -97,7 +97,7 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
  use dim,            only:maxp,ndivcurlv,maxvxyzu,maxptmass,maxalpha,nalpha,h2chemistry,&
                           use_dustgrowth,use_krome,gr,do_radiation
  use io,             only:iprint,fatal,iverbose,id,master,warning
- use options,        only:idamp,iexternalforce,use_dustfrac,implicit_radiation
+ use options,        only:iexternalforce,use_dustfrac,implicit_radiation
  use part,           only:xyzh,vxyzu,fxyzu,fext,divcurlv,divcurlB,Bevol,dBevol, &
                           rad,drad,radprop,isdead_or_accreted,rhoh,dhdrho,&
                           iphase,iamtype,massoftype,maxphase,igas,idust,mhd,&
@@ -130,6 +130,7 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
 #endif
  use timing,         only:increment_timer,get_timings,itimer_extf
  use growth,         only:check_dustprop
+ use damping,        only:idamp
 
  use cons2primsolver, only:conservative2primitive,primitive2conservative
  use eos, only:equationofstate
@@ -771,7 +772,7 @@ subroutine step_extern_gr(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,pxyzu,dens,me
  use dim,            only:maxptmass,maxp,maxvxyzu
  use io,             only:iverbose,id,master,iprint,warning
  use externalforces, only:externalforce,accrete_particles,update_externalforce
- use options,        only:iexternalforce,idamp
+ use options,        only:iexternalforce
  use part,           only:maxphase,isdead_or_accreted,iamboundary,igas,iphase,iamtype,&
                           massoftype,rhoh,ien_type,eos_vars,igamma,itemp,igasP
  use io_summary,     only:summary_variable,iosumextr,iosumextt,summary_accrete
@@ -780,7 +781,7 @@ subroutine step_extern_gr(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,pxyzu,dens,me
  use cons2primsolver,only:conservative2primitive
  use extern_gr,      only:get_grforce
  use metric_tools,   only:pack_metric,pack_metricderivs
- use damping,        only:calc_damp,apply_damp
+ use damping,        only:calc_damp,apply_damp,idamp
  integer, intent(in)    :: npart,ntypes
  real,    intent(in)    :: dtsph,time
  real,    intent(inout) :: dtextforce
@@ -829,7 +830,7 @@ subroutine step_extern_gr(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,pxyzu,dens,me
     nsubsteps     = nsubsteps + 1
     dtextforcenew = bignumber
 
-    call calc_damp(time, damp_fac, idamp)
+    call calc_damp(time, damp_fac)
 
     if (.not.last_step .and. iverbose > 1 .and. id==master) then
        write(iprint,"(a,f14.6)") '> external forces only : t=',timei
@@ -984,8 +985,8 @@ subroutine step_extern_gr(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,pxyzu,dens,me
           call get_grforce(xyzh(:,i),metrics(:,:,:,i),metricderivs(:,:,:,i),vxyzu(1:3,i),dens(i),vxyzu(4,i),pri,fext(1:3,i),dtf)
           dtextforce_min = min(dtextforce_min,C_force*dtf)
 
-          if (idamp > 0.) then
-             call apply_damp(i, fext(1,i), fext(2,i), fext(3,i), vxyzu, damp_fac)
+          if (idamp > 0) then
+             call apply_damp(fext(1,i), fext(2,i), fext(3,i), vxyzu(1:3,i), damp_fac)
           endif
 
           !
@@ -1087,7 +1088,7 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
                           idxmsi,idymsi,idzmsi,idmsi,idspinxsi,idspinysi,idspinzsi, &
                           idvxmsi,idvymsi,idvzmsi,idfxmsi,idfymsi,idfzmsi, &
                           ndptmass,update_ptmass
- use options,        only:iexternalforce,idamp,icooling
+ use options,        only:iexternalforce,icooling
  use part,           only:maxphase,abundance,nabundances,h2chemistry,eos_vars,epot_sinksink,&
                           isdead_or_accreted,iamboundary,igas,iphase,iamtype,massoftype,rhoh,divcurlv, &
                           fxyz_ptmass_sinksink,dust_temp,tau,nucleation,idK2,idmu,idkappa,idgamma
@@ -1097,7 +1098,7 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
  use timestep,       only:bignumber,C_force
  use timestep_sts,   only:sts_it_n
  use mpiutils,       only:bcast_mpi,reduce_in_place_mpi,reduceall_mpi
- use damping,        only:calc_damp,apply_damp
+ use damping,        only:calc_damp,apply_damp,idamp
  use ptmass_radiation,only:get_rad_accel_from_ptmass,isink_radiation
  use cooling,        only:energ_cooling,cooling_in_step
  use dust_formation, only:evolve_dust
@@ -1160,7 +1161,7 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
     dtsinkgas     = bignumber
     dtphi2        = bignumber
 
-    call calc_damp(time, damp_fac, idamp)
+    call calc_damp(time, damp_fac)
 
     if (.not.last_step .and. iverbose > 1 .and. id==master) then
        write(iprint,"(a,f14.6)") '> external/ptmass forces only : t=',timei
@@ -1290,8 +1291,8 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
                 fextz = fextz + fextv(3)
              endif
           endif
-          if (idamp > 0.) then
-             call apply_damp(i, fextx, fexty, fextz, vxyzu, damp_fac)
+          if (idamp > 0) then
+             call apply_damp(fextx, fexty, fextz, vxyzu(1:3,i), damp_fac)
           endif
           fext(1,i) = fextx
           fext(2,i) = fexty

--- a/src/main/step_leapfrog.F90
+++ b/src/main/step_leapfrog.F90
@@ -986,7 +986,7 @@ subroutine step_extern_gr(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,pxyzu,dens,me
           dtextforce_min = min(dtextforce_min,C_force*dtf)
 
           if (idamp > 0) then
-             call apply_damp(fext(1,i), fext(2,i), fext(3,i), vxyzu(1:3,i), damp_fac)
+             call apply_damp(fext(1,i), fext(2,i), fext(3,i), vxyzu(1:3,i), xyzh(1:3,i), damp_fac)
           endif
 
           !
@@ -1292,7 +1292,7 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
              endif
           endif
           if (idamp > 0) then
-             call apply_damp(fextx, fexty, fextz, vxyzu(1:3,i), damp_fac)
+             call apply_damp(fextx, fexty, fextz, vxyzu(1:3,i), xyzh(1:3,i), damp_fac)
           endif
           fext(1,i) = fextx
           fext(2,i) = fexty

--- a/src/main/utils_shuffleparticles.F90
+++ b/src/main/utils_shuffleparticles.F90
@@ -74,9 +74,11 @@ subroutine shuffleparticles(iprint,npart,xyzh,pmass,duniform,rsphere,dsphere,dme
  use densityforce, only:densityiterate
  use linklist,     only:ncells,ifirstincell,set_linklist,get_neighbour_list,allocate_linklist,listneigh
  use kernel,       only:cnormk,wkern,grkern,radkern2
+#ifdef PERIODIC
  use boundary,     only:dxbound,dybound,dzbound,cross_boundary
- use kdtree,       only:inodeparts,inoderange
  use mpidomain,    only:isperiodic
+#endif
+ use kdtree,       only:inodeparts,inoderange
  use allocutils,   only:allocate_array
  integer,           intent(in)    :: iprint
  integer,           intent(inout) :: npart
@@ -122,6 +124,7 @@ subroutine shuffleparticles(iprint,npart,xyzh,pmass,duniform,rsphere,dsphere,dme
  n_part            = npart
  is_ref            = .false.
  radkern12         = 1.0/radkern2
+ ncross            = 0
 
  !--Determine what has been passed in
  if (idebug > 0 .and. id==master) then

--- a/src/setup/set_disc.F90
+++ b/src/setup/set_disc.F90
@@ -417,7 +417,7 @@ subroutine set_disc(id,master,mixture,nparttot,npart,npart_start,rmin,rmax, &
  !  also shift particles to new origin if this is not at (0,0,0)
  !
  if (present(phimax)) then
-    print "(a)",'Setting up disc sector - not adjusting centre of mass'
+    if (do_verbose) print "(a)",'Setting up disc sector - not adjusting centre of mass'
  else
     call adjust_centre_of_mass(xyzh,vxyzu,particle_mass,npart_start_count,npart_tot,xorigini,vorigini)
  endif
@@ -540,7 +540,7 @@ subroutine set_disc_positions(npart_tot,npart_start_count,do_mixture,R_ref,R_in,
 
  !--loop over particles
  do i=npart_start_count,npart_tot,2
-    if (id==master .and. mod(i,npart_tot/10)==0 .and. verbose) print*,i
+    if (id==master .and. mod(i,max(npart_tot/10,10))==0 .and. verbose) print*,i
     !--get a random angle between phi_min and phi_max
     rand_no = ran2(iseed)
     phi = phi_min + (phi_max - phi_min)*ran2(iseed)

--- a/src/setup/setup_planetdisc.f90
+++ b/src/setup/setup_planetdisc.f90
@@ -7,6 +7,8 @@
 module setup
 !
 ! Set up for the de Val Borro et al. planet-disc comparison problem
+! this is a simplified disc setup with a planet on a prescribed
+! orbit using a time-dependent potential
 !
 ! :References: de Val Borro et al. (2006), MNRAS 370, 529
 !
@@ -33,8 +35,8 @@ module setup
  public :: setpart
 
  integer :: np, norbits
- real :: R_in, R_out, HoverRinput, sig0, sig_in, alphaSS
- real :: p_indexinput, q_indexinput
+ real :: R_in, R_out, HoverR, sig0, sig_in, alphaSS
+ real :: p_index, q_index
 
  private
 
@@ -54,7 +56,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use timestep,      only:dtmax,tmax
  use prompting,     only:prompt
  use extern_binary, only:accradius1,accradius2 !,binary_posvel
- use extern_binary, only:binarymassr,eps_soft1,eps_soft2,ramp
+ use extern_binary,  only:binarymassr,eps_soft1,eps_soft2,ramp
  use externalforces, only:iext_binary
 
  integer,            intent(in)            :: id
@@ -66,7 +68,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  real,               intent(out)           :: massoftype(:)
  real,               intent(inout)         :: time
  character (len=20), intent (in), optional :: fileprefix
- !integer :: i
+ integer :: ierr
 
  !real :: xbinary(10),vbinary(6)
  real :: a0
@@ -89,23 +91,28 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  time  = 0.
  a0    = 1.
  binarymassr = 1.e-3
- HoverRinput = 0.05
+ HoverR = 0.05
  accradius1 = 0.0
  accradius2 = 0.3
- eps_soft1 = 0.6*HoverRinput*a0
+ eps_soft1 = 0.6*HoverR*a0
  R_in  = 0.4
  R_out = 2.5
  sig0  = 0.002/(pi*a0**2)
  alphaSS = 0.01
- p_indexinput = 0.
- q_indexinput = 0.5
+ p_index = 1.
+ q_index = 0.25
  ramp = .true.
  norbits = 100
 
  print "(a,/)",'Phantomsetup: routine to setup planet-disc interaction with fixed planet orbit '
  inquire(file=filename,exist=iexist)
  if (iexist) then
-    call read_setupfile(filename)
+    call read_setupfile(filename,ierr)
+    if (ierr /= 0) then
+       print "(a)",' ERRORS reading '//trim(filename)//', rewriting...'
+       call write_setupfile(filename)
+       stop
+    endif
  elseif (id==master) then
     print "(a,/)",trim(filename)//' not found: using interactive setup'
     !
@@ -122,9 +129,9 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
 
     call prompt('Enter inner disc edge R_in ',R_in,accradius1)
     call prompt('Enter outer disc edge R_out ',R_out,R_in)
-    call prompt('Enter H/R at R=R_in ',HoverRinput,0.)
-    call prompt('Enter p index of surface density profile Sigma = Sigma0*R^-p',p_indexinput,0.)
-    call prompt('Enter q index of temperature profile cs = cs0*R^-q',q_indexinput,0.)
+    call prompt('Enter H/R at R=R_in ',HoverR,0.)
+    call prompt('Enter p index of surface density profile Sigma = Sigma0*R^-p',p_index,0.)
+    call prompt('Enter q index of temperature profile cs = cs0*R^-q',q_index,0.)
     call prompt('Enter Sigma0 for disc',sig0)
     call prompt('Enter desired value of alpha_SS',alphaSS,0.)
     !
@@ -144,15 +151,15 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  alpha=alphaSS
 
  !--set sig_in as required for set_disc (sig_norm at R=Rin)
- sig_in = sig0*R_in**p_indexinput
+ sig_in = sig0*R_in**p_index
 
  call set_disc(id,master     = master,        &
                npart         = np,            &
                rmin          = R_in,          &
                rmax          = R_out,         &
-               p_index       = p_indexinput,  &
-               q_index       = q_indexinput,  &
-               HoverR        = HoverRinput,   &
+               p_index       = p_index,  &
+               q_index       = q_index,  &
+               HoverR        = HoverR,   &
                sig_norm      = sig_in,        &
                star_mass     = 1.0,           &
                gamma         = gamma,         &
@@ -215,42 +222,45 @@ subroutine write_setupfile(filename)
 
  call write_inopt(R_in,'R_in','inner radius',iunit)
  call write_inopt(R_out,'R_out', 'outer radius',iunit)
- call write_inopt(HoverRinput,'HoverRinput','H/R at R_in',iunit)
+ call write_inopt(HoverR,'HoverR','H/R at R_in',iunit)
  call write_inopt(sig0,'sig0','disc surface density',iunit)
- call write_inopt(p_indexinput,'p_indexinput','surface density profile',iunit)
- call write_inopt(q_indexinput,'q_indexinput','temperature profile',iunit)
+ call write_inopt(p_index,'p_index','surface density profile',iunit)
+ call write_inopt(q_index,'q_index','temperature profile',iunit)
  call write_inopt(alphaSS,'alphaSS','desired alpha_SS',iunit)
 
  close(iunit)
 
 end subroutine write_setupfile
 
-subroutine read_setupfile(filename)
+subroutine read_setupfile(filename,ierr)
  use infile_utils, only:open_db_from_file,inopts,read_inopt,close_db
  use extern_binary, only:accradius1,accradius2,binary_posvel
  use extern_binary, only:binarymassr
  implicit none
  character(len=*), intent(in) :: filename
+ integer, intent(out) :: ierr
  integer, parameter :: iunit = 21
- integer :: ierr
+ integer :: nerr
  type(inopts), dimension(:), allocatable :: db
 
  print "(a)",'reading setup options from '//trim(filename)
 
  call open_db_from_file(db,filename,iunit,ierr)
 
- call read_inopt(np,'np',db,ierr)
- call read_inopt(binarymassr,'mplanet',db,ierr)
- call read_inopt(accradius1,'accradius1',db,ierr)
- call read_inopt(accradius2,'accradius2',db,ierr)
- call read_inopt(R_in,'R_in',db,ierr)
- call read_inopt(R_out,'R_out',db,ierr)
- call read_inopt(HoverRinput,'HoverRinput',db,ierr)
- call read_inopt(sig0,'sig0',db,ierr)
- call read_inopt(p_indexinput,'p_indexinput',db,ierr)
- call read_inopt(q_indexinput,'q_indexinput',db,ierr)
- call read_inopt(alphaSS,'alphaSS',db,ierr)
- call read_inopt(norbits,'norbits',db,ierr,min=1)
+ nerr = 0
+ call read_inopt(np,'np',db,errcount=nerr)
+ call read_inopt(binarymassr,'mplanet',db,errcount=nerr)
+ call read_inopt(accradius1,'accradius1',db,errcount=nerr)
+ call read_inopt(accradius2,'accradius2',db,errcount=nerr)
+ call read_inopt(R_in,'R_in',db,errcount=nerr)
+ call read_inopt(R_out,'R_out',db,errcount=nerr)
+ call read_inopt(HoverR,'HoverR',db,errcount=nerr)
+ call read_inopt(sig0,'sig0',db,errcount=nerr)
+ call read_inopt(p_index,'p_index',db,errcount=nerr)
+ call read_inopt(q_index,'q_index',db,errcount=nerr)
+ call read_inopt(alphaSS,'alphaSS',db,errcount=nerr)
+ call read_inopt(norbits,'norbits',db,errcount=nerr,min=1)
+ ierr = nerr
 
  call close_db(db)
  close(iunit)

--- a/src/setup/setup_planetdisc.f90
+++ b/src/setup/setup_planetdisc.f90
@@ -15,18 +15,18 @@ module setup
 ! :Owner: Daniel Price
 !
 ! :Runtime parameters:
-!   - HoverRinput  : *H/R at R_in*
-!   - R_in         : *inner radius*
-!   - R_out        : *outer radius*
-!   - accradius1   : *primary accretion radius*
-!   - accradius2   : *secondary accretion radius*
-!   - alphaSS      : *desired alpha_SS*
-!   - mplanet      : *m1/(m1+m2)*
-!   - norbits      : *number of orbits*
-!   - np           : *number of particles*
-!   - p_indexinput : *surface density profile*
-!   - q_indexinput : *temperature profile*
-!   - sig0         : *disc surface density*
+!   - HoverR     : *H/R at R_in*
+!   - R_in       : *inner radius*
+!   - R_out      : *outer radius*
+!   - accradius1 : *primary accretion radius*
+!   - accradius2 : *secondary accretion radius*
+!   - alphaSS    : *desired alpha_SS*
+!   - mplanet    : *m1/(m1+m2)*
+!   - norbits    : *number of orbits*
+!   - np         : *number of particles*
+!   - p_index    : *surface density profile*
+!   - q_index    : *temperature profile*
+!   - sig0       : *disc surface density*
 !
 ! :Dependencies: extern_binary, externalforces, infile_utils, io, options,
 !   physcon, prompting, setdisc, timestep, units

--- a/src/tests/test_poly.f90
+++ b/src/tests/test_poly.f90
@@ -1,6 +1,6 @@
 !--------------------------------------------------------------------------!
 ! The Phantom Smoothed Particle Hydrodynamics code, by Daniel Price et al. !
-! Copyright (c) 2007-2022 The Authors (see AUTHORS)                        !
+! Copyright (c) 2007-2023 The Authors (see AUTHORS)                        !
 ! See LICENCE file for usage and distribution conditions                   !
 ! http://phantomsph.bitbucket.io/                                          !
 !--------------------------------------------------------------------------!
@@ -14,7 +14,7 @@ module testpoly
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: quartic
+! :Dependencies: io, quartic, testutils
 !
  use testutils, only:checkval,update_test_scores
  use io,        only:id,master

--- a/src/utils/moddump_sink.f90
+++ b/src/utils/moddump_sink.f90
@@ -43,7 +43,7 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  do while (isinkpart /= 0)
     call prompt('Enter the sink particle number to modify:',isinkpart,0,nptmass)
     if (isinkpart <= 0) exit
- 
+
     mass = xyzmh_ptmass(4,isinkpart)
     mass_old = mass
     call prompt('Enter new mass for the sink:',mass,0.)

--- a/src/utils/showarrays.f90
+++ b/src/utils/showarrays.f90
@@ -19,7 +19,7 @@ program showarrays
  use dump_utils, only:print_arrays_in_file
  implicit none
  integer, parameter   :: iu = 23
- integer              :: nargs,ierr,i
+ integer              :: nargs,i
  character(len=120)   :: dumpfile
  !
  ! get filenames from the command line


### PR DESCRIPTION
Type of PR: 
new physics

Description:
implementation of "wave-killing" boundary zones for disc simulations, idamp=3

Testing:
simulation of accretion disc that does not accrete: seems to hold disc profile steady between the boundaries

Caveats:
- currently assumes M=1, mainly useful for disc with external potential
- velocity is damped to purely Keplerian profile, not accounting for pressure gradient
- radius is relative to the origin, so assumes centre of mass is at the origin

Did you run the bots? no
