### PR TITLE
Removed lines in readwrite_dump preventing multigrains simulations to run

### DIFF
--- a/src/main/readwrite_dumps_fortran.F90
+++ b/src/main/readwrite_dumps_fortran.F90
@@ -1938,10 +1938,6 @@ subroutine count_particle_types(npartoftype)
  npartoftype(:) = 0
  do i = 1, npart
     itype = iamtype(iphase(i))
-    if (itype  >  8) then
-       print *, "particle i=", i,"is type", itype
-       cycle
-    endif
     npartoftype(itype) = npartoftype(itype) + 1
  enddo
 


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
Removed 4 lines in readwrite_dump_fortran.f90 preventing simulations with more than 2 dust species to run.

Testing:
Multigrains (5 dust species) simulation started without any problems as well as the dustyshock test.

Did you run the bots? no
