### PR TITLE
Fixed problems with phantom2hdf5 not compilling and added missing got arrays for the reading of hdf5 files.

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -612,7 +612,7 @@ edit: checksetup
 #----------------------------------------------------
 # these are the sources for anything which uses the readwrite_dumps module
 #
-SRCDUMP= physcon.f90 ${CONFIG} ${SRCKERNEL} io.F90 units.f90 boundary.f90 mpi_utils.F90 \
+SRCDUMP= physcon.f90 ${CONFIG} ${SRCKERNEL} utils_omp.F90 io.F90 units.f90 boundary.f90 mpi_utils.F90 \
          utils_timing.f90 utils_infiles.f90 dtype_kdtree.f90 utils_allocate.f90 part.F90 ${DOMAIN} \
          mpi_dens.F90 mpi_force.F90 \
          mpi_balance.F90 mpi_memory.F90 mpi_derivs.F90 mpi_tree.F90 kdtree.F90 linklist_kdtree.F90 \
@@ -652,7 +652,7 @@ libsetup: $(OBJLIBSETUP)
 .PHONY: phantomsetup
 phantomsetup: setup
 
-SRCSETUP= utils_omp.F90 utils_summary.F90 utils_gravwave.f90 \
+SRCSETUP= utils_summary.F90 utils_gravwave.f90 \
           set_dust_options.f90 \
           utils_indtimesteps.F90 partinject.F90 \
           ${SRCTURB} ${SRCNIMHD} ${SRCCHEM} \

--- a/src/main/readwrite_dumps_hdf5.F90
+++ b/src/main/readwrite_dumps_hdf5.F90
@@ -36,7 +36,7 @@ module readwrite_dumps_hdf5
 
  implicit none
  character(len=80), parameter, public :: &    ! module version
-   modid="$Id: 98a6578676f962cf0d0ad7c564f4b5d036bc7d0a $"
+   modid="$Id$"
 
  public :: read_dump_hdf5,read_smalldump_hdf5
  public :: write_smalldump_hdf5,write_fulldump_hdf5,write_dump_hdf5

--- a/src/main/readwrite_dumps_hdf5.F90
+++ b/src/main/readwrite_dumps_hdf5.F90
@@ -36,7 +36,7 @@ module readwrite_dumps_hdf5
 
  implicit none
  character(len=80), parameter, public :: &    ! module version
-   modid="$Id$"
+   modid="$Id: 98a6578676f962cf0d0ad7c564f4b5d036bc7d0a $"
 
  public :: read_dump_hdf5,read_smalldump_hdf5
  public :: write_smalldump_hdf5,write_fulldump_hdf5,write_dump_hdf5
@@ -474,7 +474,7 @@ subroutine read_any_dump_hdf5(                                                  
  use dim,            only:maxp,gravity,maxalpha,mhd,use_dust,use_dustgrowth, &
                           h2chemistry,nsinkproperties,     &
                           maxp_hard,use_krome,store_dust_temperature,        &
-                          do_radiation,do_nucleation,gr
+                          do_radiation,do_nucleation,gr,idumpfile
  use eos,            only:ieos,polyk,gamma,polyk2,qfacdisc,isink
  use checkconserved, only:get_conserv,etot_in,angtot_in,totmom_in,mdust_in
  use io,             only:fatal,error
@@ -492,6 +492,7 @@ subroutine read_any_dump_hdf5(                                                  
  use part,           only:dt_in
 #endif
  use setup_params,   only:rhozero
+ use timestep,       only:dtmax_user,idtmax_n,idtmax_frac
  use units,          only:udist,umass,utime,unit_Bfield,set_units_extra
  use externalforces, only:iext_gwinspiral,iext_binary,iext_corot_binary
  use extern_gwinspiral, only:Nstar
@@ -712,9 +713,9 @@ subroutine read_any_dump_hdf5(                                                  
                       got_arrays%got_krome_gamma, &
                       got_arrays%got_krome_mu,    &
                       got_arrays%got_krome_T,     &
-                      .false.,                    &
-                      .false.,                    &
-                      .false.,                    &
+                      got_arrays%got_x,           &
+                      got_arrays%got_z,           &
+                      got_arrays%got_mu,          &
                       got_arrays%got_abund,       &
                       got_arrays%got_dustfrac,    &
                       got_arrays%got_sink_data,   &
@@ -729,6 +730,7 @@ subroutine read_any_dump_hdf5(                                                  
                       got_arrays%got_raden,       &
                       got_arrays%got_kappa,       &
                       got_arrays%got_Tdust,       &
+                      got_arrays%got_nucleation,  &
                       got_arrays%got_iorig,       &
                       iphase,                     &
                       xyzh,                       &

--- a/src/main/utils_dumpfiles_hdf5.f90
+++ b/src/main/utils_dumpfiles_hdf5.f90
@@ -17,7 +17,7 @@ module utils_dumpfiles_hdf5
 ! :Dependencies: dim, eos, part, utils_hdf5
 !
  use dim,        only:maxtypes,maxdustsmall,maxdustlarge,nabundances,nsinkproperties
- use part,       only:eos_vars_label,igasP,itemp,maxirad
+ use part,       only:eos_vars_label,igasP,itemp,iX,iZ,imu,maxirad,n_nucleation
  use eos,        only:ieos,eos_is_non_ideal,eos_outputs_gasP
  use utils_hdf5, only:write_to_hdf5,    &
                       read_from_hdf5,   &
@@ -70,9 +70,13 @@ module utils_dumpfiles_hdf5
                           nparttot,                      &
                           npartoftypetot(maxtypes),      &
                           iexternalforce,                &
-                          ieos
+                          ieos,                          &
+                          idumpfile,                     &
+                          idtmax_n_next,                 &
+                          idtmax_frac_next
     real               :: time,                          &
                           dtmax,                         &
+                          dtmax_user,                    &
                           gamma,                         &
                           rhozero,                       &
                           polyk,                         &
@@ -150,6 +154,10 @@ module utils_dumpfiles_hdf5
                got_krome_gamma,                      &
                got_krome_mu,                         &
                got_krome_T,                          &
+               got_x,                                &
+               got_z,                                &
+               got_mu,                               &
+               got_nucleation(n_nucleation),         &
                got_orig
  end type got_arrays_hdf5
 
@@ -862,6 +870,10 @@ subroutine read_hdf5_arrays( &
  got_arrays%got_krome_gamma = .false.
  got_arrays%got_krome_mu    = .false.
  got_arrays%got_krome_T     = .false.
+ got_arrays%got_x           = .false.
+ got_arrays%got_z           = .false.
+ got_arrays%got_mu          = .false.
+ got_arrays%got_nucleation  = .false.
 
  ! Open particles group
  call open_hdf5group(file_id, 'particles', group_id, error)
@@ -887,6 +899,10 @@ subroutine read_hdf5_arrays( &
  if (eos_is_non_ideal(ieos)) then
     call read_from_hdf5(eos_vars(itemp,:), eos_vars_label(itemp), group_id, got_arrays%got_temp, error)
  endif
+
+ call read_from_hdf5(eos_vars(iX,:), eos_vars_label(iX), group_id, got_arrays%got_x, error)
+ call read_from_hdf5(eos_vars(iZ,:), eos_vars_label(iZ), group_id, got_arrays%got_z, error)
+ call read_from_hdf5(eos_vars(imu,:), eos_vars_label(imu), group_id, got_arrays%got_mu, error)
 
  ! General relativity
  if (array_options%gr) then
@@ -959,6 +975,7 @@ subroutine read_hdf5_arrays( &
     call read_from_hdf5(nucleation(7,1:npart), 'nucleation_gamma', group_id, got, error)
     call read_from_hdf5(nucleation(8,1:npart), 'nucleation_S', group_id, got, error)
     call read_from_hdf5(nucleation(9,1:npart), 'nucleation_kappa', group_id, got, error)
+    if (got) got_arrays%got_nucleation = .true.
  endif
 
  ! Radiation


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
Fixed various issues preventing the compilation of phantom2hdf5 and also added some missing got arrays (x, z, mu and nucleation) for the reading of hdf5 files.

Testing:
I successfully compiled phantom2hdf5 and made a readable .h5 file using it. I did not test the got arrays that I added.

Did you run the bots? yes
