### PR TITLE
Add possibility of varying beta cooling with radius as a power law

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -501,6 +501,7 @@ SRCGR=inverse4x4.f90 $(SRCMETRIC) metric_tools.f90 utils_gr.f90
 # chemistry and cooling
 #
 SRCCHEM= fs_data.f90 mol_data.f90 utils_spline.f90 \
+         cooling_gammie_PL.f90 \
          cooling_gammie.f90 \
          cooling_koyamainutsuka.f90 \
          cooling_ism.f90 \

--- a/src/main/cooling.F90
+++ b/src/main/cooling.F90
@@ -14,6 +14,7 @@ module cooling
 !     3 = Gammie cooling                  [explicit]
 !     5 = Koyama & Inutuska (2002)        [explicit]
 !     6 = Koyama & Inutuska (2002)        [implicit]
+!     7 = Gammie cooling power law        [explicit]
 !
 ! :References:
 !   Gail & Sedlmayr textbook Physics and chemistry of Circumstellar dust shells
@@ -90,6 +91,9 @@ subroutine init_cooling(id,master,iprint,ierr)
     case(3)
        ! Gammie
        cooling_in_step = .false.
+    case(7)
+       ! Gammie PL
+       cooling_in_step = .false.
     case default
        call init_cooling_solver(ierr)
     end select
@@ -120,6 +124,7 @@ subroutine energ_cooling(xi,yi,zi,ui,dudt,rho,dt,Tdust_in,mu_in,gamma_in,K2_in,k
  use physcon, only:Rg
  use units,   only:unit_ergg
  use cooling_gammie,         only:cooling_Gammie_explicit
+ use cooling_gammie_PL,       only:cooling_Gammie_PL_explicit
  use cooling_solver,         only:energ_cooling_solver
  use cooling_koyamainutsuka, only:cooling_KoyamaInutsuka_explicit,&
                                   cooling_KoyamaInutsuka_implicit
@@ -152,6 +157,8 @@ subroutine energ_cooling(xi,yi,zi,ui,dudt,rho,dt,Tdust_in,mu_in,gamma_in,K2_in,k
     !call cooling_molecular
  case (3)
     call cooling_Gammie_explicit(xi,yi,zi,ui,dudt)
+ case (7)
+    call cooling_Gammie_PL_explicit(xi,yi,zi,ui,dudt)
  case default
     call energ_cooling_solver(ui,dudt,rho,dt,mu,polyIndex,Tdust,K2,kappa)
  end select
@@ -168,6 +175,7 @@ subroutine write_options_cooling(iunit)
  use part,              only:h2chemistry
  use cooling_ism,       only:write_options_cooling_ism
  use cooling_gammie,    only:write_options_cooling_gammie
+ use cooling_gammie_PL,  only:write_options_cooling_gammie_PL
  use cooling_molecular, only:write_options_molecularcooling
  use cooling_solver,    only:write_options_cooling_solver
  integer, intent(in) :: iunit
@@ -179,12 +187,14 @@ subroutine write_options_cooling(iunit)
     if (icooling > 0) call write_options_cooling_ism(iunit)
  else
     call write_inopt(icooling,'icooling','cooling function (0=off, 1=cooling library (step), 2=cooling library (force),'// &
-                     '3=Gammie, 5,6=KI02)',iunit)
+                     '3=Gammie, 5,6=KI02, 7=powerlaw)',iunit)
     select case(icooling)
     case(0,4,5,6)
        ! do nothing
     case(3)
        call write_options_cooling_gammie(iunit)
+    case(7)
+       call write_options_cooling_gammie_PL(iunit)
     case default
        call write_options_cooling_solver(iunit)
     end select
@@ -202,6 +212,7 @@ subroutine read_options_cooling(name,valstring,imatch,igotall,ierr)
  use part,              only:h2chemistry
  use io,                only:fatal
  use cooling_gammie,    only:read_options_cooling_gammie
+ use cooling_gammie_PL,  only:read_options_cooling_gammie_PL
  use cooling_ism,       only:read_options_cooling_ism
  use cooling_molecular, only:read_options_molecular_cooling
  use cooling_solver,    only:read_options_cooling_solver
@@ -209,7 +220,7 @@ subroutine read_options_cooling(name,valstring,imatch,igotall,ierr)
  logical,          intent(out) :: imatch,igotall
  integer,          intent(out) :: ierr
  integer, save :: ngot = 0
- logical :: igotallism,igotallmol,igotallgammie,igotallfunc
+ logical :: igotallism,igotallmol,igotallgammie,igotallgammiePL,igotallfunc
 
  imatch        = .true.
  igotall       = .false.  ! cooling options are compulsory
@@ -238,6 +249,8 @@ subroutine read_options_cooling(name,valstring,imatch,igotall,ierr)
           ! do nothing
        case(3)
           call read_options_cooling_gammie(name,valstring,imatch,igotallgammie,ierr)
+       case(7)
+          call read_options_cooling_gammie_PL(name,valstring,imatch,igotallgammiePL,ierr)
        case default
           call read_options_cooling_solver(name,valstring,imatch,igotallfunc,ierr)
        end select

--- a/src/main/cooling_gammie_PL.f90
+++ b/src/main/cooling_gammie_PL.f90
@@ -1,0 +1,91 @@
+!--------------------------------------------------------------------------!
+! The Phantom Smoothed Particle Hydrodynamics code, by Daniel Price et al. !
+! Copyright (c) 2007-2023 The Authors (see AUTHORS)                        !
+! See LICENCE file for usage and distribution conditions                   !
+! http://phantomsph.bitbucket.io/                                          !
+!--------------------------------------------------------------------------!
+module cooling_gammie_PL
+!
+! Simple beta-cooling prescription used for experiments on gravitational
+!  instability in discs
+!
+! :References:
+!   Gammie (2001), ApJ 553, 174-183
+!
+! :Owner: Daniel Price
+!
+! :Runtime parameters:
+!   - beta_cool : *beta factor in Gammie (2001) cooling*
+!
+! :Dependencies: infile_utils, io
+!
+ implicit none
+ real, private :: beta_cool = 3., eta = 1.5, r_beta = 50.
+
+contains
+!-----------------------------------------------------------------------
+!+
+!   Gammie PL cooling
+!+
+!-----------------------------------------------------------------------
+subroutine cooling_Gammie_PL_explicit(xi,yi,zi,ui,dudti)
+
+ real, intent(in)    :: ui,xi,yi,zi
+ real, intent(inout) :: dudti
+
+ real :: omegai,r2,tcool1
+
+ r2     = xi*xi + yi*yi + zi*zi
+ Omegai = r2**(-0.75)
+ tcool1 = Omegai/(beta_cool * (r2/r_beta**2)** (-eta/2))
+ dudti  = dudti - ui*tcool1
+
+end subroutine cooling_Gammie_PL_explicit
+
+!-----------------------------------------------------------------------
+!+
+!  writes input options to the input file
+!+
+!-----------------------------------------------------------------------
+subroutine write_options_cooling_gammie_PL(iunit)
+ use infile_utils, only:write_inopt
+ integer, intent(in) :: iunit
+
+ call write_inopt(beta_cool,'beta_cool','beta factor in Gammie (2001) cooling @ R_beta',iunit)
+ call write_inopt(eta,'eta','Power law coefficient of the cooling factor',iunit)
+ call write_inopt(r_beta,'r_beta','Characteristic radius of the cooling power law profile',iunit)
+
+end subroutine write_options_cooling_gammie_PL
+
+!-----------------------------------------------------------------------
+!+
+!  reads input options from the input file
+!+
+!-----------------------------------------------------------------------
+subroutine read_options_cooling_gammie_PL(name,valstring,imatch,igotall,ierr)
+ use io, only:fatal
+ character(len=*), intent(in)  :: name,valstring
+ logical,          intent(out) :: imatch,igotall
+ integer,          intent(out) :: ierr
+ integer, save :: ngot = 0
+
+ imatch  = .true.
+ igotall = .true. ! none of the cooling options are compulsory
+ select case(trim(name))
+ case('beta_cool')
+    read(valstring,*,iostat=ierr) beta_cool
+    ngot = ngot + 1
+ case('eta')
+    read(valstring,*,iostat=ierr) eta
+    ngot = ngot + 1
+ case('r_beta')
+    read(valstring,*,iostat=ierr) r_beta
+    ngot = ngot + 1
+ case default
+    imatch = .false.
+ end select
+ if (ngot >= 1) igotall = .true.
+
+end subroutine read_options_cooling_gammie_PL
+
+end module cooling_gammie_PL


### PR DESCRIPTION
Possibility to have a Gammie \beta cooling as a function of the radius (power law).

2 new parameters: 
1) eta, that is the exponent of the power law (r^-eta)
2) r_beta, the characteristic radius at which the beta_cooling is fixed