### PR TITLE
(radiation) make cv_type runtime option and set rad=0 in relax_star when using radiation

### DIFF
--- a/src/main/eos.F90
+++ b/src/main/eos.F90
@@ -1026,17 +1026,17 @@ end function get_mean_molecular_weight
 !  return cv from rho, u in code units
 !+
 !---------------------------------------------------------
-real function get_cv(rho,u,eos_type) result(cv)
+real function get_cv(rho,u,cv_type) result(cv)
  use mesa_microphysics, only:getvalue_mesa
  use units,             only:unit_ergg,unit_density
  use physcon,           only:Rg
  real, intent(in)    :: rho,u
- integer, intent(in) :: eos_type
+ integer, intent(in) :: cv_type
  real                :: rho_cgs,u_cgs,temp
 
- select case (eos_type)
+ select case (cv_type)
 
- case(10)  ! MESA EoS
+ case(1)  ! MESA EoS
     rho_cgs = rho*unit_density
     u_cgs = u*unit_ergg
     call getvalue_mesa(rho_cgs,u_cgs,4,temp)

--- a/src/main/radiation_utils.f90
+++ b/src/main/radiation_utils.f90
@@ -445,17 +445,17 @@ end subroutine get_opacity
 !  get 1/mu from rho, u
 !+
 !--------------------------------------------------------------------
-real function get_1overmu(rho,u,mu_type) result(rmu)
+real function get_1overmu(rho,u,cv_type) result(rmu)
  use eos,               only:gmw
  use mesa_microphysics, only:get_1overmu_mesa
  use physcon,           only:Rg
  use units,             only:unit_density,unit_ergg
  real, intent(in)    :: rho,u
- integer, intent(in) :: mu_type
+ integer, intent(in) :: cv_type
  real                :: rho_cgs,u_cgs
 
- select case (mu_type)
- case(2) ! mu from MESA EoS tables
+ select case (cv_type)
+ case(1) ! mu from MESA EoS tables
     rho_cgs = rho*unit_density
     u_cgs = u*unit_ergg
     rmu = get_1overmu_mesa(rho_cgs,u_cgs,real(Rg))

--- a/src/main/readwrite_infile.F90
+++ b/src/main/readwrite_infile.F90
@@ -127,7 +127,7 @@ subroutine write_infile(infile,logfile,evfile,dumpfile,iwritein,iprint)
  use cooling,         only:write_options_cooling
  use gravwaveutils,   only:write_options_gravitationalwaves
  use radiation_utils,    only:kappa_cgs
- use radiation_implicit, only:tol_rad,itsmax_rad
+ use radiation_implicit, only:tol_rad,itsmax_rad,cv_type
  use dim,                only:maxvxyzu,maxptmass,gravity,sink_radiation,gr,nalpha
  use part,               only:h2chemistry,maxp,mhd,maxalpha,nptmass
  character(len=*), intent(in) :: infile,logfile,evfile,dumpfile
@@ -303,8 +303,9 @@ subroutine write_infile(infile,logfile,evfile,dumpfile,iwritein,iprint)
     call write_inopt(iopacity_type,'iopacity_type','opacity method (0=inf,1=mesa,2=constant,-1=preserve)',iwritein)
     if (iopacity_type == 2) call write_inopt(kappa_cgs,'kappa_cgs','constant opacity value in cm2/g',iwritein)
     if (implicit_radiation) then
-       call write_inopt(tol_rad,'tol_rad','tolerance on backwards Euler implicit solve of dxi/dt',iwritein)
-       call write_inopt(itsmax_rad,'itsmax_rad','max number of iterations allowed in implicit solver',iwritein)
+      call write_inopt(tol_rad,'tol_rad','tolerance on backwards Euler implicit solve of dxi/dt',iwritein)
+      call write_inopt(itsmax_rad,'itsmax_rad','max number of iterations allowed in implicit solver',iwritein)
+      call write_inopt(cv_type,'cv_type','how to get cv and mean mol weight (0=constant,1=mesa)',iwritein)
     endif
  endif
 #ifdef GR
@@ -359,7 +360,7 @@ subroutine read_infile(infile,logfile,evfile,dumpfile)
  use ptmass,          only:read_options_ptmass
  use ptmass_radiation,   only:read_options_ptmass_radiation,isink_radiation,alpha_rad
  use radiation_utils,    only:kappa_cgs
- use radiation_implicit, only:tol_rad,itsmax_rad
+ use radiation_implicit, only:tol_rad,itsmax_rad,cv_type
  use damping,         only:read_options_damping
  use gravwaveutils,   only:read_options_gravitationalwaves
  character(len=*), parameter   :: label = 'read_infile'
@@ -544,6 +545,8 @@ subroutine read_infile(infile,logfile,evfile,dumpfile)
        read(valstring,*,iostat=ierr) limit_radiation_flux
     case('iopacity_type')
        read(valstring,*,iostat=ierr) iopacity_type
+    case('cv_type')
+       read(valstring,*,iostat=ierr) cv_type
     case('kappa_cgs')
        read(valstring,*,iostat=ierr) kappa_cgs
     case('tol_rad')


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
- Using relax_star with do_radiation = .true. requires setting rad=0.
- Use integer runtime option cv_type to specify method to calculate mean molecular weight in get_1overmu and in get_cv. For cv_type = 0, use mu = gmw and cv = Rg/((gamma-1.)*gmw*unit_ergg). For cv_type = 1, use MESA tables. 

Testing:
Set up radiating star.

Did you run the bots? yes/no
no