### PR TITLE
(hfact) remove remaining hardwired hfact=1.2; replace with hfact=hfact_default

### DIFF
--- a/src/utils/moddump_extenddisc.f90
+++ b/src/utils/moddump_extenddisc.f90
@@ -29,12 +29,13 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  use part,       only:igas,isdead_or_accreted,xyzmh_ptmass,vxyz_ptmass,nptmass
  use eos,        only:gamma,polyk
  use io,         only:id,master,fatal
+ use kernel,     only:hfact_default
  use setdisc,    only:set_disc,get_disc_mass,scaled_sigma
  use physcon,    only:pi
  use vectorutils,only:rotatevec
  use prompting,      only:prompt
  use centreofmass,   only:reset_centreofmass,get_total_angular_momentum
- use infile_utils, only:open_db_from_file,inopts,read_inopt,close_db
+ use infile_utils,   only:open_db_from_file,inopts,read_inopt,close_db
  integer, intent(inout) :: npart
  integer, intent(inout) :: npartoftype(:)
  real,    intent(inout) :: massoftype(:)
@@ -92,7 +93,7 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  pmass = massoftype(igas)
  sigmaprofile = 2
  sigma_norm = 1.0
- hfact = 1.2
+ hfact = hfact_default
 
  ! Run a basic disc analysis to determine tilt and twist as a function of radius
  sigma = 0.
@@ -214,7 +215,6 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
 
  deallocate(xyzh_add,vxyzu_add)
 
- return
 end subroutine modify_dump
 
 end module moddump

--- a/src/utils/moddump_sphNG2phantom.f90
+++ b/src/utils/moddump_sphNG2phantom.f90
@@ -25,6 +25,7 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  use eos,      only:polyk,polyk2
  use units,    only:unit_velocity
  use part,     only:hfact
+ use kernel,   only:hfact_default
  integer, intent(inout) :: npart
  integer, intent(inout) :: npartoftype(:)
  real,    intent(inout) :: massoftype(:)
@@ -49,10 +50,8 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  print*,' the sound speed in the medium is ',sqrt(polyk2)
  print*,'                          in cm/s ',sqrt(polyk2)*unit_velocity
 
- hfact = 1.2
+ hfact = hfact_default
 
- return
 end subroutine modify_dump
 
 end module moddump
-

--- a/src/utils/moddump_sphNG2phantom_addBfield.f90
+++ b/src/utils/moddump_sphNG2phantom_addBfield.f90
@@ -21,8 +21,9 @@ module moddump
 contains
 
 subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
- use setup_params, only: ihavesetupB
- use part,         only: hfact,mhd
+ use setup_params, only:ihavesetupB
+ use part,         only:hfact,mhd
+ use kernel,       only:hfact_default
 ! use timestep,      only: dtmax
  !traced dtmax to "timestep" but can't find "timestep"?
  !also can't find "dim"?
@@ -44,8 +45,7 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  ! - from 'set_default_options' - options which comes from 'timestep' ?
 
  ! Define hfact
- hfact = 1.2
-
+ hfact = hfact_default
 
  print*,'sphNG data reformatted for phantom write'
 
@@ -58,4 +58,3 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
 end subroutine modify_dump
 
 end module moddump
-

--- a/src/utils/phantomanalysis.f90
+++ b/src/utils/phantomanalysis.f90
@@ -25,6 +25,7 @@ program phantomanalysis
  use fileutils,       only:numfromfile,basename
  use analysis,        only:do_analysis,analysistype
  use eos,             only:ieos
+ use kernel,          only:hfact_default
  implicit none
  integer            :: nargs,iloc,ierr,iarg,i
  real               :: time
@@ -107,8 +108,8 @@ program phantomanalysis
     endif
 
     if (hfact < tiny(hfact)) then
-       print "(a,f6.2,a)",' WARNING! hfact = ',hfact,' from dump file, resetting to 1.2'
-       hfact = 1.2
+       print "(a,f6.2,a)",' WARNING! hfact = ',hfact,' from dump file, resetting to default'
+       hfact = hfact_default
     endif
 
     call do_analysis(trim(dumpfile),numfromfile(dumpfile),xyzh,vxyzu, &


### PR DESCRIPTION

Type of PR: 
 other

Description:
the default setting of hfact=1.2 is ok for the cubic spline but not if a different kernel is employed. Hence we should not have any hardwired hfact=1.2 statements in the code. This replaces those remaining with hfact=hfact_default where hfact_default is a parameter in the top of the corresponding kernel module.

Testing:
compiled phantomanalysis and moddump with the amended files

Did you run the bots? no
