### PR TITLE
Fix: test output being written to stderr

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,40 +28,42 @@ Giovanni Dipierro <giovanni.dipierro@leicester.ac.uk>
 Hauke Worpel <hworpel@aip.de>
 Roberto Iaconi <robertoiaconi1@gmail.com>
 Caitlyn Hardiman <caitlyn.hardiman1@monash.edu>
-Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
 Simon Glover <glover@uni-heidelberg.de>
+Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
+Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
 Martina Toscani <mtoscani94@gmail.com>
 MatsEsseldeurs <matsesseldeurs@yahoo.com>
-Jean-François Gonzalez <Jean-Francois.Gonzalez@ens-lyon.fr>
-Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Alison Young <alison.young@ed.ac.uk>
+Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Simone Ceppi <simo.ceppi@gmail.com>
 Christopher Russell <crussell@udel.edu>
-fitzHu <54089891+Fitz-Hu@users.noreply.github.com>
-Alex Pettitt <alex@astro1.sci.hokudai.ac.jp>
-Stephen Neilson <36410751+s-neilson@users.noreply.github.com>
-Megha Sharma <msha0023@student.monash.edu>
 Alessia Franchini <alessia.franchini@unlv.edu>
-Nicole Rodrigues <nicole.rodrigues@monash.edu>
+Alex Pettitt <alex@astro1.sci.hokudai.ac.jp>
+Megha Sharma <msha0023@student.monash.edu>
+Stephen Neilson <36410751+s-neilson@users.noreply.github.com>
+fitzHu <54089891+Fitz-Hu@users.noreply.github.com>
 Kieran Hirsh <kieran.hirsh1@monash.edu>
-Nicolas Cuello <cuellonicolas@gmail.com>
-Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
+Nicole Rodrigues <nicole.rodrigues@monash.edu>
 Chris Nixon <cjn@leicester.ac.uk>
 Jolien128 <72729152+Jolien128@users.noreply.github.com>
-sahl95 <sahl_rs@yahoo.com>
-David Trevascus <dtre10@student.monash.edu>
+Nicolas Cuello <cuellonicolas@gmail.com>
+Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
+Sahl Rowther <sr627@spectre14.cm.cluster>
+Benoit Commercon <benoit.commercon@gmail.com>
 Cristiano Longarini <cristiano.longarini@unimi.it>
+David Trevascus <dtre10@student.monash.edu>
+Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
 Joe Fisher <jwfis1@student.monash.edu>
 Orsola De Marco <orsola.demarco@mq.edu.au>
-Benoit Commercon <benoit.commercon@gmail.com>
 Zachary Pellow <zpel1@student.monash.edu>
 caitlynhardiman <72479852+caitlynhardiman@users.noreply.github.com>
-Giulia Ballabio <giulia.ballabio2@studenti.unimi.it>
-Stéven Toupin <steven.toupin@gmail.com>
-Cox, Samuel <sc676@leicester.ac.uk>
-Jorge Cuadra <jcuadra@astro.puc.cl>
-James <jhw5@st-andrews.ac.uk>
-s-neilson <36410751+s-neilson@users.noreply.github.com>
+sahl95 <sahl_rs@yahoo.com>
 Alison Young <ayoung@astro.ex.ac.uk>
-Steven Rieder <steven@rieder.nl>
+Cox, Samuel <sc676@leicester.ac.uk>
+James <jhw5@st-andrews.ac.uk>
+Jorge Cuadra <jcuadra@astro.puc.cl>
 Maxime Lombart <maxime.lombart@ens-lyon.fr>
+Sahl Rowther <sr627@spectre11.cm.cluster>
+Steven Rieder <steven@rieder.nl>
+Stéven Toupin <steven.toupin@gmail.com>
+s-neilson <36410751+s-neilson@users.noreply.github.com>

--- a/src/tests/test_fastmath.F90
+++ b/src/tests/test_fastmath.F90
@@ -36,7 +36,7 @@ subroutine test_math(ntests,npass,usefsqrt,usefinvsqrt)
  real, allocatable :: x(:),f(:),y(:)
  real :: t1,t2,errmax,tnative
 
- if (id==master) write(stderr,"(a,/)") '--> TESTING FAST SQRT ROUTINES'
+ if (id==master) write(*,"(a,/)") '--> TESTING FAST SQRT ROUTINES'
 
  usefsqrt    = .true.
  usefinvsqrt = .true.
@@ -46,10 +46,10 @@ subroutine test_math(ntests,npass,usefsqrt,usefinvsqrt)
  call testsqrt(ierr,output=.false.)
  if (ierr /= 0) then
     ! report errors on any threads
-    write(stderr, "(a)") ' *** ERROR with fast sqrt on this architecture ***'
+    write(*, "(a)") ' *** ERROR with fast sqrt on this architecture ***'
     usefsqrt    = .false.
     usefinvsqrt = .false.
-    write(stderr,"(/,a,/)") '<-- FAST SQRT TEST FAILED'
+    write(*,"(/,a,/)") '<-- FAST SQRT TEST FAILED'
     return
  endif
 
@@ -83,7 +83,7 @@ subroutine test_math(ntests,npass,usefsqrt,usefinvsqrt)
  enddo
  call cpu_time(t2)
  tnative = t2-t1
- if (id==master) write(stderr,"(a,es10.3,a)") ' native 1/sqrt done in ',tnative,' cpu-s'
+ if (id==master) write(*,"(a,es10.3,a)") ' native 1/sqrt done in ',tnative,' cpu-s'
  y = f
 
  call barrier_mpi
@@ -95,14 +95,14 @@ subroutine test_math(ntests,npass,usefsqrt,usefinvsqrt)
  call cpu_time(t2)
 
  ! run tests on all threads, but only report detailed results on master thread
- if (id==master) write(stderr,"(a,es10.3,a)") '   fast 1/sqrt done in ',t2-t1,' cpu-s'
+ if (id==master) write(*,"(a,es10.3,a)") '   fast 1/sqrt done in ',t2-t1,' cpu-s'
 
  if ((t2-t1) > tnative) then
-    if (id==master) write(stderr,"(a,f4.1)") ' so finvsqrt(x) is SLOWER than 1/sqrt(x) by factor of ',&
+    if (id==master) write(*,"(a,f4.1)") ' so finvsqrt(x) is SLOWER than 1/sqrt(x) by factor of ',&
                                (t2-t1)/tnative
     usefinvsqrt = .false.
  else
-    if (id==master) write(stderr,"(a,f4.1)") ' so finvsqrt(x) is FASTER than 1/sqrt(x) by factor of ', &
+    if (id==master) write(*,"(a,f4.1)") ' so finvsqrt(x) is FASTER than 1/sqrt(x) by factor of ', &
                                 tnative/(t2-t1)
  endif
 
@@ -110,10 +110,10 @@ subroutine test_math(ntests,npass,usefsqrt,usefinvsqrt)
  do i=1,n
     errmax = max(errmax,abs(y(i) - f(i))/y(i))
  enddo
- if (id==master) write(stderr,"(1x,a,es10.3)") 'max relative error is ',errmax
+ if (id==master) write(*,"(1x,a,es10.3)") 'max relative error is ',errmax
  if (errmax > 1.e-7) usefinvsqrt = .false.
 
- if (id==master) write(stderr,*)
+ if (id==master) write(*,*)
  call barrier_mpi
 !
 !--check timings for sqrt
@@ -124,7 +124,7 @@ subroutine test_math(ntests,npass,usefsqrt,usefinvsqrt)
  enddo
  call cpu_time(t2)
  tnative = t2-t1
- if (id==master) write(stderr,"(a,es10.3,a)") '   native sqrt done in ',tnative,' cpu-s'
+ if (id==master) write(*,"(a,es10.3,a)") '   native sqrt done in ',tnative,' cpu-s'
  y = f
  call barrier_mpi
 
@@ -133,28 +133,28 @@ subroutine test_math(ntests,npass,usefsqrt,usefinvsqrt)
     f(i) = x(i)*finvsqrt(x(i))
  enddo
  call cpu_time(t2)
- if (id==master) write(stderr,"(a,es10.3,a)") ' x*finvsqrt(x) done in ',t2-t1,' cpu-s'
+ if (id==master) write(*,"(a,es10.3,a)") ' x*finvsqrt(x) done in ',t2-t1,' cpu-s'
 
  if ((t2-t1) > tnative) then
-    if (id==master) write(stderr,"(a,f4.1)") ' so x*finvsqrt(x) is SLOWER than sqrt(x) by factor of ',&
+    if (id==master) write(*,"(a,f4.1)") ' so x*finvsqrt(x) is SLOWER than sqrt(x) by factor of ',&
                              (t2-t1)/tnative
     usefsqrt = .false.
  else
-    if (id==master) write(stderr,"(a,f4.1)") ' so x*finvsqrt(x) is FASTER than sqrt(x) by factor of ',tnative/(t2-t1)
+    if (id==master) write(*,"(a,f4.1)") ' so x*finvsqrt(x) is FASTER than sqrt(x) by factor of ',tnative/(t2-t1)
  endif
 
  errmax = 0.
  do i=1,n
     errmax = max(errmax,abs(y(i) - f(i))/(y(i) + epsilon(y)))
  enddo
- if (id==master) write(stderr,"(1x,a,es10.3)") 'max relative error is ',errmax
+ if (id==master) write(*,"(1x,a,es10.3)") 'max relative error is ',errmax
  if (errmax > 1.e-7) usefinvsqrt = .false.
 
  if (allocated(x)) deallocate(x)
  if (allocated(f)) deallocate(f)
  if (allocated(y)) deallocate(y)
 
- if (id==master) write(stderr,"(/,a,/)") '<-- FAST SQRT TEST COMPLETE'
+ if (id==master) write(*,"(/,a,/)") '<-- FAST SQRT TEST COMPLETE'
  call barrier_mpi
 
 end subroutine test_math

--- a/src/tests/test_kernel.f90
+++ b/src/tests/test_kernel.f90
@@ -41,7 +41,7 @@ subroutine test_kernel(ntests,npass)
  real :: dq,q2,qi,errmax(nktest),eps,tolgrad
  real :: potensoft,fsoft,potensofte,fsofte,dp
 
- if (id==master) write(stderr,"(a,/)") '--> TESTING '//trim(kernelname)//' kernel'
+ if (id==master) write(*,"(a,/)") '--> TESTING '//trim(kernelname)//' kernel'
 !
 !--check that wab0 and gradh0 are equal to values at q=zero
 !
@@ -120,7 +120,7 @@ subroutine test_kernel(ntests,npass)
  call checkvalbuf_end('get_kernel_grav1 == grkern',ncheck(6),nerr(6),errmax(6),tiny(0.))
  call checkvalbuf_end('dphi/dh = phi - q*dphi/dq',ncheck(7),nerr(7),errmax(7),2.e-7)
 
- if (id==master) write(stderr,"(/,a,/)") '<-- KERNEL TEST COMPLETE'
+ if (id==master) write(*,"(/,a,/)") '<-- KERNEL TEST COMPLETE'
 
 end subroutine test_kernel
 


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
There are a handful of tests which write part of the log to stderr. The majority of tests in the suite write to stdout, so they have all been changed to stdout for consistency.

Testing:
Running test locally, splitting stdout and stderr to identify erroneously written log lines.

Did you run the bots? yes, via pre-commit
