### PR TITLE
No warnings

### DIFF
--- a/build/Makefile_defaults_gfortran
+++ b/build/Makefile_defaults_gfortran
@@ -30,3 +30,7 @@ GFORTRAN_VERSION_MAJOR=${shell gfortran -dumpversion | cut -d'.' -f 1}
 ifeq ($(shell [ $(GFORTRAN_VERSION_MAJOR) -gt 6 ] && echo true),true)
     DEBUGFLAG+= -finit-derived
 endif
+
+ifeq ($(NOWARN), yes)
+    FFLAGS+= -Werror
+endif

--- a/build/Makefile_setups
+++ b/build/Makefile_setups
@@ -98,7 +98,7 @@ endif
 ifeq ($(SETUP), turbdrive)
 #   driven turbulence
     ifeq ($(IND_TIMESTEPS), yes)
-        FPPFLAGS= -DPERIODIC -DCORRECT_BULK_MOTION -DSTIR_FROM_FILE
+        FPPFLAGS= -DPERIODIC -DCORRECT_BULK_MOTION
     else
         FPPFLAGS= -DPERIODIC # -DCORRECT_MEAN_FORCE
     endif
@@ -122,7 +122,7 @@ endif
 
 ifeq ($(SETUP), turb)
 #   driven supersonic turbulence (hydro, mhd, dusty)
-    FPPFLAGS      = -DPERIODIC -DCORRECT_BULK_MOTION -DSTIR_FROM_FILE
+    FPPFLAGS      = -DPERIODIC -DCORRECT_BULK_MOTION
     SETUPFILE     = setup_turb.f90
     SRCTURB       = forcing.F90
     IND_TIMESTEPS = yes

--- a/scripts/bots.sh
+++ b/scripts/bots.sh
@@ -233,11 +233,11 @@ for edittype in $bots_to_run; do
                      -e 's/IAND(/iand(/g' \
                      -e 's/IEOR(/ieor(/g' \
                      -e 's/MODULO(/modulo(/g' \
-                     -e 's/KIND(/kind(/g' \
                      -e 's/HUGE(/huge(/g' \
                      -e 's/TINY(/tiny(/g' \
                      -e 's/SELECTED_REAL_KIND(/selected_real_kind(/g' \
                      -e 's/SELECTED_INT_KIND(/selected_int_kind(/g' \
+                     -e 's/KIND(/kind(/g' \
                      -e 's/ REAL/ real/g' $file > $out;;
                'endif' )
                  sed -e 's/end if/endif/g' \

--- a/scripts/bots.sh
+++ b/scripts/bots.sh
@@ -226,6 +226,9 @@ for edittype in $bots_to_run; do
                      -e 's/INTENT(IN)/intent(in)/g' \
                      -e 's/INTENT(OUT)/intent(out)/g' \
                      -e 's/INTENT(INOUT)/intent(inout)/g' \
+                     -e 's/intent(IN)/intent(in)/g' \
+                     -e 's/intent(OUT)/intent(out)/g' \
+                     -e 's/intent(INOUT)/intent(inout)/g' \
                      -e 's/INT(/int(/g' \
                      -e 's/MIN(/min(/g' \
                      -e 's/ABS(/abs(/g' \
@@ -237,6 +240,8 @@ for edittype in $bots_to_run; do
                      -e 's/TINY(/tiny(/g' \
                      -e 's/SELECTED_REAL_KIND(/selected_real_kind(/g' \
                      -e 's/SELECTED_INT_KIND(/selected_int_kind(/g' \
+                     -e 's/SELECTED_REAL_kind(/selected_real_kind(/g' \
+                     -e 's/SELECTED_INT_kind(/selected_int_kind(/g' \
                      -e 's/KIND(/kind(/g' \
                      -e 's/ REAL/ real/g' $file > $out;;
                'endif' )

--- a/scripts/buildbot.sh
+++ b/scripts/buildbot.sh
@@ -84,8 +84,9 @@ allsetups=${setuparr[@]:$offset:$batchsize}
 echo "Batch ${batch}: ${allsetups}"
 #
 # change the line below to exclude things that depend on external libraries from the build
+# we also choose to disallow compiler warnings here
 #
-nolibs='MESAEOS=no'
+nolibs='MESAEOS=no NOWARN=yes'
 if [ ! -e $phantomdir/scripts/$0 ]; then
    echo "Error: This script needs to be run from the phantom/scripts directory";
    exit;

--- a/scripts/buildbot.sh
+++ b/scripts/buildbot.sh
@@ -84,9 +84,15 @@ allsetups=${setuparr[@]:$offset:$batchsize}
 echo "Batch ${batch}: ${allsetups}"
 #
 # change the line below to exclude things that depend on external libraries from the build
-# we also choose to disallow compiler warnings here
 #
-nolibs='MESAEOS=no NOWARN=yes'
+nolibs='MESAEOS=no'
+#
+# disallow compiler warnings?
+#
+nowarn='NOWARN=yes'
+#
+# check we are running the script from the scripts directory
+#
 if [ ! -e $phantomdir/scripts/$0 ]; then
    echo "Error: This script needs to be run from the phantom/scripts directory";
    exit;
@@ -314,19 +320,19 @@ for setup in $listofsetups; do
       fi
       colour=$white; # white (default)
       ncheck=$((ncheck + 1));
-      #echo "::group:: checking $component with make SETUP=${setup} ${target}";
+
       printf "Checking $setup ($target)... ";
-      if [ "$component"=="setup" ]; then
+      if [[ "$component" == "setup" ]]; then
          rm -f $phantomdir/bin/phantomsetup;
          #make clean >& /dev/null;
       fi
-      #case $component in
-      #'utils')
-      #  make cleanutils >& /dev/null;;
-      #*)
-      #  make clean >& /dev/null;;
-      #esac
-      make SETUP=$setup $nolibs $maxp $target 1> $makeout 2> $errorlog; err=$?;
+      if [[ "$setup" == "blob" ]]; then
+         mynowarn='';
+         echo "allowing warnings for SETUP=blob"
+      else
+         mynowarn=$nowarn;
+      fi
+      make SETUP=$setup $nolibs $mynowarn $maxp $target 1> $makeout 2> $errorlog; err=$?;
       #--remove line numbers from error log files
       sed -e 's/90(.*)/90/g' -e 's/90:.*:/90/g' $errorlog | grep -v '/tmp' > $errorlog.tmp && mv $errorlog.tmp $errorlog;
       if [ $err -eq 0 ]; then

--- a/src/lib/NICIL/src/nicil.F90
+++ b/src/lib/NICIL/src/nicil.F90
@@ -1184,6 +1184,7 @@ pure subroutine nicil_update_nimhd(icall,eta_ohm,eta_hall,eta_ambi,Bfield,rho,T,
        else
           nden_electronR = nicil_ionR_get_ne(nden_save(1:iire))  ! in this case, need to calculate electron density from ions
           n_g_tot        = 0. ! to prevent compiler warnings
+          zeta           = 0.
        endif
 
        !--Sum the ion populations from thermal and cosmic ray ionisation

--- a/src/main/config.F90
+++ b/src/main/config.F90
@@ -49,8 +49,10 @@ module dim
  ! storage of thermal energy or not
 #ifdef ISOTHERMAL
  integer, parameter :: maxvxyzu = 3
+ logical, parameter :: isothermal = .true.
 #else
  integer, parameter :: maxvxyzu = 4
+ logical, parameter :: isothermal = .false.
 #endif
 
  integer :: maxTdust = 0

--- a/src/main/config.F90
+++ b/src/main/config.F90
@@ -334,6 +334,7 @@ module dim
  integer :: maxmhdan = 0
  integer :: maxdustan = 0
  integer :: maxgran = 0
+ integer :: maxindan = 0
 
  !--------------------
  ! Phase and gradh sizes - inconsistent with everything else, but keeping to original logic
@@ -432,6 +433,10 @@ subroutine update_max_sizes(n,ntot)
  maxmhdan = maxmhd
  maxdustan = maxp_dustfrac
  maxgran = maxgr
+#endif
+
+#ifdef IND_TIMESTEPS
+ maxindan = maxan
 #endif
 
 #ifdef RADIATION

--- a/src/main/cons2primsolver.f90
+++ b/src/main/cons2primsolver.f90
@@ -143,7 +143,8 @@ subroutine conservative2primitive(x,metrici,v,dens,u,P,temp,gamma,rho,pmom,en,ie
  integer, intent(in)  :: ien_type
  real, dimension(1:3,1:3) :: gammaijUP
  real :: sqrtg,sqrtg_inv,lorentz_LEO,pmom2,alpha,betadown(1:3),betaUP(1:3),enth_old,v3d(1:3)
- real :: f,df,term,lorentz_LEO2,gamfac,pm_dot_b,sqrt_gamma_inv,enth,gamma1,cgsdens,cgsu
+ real :: f,df,term,lorentz_LEO2,gamfac,pm_dot_b,sqrt_gamma_inv,enth,gamma1
+ real(kind=8) :: cgsdens,cgsu
  integer :: niter, i
  real, parameter :: tol = 1.e-12
  integer, parameter :: nitermax = 100
@@ -188,7 +189,7 @@ subroutine conservative2primitive(x,metrici,v,dens,u,P,temp,gamma,rho,pmom,en,ie
        case (12)
           cgsdens = dens * unit_density
           cgsu = 1.5*rg*temp/gmw + radconst*temp**4/cgsdens
-          u = cgsu / unit_ergg
+          u = real(cgsu / unit_ergg)
           if (u > 0.) then
              gamma1 = P/(u*dens)
              gamma = 1. + gamma1
@@ -251,7 +252,7 @@ subroutine conservative2primitive(x,metrici,v,dens,u,P,temp,gamma,rho,pmom,en,ie
     case (12)
        cgsdens = dens * unit_density
        cgsu = 1.5*rg*temp/gmw + radconst*temp**4/cgsdens
-       u = cgsu / unit_ergg
+       u = real(cgsu / unit_ergg)
        if (u > 0.) then
           gamma = 1. + P/(u*dens)
        else

--- a/src/main/energies.F90
+++ b/src/main/energies.F90
@@ -83,7 +83,7 @@ subroutine compute_energies(t)
  use nicil,          only:nicil_update_nimhd,nicil_get_halldrift,nicil_get_ambidrift, &
                      use_ohm,use_hall,use_ambi,n_data_out,n_warn
 #ifdef GR
- use part,           only:metrics,metricderivs
+ use part,           only:metrics
  use metric_tools,   only:unpack_metric
  use utils_gr,       only:dot_product_gr,get_geodesic_accel
  use vectorutils,    only:cross_product3D

--- a/src/main/eos.F90
+++ b/src/main/eos.F90
@@ -390,8 +390,8 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,tempi,eni,gam
        temperaturei = min(0.67 * cgseni * mui / kb_on_mh, (cgseni*cgsrhoi/radconst)**0.25)
     endif
     call equationofstate_gasradrec(cgsrhoi,cgseni*cgsrhoi,temperaturei,imui,X_i,1.-X_i-Z_i,cgspresi,cgsspsoundi)
-    ponrhoi  = cgspresi / (unit_pressure * rhoi)
-    spsoundi = cgsspsoundi / unit_velocity
+    ponrhoi  = real(cgspresi / (unit_pressure * rhoi))
+    spsoundi = real(cgsspsoundi / unit_velocity)
     tempi    = temperaturei
     if (present(mu_local)) mu_local = 1./imui
 
@@ -765,10 +765,10 @@ subroutine calc_rec_ene(XX,YY,e_rec)
  real, intent(in)  :: XX, YY
  real, intent(out) :: e_rec
  real              :: e_H2,e_HI,e_HeI,e_HeII
- real, parameter   :: e_ion_H2   = 1.312d13, & ! ionisation energies in erg/mol
-                      e_ion_HI   = 4.36d12, &
-                      e_ion_HeI  = 2.3723d13, &
-                      e_ion_HeII = 5.2505d13
+ real, parameter   :: e_ion_H2   = 1.312e13, & ! ionisation energies in erg/mol
+                      e_ion_HI   = 4.36e12, &
+                      e_ion_HeI  = 2.3723e13, &
+                      e_ion_HeII = 5.2505e13
 
  ! XX     : Hydrogen mass fraction
  ! YY     : Helium mass fraction
@@ -926,7 +926,7 @@ subroutine get_rho_from_p_s(pres,S,rho,mu,rhoguess,ientropy)
  real, intent(inout) :: rho
  real                :: srho,srho_plus_dsrho,S_plus_dS,dSdsrho
  real(kind=8)        :: corr
- real,    parameter  :: eoserr=1d-9,dfac=1d-12
+ real,    parameter  :: eoserr=1e-9,dfac=1e-12
  integer, intent(in) :: ientropy
 
  ! We apply the Newton-Raphson method directly to rho^1/2 ("srho") instead
@@ -961,7 +961,7 @@ subroutine get_p_from_rho_s(ieos,S,rho,mu,P,temp)
  real, intent(out)   :: P
  integer, intent(in) :: ieos
  real                :: corr,df,f,temp_new,cgsrho,cgsp,cgss
- real,    parameter  :: eoserr=1d-12
+ real,    parameter  :: eoserr=1e-12
  integer             :: niter
  integer, parameter  :: nitermax = 1000
 

--- a/src/main/eos_barotropic.f90
+++ b/src/main/eos_barotropic.f90
@@ -70,11 +70,11 @@ subroutine init_eos_barotropic(polyk,polyk2,ierr)
  endif
 
  ! Convert to code units, and calculate constants
- rhocrit0 = rhocrit0cgs/unit_density
- rhocrit1 = rhocrit1cgs/unit_density
- rhocrit2 = rhocrit2cgs/unit_density
- rhocrit3 = rhocrit3cgs/unit_density
- rhocrit4 = rhocrit4cgs/unit_density
+ rhocrit0 = real(rhocrit0cgs/unit_density)
+ rhocrit1 = real(rhocrit1cgs/unit_density)
+ rhocrit2 = real(rhocrit2cgs/unit_density)
+ rhocrit3 = real(rhocrit3cgs/unit_density)
+ rhocrit4 = real(rhocrit4cgs/unit_density)
  fac2     = polyk*(rhocrit2/rhocrit1)**(gamma1-1.)
  fac3     =  fac2*(rhocrit3/rhocrit2)**(gamma2-1.)
  fac4     =  fac3*(rhocrit4/rhocrit3)**(gamma3-1.)

--- a/src/main/eos_piecewise.f90
+++ b/src/main/eos_piecewise.f90
@@ -29,10 +29,10 @@ module eos_piecewise
 
  !--Default initial parameters for piecewise polytrope Eos
  integer, parameter :: maxEOSopt =  4 ! maximum number of piecewise polytrope defaults
- real :: rhocrit0pwpcgs = 2.62780d12
- real :: rhocrit1pwpcgs = 5.01187d14
- real :: rhocrit2pwpcgs = 1.0d15
- real :: p1pwpcgs       = 2.46604d34
+ real(kind=8) :: rhocrit0pwpcgs = 2.62780d12
+ real(kind=8) :: rhocrit1pwpcgs = 5.01187d14
+ real(kind=8) :: rhocrit2pwpcgs = 1.0d15
+ real(kind=8) :: p1pwpcgs       = 2.46604d34
  real :: gamma0pwp      = 5./3.
  real :: gamma1pwp      = 3.166
  real :: gamma2pwp      = 3.573
@@ -92,10 +92,10 @@ subroutine init_eos_piecewise(ierr)
     ierr = 3
     return
  endif
- rhocrit0pwp = rhocrit0pwpcgs/unit_density
- rhocrit1pwp = rhocrit1pwpcgs/unit_density
- rhocrit2pwp = rhocrit2pwpcgs/unit_density
- p1pwp       = p1pwpcgs/unit_pressure
+ rhocrit0pwp = real(rhocrit0pwpcgs/unit_density)
+ rhocrit1pwp = real(rhocrit1pwpcgs/unit_density)
+ rhocrit2pwp = real(rhocrit2pwpcgs/unit_density)
+ p1pwp       = real(p1pwpcgs/unit_pressure)
  k1pwp       = p1pwp/rhocrit1pwp**gamma1pwp
  k2pwp       = p1pwp/rhocrit1pwp**gamma2pwp
  p2pwp       = k2pwp*rhocrit2pwp**gamma2pwp
@@ -164,10 +164,10 @@ real function get_dPdrho_piecewise(rho) result(get_dPdrho)
  real              :: polyk0,polyk1,polyk2,polyk3
  real              :: gamma,polyk
 
- rhocrit0pwp = rhocrit0pwpcgs/unit_density
- rhocrit1pwp = rhocrit1pwpcgs/unit_density
- rhocrit2pwp = rhocrit2pwpcgs/unit_density
- presscrit   = p1pwpcgs/unit_pressure
+ rhocrit0pwp = real(rhocrit0pwpcgs/unit_density)
+ rhocrit1pwp = real(rhocrit1pwpcgs/unit_density)
+ rhocrit2pwp = real(rhocrit2pwpcgs/unit_density)
+ presscrit   = real(p1pwpcgs/unit_pressure)
  polyk1      = presscrit/rhocrit1pwp**gamma1pwp
  polyk2      = presscrit/rhocrit1pwp**gamma2pwp
  polyk3      = polyk2*rhocrit2pwp**(gamma2pwp-gamma3pwp)

--- a/src/main/evwrite.F90
+++ b/src/main/evwrite.F90
@@ -336,10 +336,10 @@ end subroutine fill_ev_header
 !+
 !----------------------------------------------------------------
 subroutine write_evfile(t,dt)
- use timestep,      only:dtmax_user
  use energies,      only:compute_energies,ev_data_update
  use io,            only:id,master,ievfile
 #ifndef GR
+ use timestep,      only:dtmax_user
  use options,       only:iexternalforce
  use extern_binary, only:accretedmass1,accretedmass2
 #endif

--- a/src/main/extern_densprofile.f90
+++ b/src/main/extern_densprofile.f90
@@ -79,9 +79,8 @@ end subroutine densityprofile_force
 !+
 !----------------------------------------------
 subroutine load_extern_densityprofile(ierr)
- use units,   only: umass, utime, udist
- use physcon, only: pi, gg
- use io,      only: error
+ use units, only:get_G_code
+ use io,    only:error
  integer, intent(out) :: ierr
 
  real :: rtab(nrhotab), rhotab(nrhotab), menctab(nrhotab)
@@ -100,7 +99,7 @@ subroutine load_extern_densityprofile(ierr)
     call calc_menc(ntab, rtab, rhotab, menctab)
     ! Store r^2 and (- G Menc / r^3) values
     r2tab = rtab(1:ntab)**2
-    gcode = gg * umass * utime**2 / udist**3
+    gcode = get_G_code()
     ftab(1) = 0.0    ! get NaN if dividing by zero at r = 0
     do i = 2, ntab
        ftab(i) = - gcode * menctab(i) / rtab(i)**3

--- a/src/main/extern_gnewton.F90
+++ b/src/main/extern_gnewton.F90
@@ -34,28 +34,19 @@ contains
 !+
 !------------------------------------------------
 subroutine get_gnewton_spatial_force(xi,yi,zi,mass,fextxi,fextyi,fextzi,phi)
-#ifdef FINVSQRT
- use fastmath, only:finvsqrt
-#endif
- use units, only: udist, utime
- use physcon, only: c
+ use units, only:get_c_code
  real, intent(in)    :: xi,yi,zi,mass
  real, intent(inout) :: fextxi,fextyi,fextzi
  real, intent(out)   :: phi
  real                :: r2,dr,dr3,ccode,rg
 
- ccode = c/(udist/utime)
+ ccode = get_c_code()
  rg = (mass)/(ccode)**2
 
  r2 = xi*xi + yi*yi + zi*zi
 
  if (r2 > epsilon(r2)) then
-#ifdef FINVSQRT
-    dr  = finvsqrt(r2)
-#else
     dr = 1./sqrt(r2)
-#endif
-
     dr3 = dr**3
     fextxi = fextxi - mass*xi*dr3*(1.-2.*rg*dr)**2
     fextyi = fextyi - mass*yi*dr3*(1.-2.*rg*dr)**2
@@ -72,18 +63,14 @@ end subroutine get_gnewton_spatial_force
 !+
 !-----------------------------------------------------------------------
 subroutine get_gnewton_vdependent_force(xyzi,veli,mass,fexti)
-#ifdef FINVSQRT
- use fastmath, only:finvsqrt
-#endif
- use physcon, only:c
- use units,   only:utime,udist
+ use units, only:get_c_code
  real, intent(in)  :: xyzi(3), veli(3)
  real, intent(in)  :: mass
  real, intent(out) :: fexti(3)
  real              :: r2,dr,dr3,dr5,dr_rel,A,B,ccode,rg
  real              :: xi,yi,zi,vxi,vyi,vzi
 
- ccode = c/(udist/utime)
+ ccode = get_c_code()
  rg = (mass)/(ccode)**2
 
  xi=xyzi(1)
@@ -96,12 +83,7 @@ subroutine get_gnewton_vdependent_force(xyzi,veli,mass,fexti)
  r2 = xi*xi + yi*yi + zi*zi
 
  if (r2 > epsilon(r2)) then
-#ifdef FINVSQRT
-    dr  = finvsqrt(r2)
-#else
     dr = 1./sqrt(r2)
-#endif
-
     dr_rel = 1./(1.-2.*rg*dr)
     dr3 = dr**3
     dr5 = dr**5
@@ -189,11 +171,7 @@ end subroutine update_gnewton_leapfrog
 !+
 !-----------------------------------------------------------------------
 subroutine get_gnewton_energy(xyzi,veli,mass,energy,angmomx,angmomy,angmomz)
-#ifdef FINVSQRT
- use fastmath, only:finvsqrt
-#endif
- use physcon, only:c
- use units,   only:utime,udist
+ use units, only:get_c_code
  implicit none
  real, dimension(3), intent(in)    :: xyzi, veli
  real,               intent(in)    :: mass
@@ -210,16 +188,11 @@ subroutine get_gnewton_energy(xyzi,veli,mass,energy,angmomx,angmomy,angmomz)
  vyi=veli(2)
  vzi=veli(3)
 
- ccode = c/(udist/utime)
+ ccode = get_c_code()
  rg = (mass)/(ccode)**2
 
  r2 = xi*xi + yi*yi + zi*zi
-
-#ifdef FINVSQRT
- dr = finvsqrt(r2)
-#else
  dr = 1./sqrt(r2)
-#endif
 
  dr_rel = 1./(1.-2.*rg*dr)
  dr_rel2 = dr_rel**2

--- a/src/main/extern_gwinspiral.f90
+++ b/src/main/extern_gwinspiral.f90
@@ -81,8 +81,7 @@ end subroutine initialise_gwinspiral
 !+
 !-----------------------------------------------------------------------
 subroutine gw_still_inspiralling(npart,xyzh,vxyzu,nptmass,xyzmh_ptmass,vxyz_ptmass,stopped_now)
- use physcon,      only: c
- use units,        only: unit_velocity
+ use units,        only:get_c_code
  use centreofmass, only:get_centreofmass
  integer, intent(in)  :: npart,nptmass
  real,    intent(in)  :: xyzh(:,:),vxyzu(:,:),xyzmh_ptmass(:,:),vxyz_ptmass(:,:)
@@ -96,7 +95,7 @@ subroutine gw_still_inspiralling(npart,xyzh,vxyzu,nptmass,xyzmh_ptmass,vxyz_ptma
 !
 ! Calculate force coefficients
 !
- c_code      = c/unit_velocity
+ c_code      = get_c_code()
  fstar1_coef = 0.
  fstar2_coef = 0.
  stopped_now = .false.

--- a/src/main/extern_lensethirring.f90
+++ b/src/main/extern_lensethirring.f90
@@ -197,30 +197,26 @@ end subroutine update_ltforce_leapfrog
 !+
 !---------------------------------------------------------------
 subroutine check_lense_thirring_settings(ierr,accradius1)
- use units,   only:umass,utime,udist
- use physcon, only:c,gg
+ use units,   only:c_is_unity,G_is_unity,get_c_code,get_G_code
  use io,      only:error,warning
  integer, intent(out) :: ierr
  real,    intent(in)  :: accradius1
- real :: ccode,gcode
- real, parameter :: tol = 1.e-10
-
  !
  !--check that c=1 in code units
  !
  ierr = 0
- ccode = c/(udist/utime)
- if (abs(ccode-1.) > tol) then
+ if (.not.c_is_unity()) then
     ierr = ierr + 1
-    call error('Lense-Thirring','c /= 1 in code units, but assumed for Lense-Thirring force',var='c',val=ccode)
+    call error('Lense-Thirring','c /= 1 in code units, but assumed for Lense-Thirring force',&
+         var='c',val=real(get_c_code()))
  endif
  !
  !--check that G=1 in code units
  !
- gcode = gg*umass*utime**2/udist**3
- if (abs(gcode-1.) > tol) then
+ if (.not.G_is_unity()) then
     ierr = ierr + 1
-    call error('Lense-Thirring','G /= 1 in code units, but assumed for Lense-Thirring force',var='G',val=gcode)
+    call error('Lense-Thirring','G /= 1 in code units, but assumed for Lense-Thirring force',&
+         var='G',val=real(get_G_code()))
  endif
  !
  !--check that the inner disc edge is >= the Schwarzschild radius
@@ -301,5 +297,3 @@ subroutine read_options_ltforce(name,valstring,imatch,igotall,ierr)
 end subroutine read_options_ltforce
 
 end module extern_lensethirring
-
-

--- a/src/main/extern_prdrag.F90
+++ b/src/main/extern_prdrag.F90
@@ -57,28 +57,20 @@ contains
 !+
 !------------------------------------------------
 subroutine get_prdrag_spatial_force(xi,yi,zi,MStar,fextxi,fextyi,fextzi,phi)
-#ifdef FINVSQRT
- use fastmath, only:finvsqrt
-#endif
  use lumin_nsdisc, only:beta
- use physcon, only: gg
- use units, only: udist, umass, utime
+ use units,        only:get_G_code
  real, intent(in)    :: xi,yi,zi,Mstar
  real, intent(inout) :: fextxi,fextyi,fextzi
  real, intent(out)   :: phi
  real                   :: r2,dr,dr3,betai,Mbdr3,rbetai,gcode
 
- gcode = gg / (udist**3/(utime**2*umass))
+ gcode = get_G_code()
 
  r2 = xi*xi + yi*yi + zi*zi
  betai = beta(xi,yi,zi)
  rbetai = k0*betai
  if (r2 > epsilon(r2)) then
-#ifdef FINVSQRT
-    dr  = finvsqrt(r2)
-#else
     dr = 1./sqrt(r2)
-#endif
     dr3 = dr**3
     Mbdr3 = Mstar*gcode*(1.-rbetai)*dr3
     fextxi = fextxi - xi*Mbdr3
@@ -95,17 +87,16 @@ end subroutine get_prdrag_spatial_force
 !+
 !-----------------------------------------------------------------------
 subroutine get_prdrag_vdependent_force(xyzi,vel,Mstar,fexti)
- use lumin_nsdisc, only: beta      !Change your Poynting-Robertson here.
- use physcon, only: gg, c
- use units, only: udist, umass, utime
+ use lumin_nsdisc, only:beta      !Change your Poynting-Robertson here.
+ use units,        only:get_c_code,get_G_code
  real, intent(in)  :: xyzi(3), vel(3)
  real, intent(in)  :: Mstar
  real, intent(out) :: fexti(3)
  real :: rhat(3)
- real                              :: betai, r, r2, r3, vr, gcode, ccode
+ real :: betai, r, r2, r3, vr, gcode, ccode
 
- ccode = c  / (udist/utime)
- gcode = gg / (udist**3/(utime**2*umass))
+ ccode = get_c_code()
+ gcode = get_G_code()
 
  r2     = dot_product( xyzi, xyzi )
  r      = sqrt(r2)
@@ -123,8 +114,7 @@ end subroutine get_prdrag_vdependent_force
 
 subroutine update_prdrag_leapfrog(vhalfx,vhalfy,vhalfz,fxi,fyi,fzi,fexti,dt,xi,yi,zi,Mstar)
  use lumin_nsdisc,  only:beta
- use physcon, only: c
- use units, only: udist, utime
+ use units,         only:get_c_code
  use io,            only:warn
  real, intent(in)    :: dt,xi,yi,zi, Mstar
  real, intent(in)    :: vhalfx,vhalfy,vhalfz
@@ -136,7 +126,7 @@ subroutine update_prdrag_leapfrog(vhalfx,vhalfy,vhalfz,fxi,fyi,fzi,fexti,dt,xi,y
  real                              :: xi2, yi2, zi2, ccode, kd
  character(len=30), parameter :: label = 'update_prdrag_leapfrog'
 
- ccode = c  / (udist/utime)
+ ccode = get_c_code()
 
  xi2    = xi*xi
  yi2    = yi*yi

--- a/src/main/extern_staticsine.f90
+++ b/src/main/extern_staticsine.f90
@@ -28,11 +28,10 @@ module extern_staticsine
  !--code input parameters: these are the default values
  !  and can be changed in the input file
  !
-
- real(kind=8), public :: amplitude = 100.0
- real(kind=8), public :: wavek = pi/4.0
- real(kind=8), public :: phase = 2.0
- real(kind=8), public :: inclination = 0.0
+ real, public :: amplitude = 100.0
+ real, public :: wavek = real(pi)/4.0
+ real, public :: phase = 2.0
+ real, public :: inclination = 0.0
 
  public :: staticsine_force
  public :: write_options_staticsine, read_options_staticsine
@@ -65,7 +64,6 @@ subroutine staticsine_force(xi,yi,fxi,fyi,fzi,phi)
  fyi = -fi*sin(inclination)
  fzi = 0.0
 
- return
 end subroutine staticsine_force
 
 !-----------------------------------------------------------------------

--- a/src/main/externalforces.F90
+++ b/src/main/externalforces.F90
@@ -97,9 +97,6 @@ contains
 !+
 !-----------------------------------------------------------------------
 subroutine externalforce(iexternalforce,xi,yi,zi,hi,ti,fextxi,fextyi,fextzi,phi,dtf,ii)
-#ifdef FINVSQRT
- use fastmath,         only:finvsqrt
-#endif
  use extern_corotate,  only:get_centrifugal_force,get_companion_force,icompanion_grav
  use extern_binary,    only:binary_force
  use extern_prdrag,    only:get_prdrag_spatial_force
@@ -113,8 +110,7 @@ subroutine externalforce(iexternalforce,xi,yi,zi,hi,ti,fextxi,fextyi,fextzi,phi,
  use extern_Bfield,      only:get_externalB_force
  use extern_staticsine,  only:staticsine_force
  use extern_gwinspiral,  only:get_gw_force_i
- use units,              only:udist,umass,utime
- use physcon,            only:pc,pi,gg
+ use units,              only:get_G_code
  use io,                 only:fatal
  use part,               only:rhoh,massoftype,igas
  integer, intent(in)  :: iexternalforce
@@ -145,11 +141,7 @@ subroutine externalforce(iexternalforce,xi,yi,zi,hi,ti,fextxi,fextyi,fextzi,phi,
     r2 = xi*xi + yi*yi + zi*zi + eps2_soft
 
     if (r2 > epsilon(r2)) then
-#ifdef FINVSQRT
-       dr  = finvsqrt(r2)
-#else
        dr = 1./sqrt(r2)
-#endif
        dr3 = mass1*dr**3
        fextxi = fextxi - xi*dr3
        fextyi = fextyi - yi*dr3
@@ -220,13 +212,9 @@ subroutine externalforce(iexternalforce,xi,yi,zi,hi,ti,fextxi,fextyi,fextzi,phi,
 
 !--Spiral/galactic potential references in extern_spiral.
 !--Calc r^2 (3D) and d^2 (2D), phi (x-y), theta (xy-z)
-    gcode = gg*umass*utime**2/udist**3 !Needed to convert gg in codes natural units
+    gcode = get_G_code() !Needed to convert gg in codes natural units
     d2   = (xi*xi + yi*yi)       !or  r    = sqrt(d2+zi*zi)
-#ifdef FINVSQRT
-    dr   = finvsqrt(d2+zi*zi)    !1/r
-#else
     dr   = 1./sqrt(d2+zi*zi)    !1/r
-#endif
     r    = 1./dr
     phii = atan2(yi,xi)
 
@@ -540,7 +528,7 @@ end subroutine update_vdependent_extforce_leapfrog
 !-----------------------------------------------------------------------
 subroutine update_externalforce(iexternalforce,ti,dmdt)
  use io,                only:iprint,iverbose,warn
- use lumin_nsdisc,      only:set_Lstar, BurstProfile, LumAcc, make_beta_grids
+ use lumin_nsdisc,      only:set_Lstar,BurstProfile,LumAcc,make_beta_grids
  use part,              only:xyzh,vxyzu,massoftype,npartoftype,igas,npart,nptmass,&
                              xyzmh_ptmass,vxyz_ptmass
  use extern_gwinspiral, only:gw_still_inspiralling,get_gw_force

--- a/src/main/externalforces.F90
+++ b/src/main/externalforces.F90
@@ -331,11 +331,7 @@ subroutine externalforce(iexternalforce,xi,yi,zi,hi,ti,fextxi,fextyi,fextzi,phi,
     r2 = xi*xi + yi*yi + zi*zi + eps2_soft
 
     if (r2 > epsilon(r2)) then
-#ifdef FINVSQRT
-       dr  = finvsqrt(r2)
-#else
        dr = 1./sqrt(r2)
-#endif
        R_g = 1.0
        factor = 1. + 6.*R_g*dr
        dr3 = mass1*dr**3
@@ -411,11 +407,7 @@ subroutine externalforce(iexternalforce,xi,yi,zi,hi,ti,fextxi,fextyi,fextzi,phi,
        !--external force timestep based on sqrt(h/accel)
        !
        if (hi > epsilon(hi)) then
-#ifdef FINVSQRT
-          dtf1 = sqrt(hi*finvsqrt(f2i))
-#else
           dtf1 = sqrt(hi/sqrt(f2i))
-#endif
        else
           dtf1 = huge(dtf1)
        endif

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -2674,6 +2674,7 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
        endif
     else
        rho1i = 0.
+       vwavei = 0.
     endif
 
 #ifdef GRAVITY

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -2452,7 +2452,7 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
                           use_dustfrac,damp,icooling,implicit_radiation
  use part,           only:h2chemistry,rhoanddhdrho,iboundary,igas,maxphase,maxvxyzu,nptmass,xyzmh_ptmass, &
                           massoftype,get_partinfo,tstop,strain_from_dvdx,ithick,iradP,sinks_have_heating,luminosity, &
-                          nucleation,idK2,idmu,idkappa,idgamma,dust_temp
+                          nucleation,idK2,idmu,idkappa,idgamma,dust_temp,pxyzu
  use cooling,        only:energ_cooling,cooling_in_step
  use ptmass_heating, only:energ_sinkheat
 #ifdef IND_TIMESTEPS
@@ -2465,9 +2465,9 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
  use linklist,       only:get_distance_from_centre_of_mass
  use kdtree,         only:expand_fgrav_in_taylor_series
  use nicil,          only:nicil_get_dudt_nimhd,nicil_get_dt_nimhd
- use timestep,       only:C_cour,C_cool,C_force,bignumber,dtmax
+ use timestep,       only:C_cour,C_cool,C_force,C_rad,C_ent,bignumber,dtmax
  use timestep_sts,   only:use_sts
- use units,          only:unit_ergg,unit_density,unit_velocity
+ use units,          only:unit_ergg,unit_density,get_c_code
  use eos_shen,       only:eos_shen_get_dTdu
 #ifdef KROME
  use part,           only:gamma_chem
@@ -2481,10 +2481,8 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
 #endif
  use io,             only:warning
  use physcon,        only:c,kboltz
- use timestep,       only:C_rad
 #ifdef GR
  use part,           only:pxyzu
- use timestep,       only:C_ent
 #endif
 
  integer,            intent(in)    :: icall
@@ -2755,7 +2753,7 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
           if (ien_type == ien_etotal) then
              fxyz4 = fxyz4 + fsum(idudtdissi) + fsum(idendtdissi)
           elseif (ien_type == ien_entropy_s) then
-             fxyz4 = fxyz4 + u0i/tempi*(fsum(idudtdissi) + fsum(idendtdissi))/kboltz
+             fxyz4 = fxyz4 + real(u0i/tempi*(fsum(idudtdissi) + fsum(idendtdissi))/kboltz)
           elseif (ien_type == ien_entropy) then ! here eni is the entropy
              if (gr .and. ishock_heating > 0) then
                 fxyz4 = fxyz4 + (gamma - 1.)*densi**(1.-gamma)*u0i*fsum(idudtdissi)
@@ -2783,7 +2781,7 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
              if (abs(damp) < tiny(damp)) then
                 rho_cgs = rhoi * unit_density
                 call eos_shen_get_dTdu(rho_cgs,eni,0.05,dTdui_cgs)
-                dTdui = dTdui_cgs / unit_ergg
+                dTdui = real(dTdui_cgs / unit_ergg)
                 !use cgs
                 fxyz4 = fxyz4 + dTdui*(pri*rho1i*rho1i*drhodti + fsum(idudtdissi))
              else
@@ -2912,12 +2910,10 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
           if (eni + dtc*fxyzu(4,i) < epsilon(0.) .and. eni > epsilon(0.)) dtcool = C_cool*abs(eni/fxyzu(4,i))
        endif
 
-#ifdef GR
        ! s entropy timestep to avoid too large s entropy leads to infinite temperature
-       if (ien_type == ien_entropy_s .and. gr) then
+       if (gr .and. ien_type == ien_entropy_s) then
           dtent = C_ent*abs(pxyzu(4,i)/fxyzu(4,i))
        endif
-#endif
 
        ! timestep based on non-ideal MHD
        if (mhd_nonideal) then
@@ -3011,7 +3007,7 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
              dtradi = bignumber
           else
              drad(iradxi,i) = fsum(idradi) + radprop(iradP,i)*drhodti*rho1i*rho1i
-             c_code     = c/unit_velocity
+             c_code     = get_c_code()
              radkappai  = xpartveci(iradkappai)
              radlambdai = xpartveci(iradlambdai)
              ! eq30 Whitehouse & Bate 2004

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -1452,6 +1452,7 @@ subroutine compute_forces(i,iamgasi,iamdusti,xpartveci,hi,hi1,hi21,hi41,gradhi,g
           !rhoj      = 0.
           rho1j     = 0.
           rho21j    = 0.
+          densj     = 0.
 
           mrhoj5    = 0.
           autermj   = 0.
@@ -2774,7 +2775,7 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
              fxyz4 = 0.
 #endif
              if (lightcurve) then
-                luminosity(i) = pmassi*u0i*(fsum(idendtdissi)+fsum(idudtdissi))
+                luminosity(i) = real(pmassi*u0i*(fsum(idendtdissi)+fsum(idudtdissi)),kind=kind(luminosity))
              endif
 #endif
           elseif (ieos==16) then ! here eni is the temperature

--- a/src/main/forcing.F90
+++ b/src/main/forcing.F90
@@ -31,38 +31,38 @@ module forcing
 !   mpiutils, part
 !
 
-
  public :: forceit,init_forcing,write_forcingdump,write_options_forcing,read_options_forcing
 
  integer, parameter :: st_maxmodes = 5000
 
  !OU variance corresponding to decay time and energy input rate
- real, save :: st_OUvar
+ real :: st_OUvar
 
  !last time random seeds were updated
- real, save :: tprev
+ real :: tprev
 
  !Number of modes
- integer, save :: st_nmodes
+ integer :: st_nmodes
 
- real, save :: st_mode(3,st_maxmodes), st_aka(3,st_maxmodes), st_akb(3,st_maxmodes)
- real, save :: st_OUphases(6*st_maxmodes)
- real, save :: st_ampl(  st_maxmodes)
+ real :: st_mode(3,st_maxmodes), st_aka(3,st_maxmodes), st_akb(3,st_maxmodes)
+ real :: st_OUphases(6*st_maxmodes)
+ real :: st_ampl(  st_maxmodes)
 
  !Options - give these default values to write to file
- integer, save, public  :: istir = 1
+ integer, public  :: istir = 1
+ logical, public  :: stir_from_file = .true.
  !logical,save  :: st_computeDt
- real, save, public     :: st_decay = 0.05
- real, save, public     :: st_energy = 2.0
- real, save, public     :: st_stirmin = 6.28
- real, save, public     :: st_stirmax = 18.86
- real, save, public     :: st_solweight = 1.0
- real, save, public     :: st_solweightnorm
- integer, save  :: st_seed = 1
+ real, public     :: st_decay = 0.05
+ real, public     :: st_energy = 2.0
+ real, public     :: st_stirmin = 6.28
+ real, public     :: st_stirmax = 18.86
+ real, public     :: st_solweight = 1.0
+ real, public     :: st_solweightnorm
+ integer          :: st_seed = 1
  !integer,save  :: st_freq = 1
- real, save, public    :: st_dtfreq = 0.01
- real, save, public    :: st_amplfac = 1.0
- integer, save, public  :: st_spectform = 1
+ real, public     :: st_dtfreq = 0.01
+ real, public     :: st_amplfac = 1.0
+ integer, public  :: st_spectform = 1
 
  !!namelist /force/ istir,st_spectform,st_stirmax,st_stirmin, &
  !                 st_energy,st_decay,st_solweight,st_dtfreq,st_seed
@@ -74,11 +74,8 @@ module forcing
 
 #define N_DIM 3
 !!!!#undef CORRECT_MEAN_FORCE
-!!!!##define STIR_FROM_FILE
 
-#ifdef STIR_FROM_FILE
  character(len=*), parameter :: forcingfile = 'forcing.dat'
-#endif
 
  private
 
@@ -145,9 +142,7 @@ subroutine init_forcing(dumpfile,infile,time)
  integer                           :: ikxmin, ikxmax, ikymin, ikymax, ikzmin, ikzmax
  integer                           :: ikx, iky, ikz
  real                              :: kx, ky, kz, k, kc
-#ifdef STIR_FROM_FILE
  real                              :: timeinfile
-#endif
  real, parameter                   :: twopi = 6.283185307
  real, parameter                   :: amin = 0.0 ! the amplitude of the modes at kmin and kmax for a parabolic Fourier spectrum wrt 1.0 at the centre kc
  !logical                           :: iexist
@@ -287,38 +282,38 @@ subroutine init_forcing(dumpfile,infile,time)
     tprev = -1.
     if (id==master .and. iverbose >= 2) write(iprint,*) 'SETTING VELS TO ZERO'
 
-#ifdef STIR_FROM_FILE
-    call read_stirring_data_from_file(forcingfile, time, timeinfile)
-#else
-    ! Everyone, using the same seed, initialize the OU noises for the
-    ! nmodes*6 components of the phases. Store seed in randseed
-    ! afterward.
-    call random_seed(size = st_seedLen)
-    if (.not. allocated(st_randseed)) allocate(st_randseed(st_seedLen))
-    if (id==master .and. iverbose >= 1) write(iprint,*) 'init_stir:  seed length = ', st_seedLen
-    call st_ounoiseinit(st_nmodes*6, st_seed, st_OUvar, st_OUphases)
-    call random_seed(get = st_randseed)
-    if (id==master .and. iverbose >= 1) write(iprint,*) 'init_stir:  st_randseed = ', st_randseed
-#endif
+    if (stir_from_file) then
+       call read_stirring_data_from_file(forcingfile, time, timeinfile)
+    else
+       ! Everyone, using the same seed, initialize the OU noises for the
+       ! nmodes*6 components of the phases. Store seed in randseed
+       ! afterward.
+       call random_seed(size = st_seedLen)
+       if (.not. allocated(st_randseed)) allocate(st_randseed(st_seedLen))
+       if (id==master .and. iverbose >= 1) write(iprint,*) 'init_stir:  seed length = ', st_seedLen
+       call st_ounoiseinit(st_nmodes*6, st_seed, st_OUvar, st_OUphases)
+       call random_seed(get = st_randseed)
+       if (id==master .and. iverbose >= 1) write(iprint,*) 'init_stir:  st_randseed = ', st_randseed
+    endif
 
  else ! we are restarting from a checkpoint
 
-#ifdef STIR_FROM_FILE
-    call read_stirring_data_from_file(forcingfile, time, timeinfile)
-#else
-    ! Everyone, using the same seed, initialize the OU noises for the
-    ! nmodes*6 components of the phases. Store seed in randseed
-    ! afterward.
-    call random_seed(size = st_seedLen)
-    if (.not. allocated(st_randseed)) allocate(st_randseed(st_seedLen))
-    if (id==master .and. iverbose >= 1) write(iprint,*) 'init_stir:  seed length = ', st_seedLen
-    call st_ounoiseinit(st_nmodes*6, st_seed, st_OUvar, st_OUphases)
-    call random_seed(get = st_randseed)
-    if (id==master .and. iverbose >= 1) write(iprint,*) 'init_stir:  st_randseed = ', st_randseed
+    if (stir_from_file) then
+       call read_stirring_data_from_file(forcingfile, time, timeinfile)
+    else
+       ! Everyone, using the same seed, initialize the OU noises for the
+       ! nmodes*6 components of the phases. Store seed in randseed
+       ! afterward.
+       call random_seed(size = st_seedLen)
+       if (.not. allocated(st_randseed)) allocate(st_randseed(st_seedLen))
+       if (id==master .and. iverbose >= 1) write(iprint,*) 'init_stir:  seed length = ', st_seedLen
+       call st_ounoiseinit(st_nmodes*6, st_seed, st_OUvar, st_OUphases)
+       call random_seed(get = st_randseed)
+       if (id==master .and. iverbose >= 1) write(iprint,*) 'init_stir:  st_randseed = ', st_randseed
 
-    call read_forcingdump(dumpfile,ierr)
-    if (ierr /= 0) call fatal('init_forcing','error reading forcing file')
-#endif
+       call read_forcingdump(dumpfile,ierr)
+       if (ierr /= 0) call fatal('init_forcing','error reading forcing file')
+    endif
 
     !call get_parm_from_context(global_parm_context, "st_nmodes", st_nmodes)
     if (id==master) write(iprint,*) 'init_stir:  restarting...  st_nmodes      = ', st_nmodes
@@ -347,8 +342,6 @@ subroutine init_forcing(dumpfile,infile,time)
 
  ! Then convert those into actual Fourier phases:
  call st_calcPhases()
-
- return
 
 end subroutine init_forcing
 
@@ -380,16 +373,17 @@ subroutine write_options_forcing(iunit)
 
  write(iunit,"(/,a)") '# options controlling forcing of turbulence'
  call write_inopt(istir,'istir','switch to turn stirring on or off at runtime',iunit)
-#ifndef STIR_FROM_FILE
- call write_inopt(st_spectform,'st_spectform','spectral form of stirring',iunit)
- call write_inopt(st_stirmax,'st_stirmax','maximum stirring wavenumber',iunit)
- call write_inopt(st_stirmin,'st_stirmin','minimum stirring wavenumber',iunit)
- call write_inopt(st_energy,'st_energy','energy input/mode',iunit)
- call write_inopt(st_decay,'st_decay','correlation time for driving',iunit)
- call write_inopt(st_solweight,'st_solweight','solenoidal weight',iunit)
- call write_inopt(st_dtfreq,'st_dtfreq','frequency of stirring',iunit)
- call write_inopt(st_seed,'st_seed','random number generator seed',iunit)
-#endif
+ call write_inopt(stir_from_file,'stir_from_file','stir using pre-generated file?',iunit)
+ if (.not. stir_from_file) then
+    call write_inopt(st_spectform,'st_spectform','spectral form of stirring',iunit)
+    call write_inopt(st_stirmax,'st_stirmax','maximum stirring wavenumber',iunit)
+    call write_inopt(st_stirmin,'st_stirmin','minimum stirring wavenumber',iunit)
+    call write_inopt(st_energy,'st_energy','energy input/mode',iunit)
+    call write_inopt(st_decay,'st_decay','correlation time for driving',iunit)
+    call write_inopt(st_solweight,'st_solweight','solenoidal weight',iunit)
+    call write_inopt(st_dtfreq,'st_dtfreq','frequency of stirring',iunit)
+    call write_inopt(st_seed,'st_seed','random number generator seed',iunit)
+ endif
  call write_inopt(st_amplfac,'st_amplfac','amplitude factor for stirring of turbulence',iunit)
 
 end subroutine write_options_forcing
@@ -421,17 +415,14 @@ subroutine read_options_forcing(name,valstring,igot,igotall,ierr)
  logical,          intent(out) :: igot,igotall
  integer,          intent(out) :: ierr
  integer, save                :: ngot = 0
-#ifdef STIR_FROM_FILE
- integer, parameter :: nrequired = 2
-#else
- integer, parameter :: nrequired = 10
-#endif
+ integer :: nrequired
 
  igot = .true.
  select case(trim(name))
  case('istir')
     read(valstring,*,iostat=ierr) istir
-#ifndef STIR_FROM_FILE
+ case('stir_from_file')
+    read(valstring,*,iostat=ierr) stir_from_file
  case('st_spectform')
     read(valstring,*,iostat=ierr) st_spectform
  case('st_stirmax')
@@ -448,7 +439,6 @@ subroutine read_options_forcing(name,valstring,igot,igotall,ierr)
     read(valstring,*,iostat=ierr) st_dtfreq
  case('st_seed')
     read(valstring,*,iostat=ierr) st_seed
-#endif
  case('st_amplfac')
     read(valstring,*,iostat=ierr) st_amplfac
  case default
@@ -456,6 +446,12 @@ subroutine read_options_forcing(name,valstring,igot,igotall,ierr)
  end select
 
  if (igot) ngot = ngot + 1
+
+ if (stir_from_file) then
+    nrequired = 2
+ else
+    nrequired = 10
+ endif
 
  igotall = .false.
  if (ngot >= nrequired) igotall = .true.
@@ -602,10 +598,6 @@ end subroutine read_forcingdump
 
 subroutine st_calcPhases()
 
- !use dBase, ONLY: ndim
- !use Stir_data, ONLY : st_nmodes, st_mode, st_aka, st_akb, st_OUphases, st_solweight
-
-
  real                 :: ka, kb, kk, diva, divb, curla, curlb
  integer              :: i,j
  logical, parameter   :: Debug = .false.
@@ -690,11 +682,7 @@ end subroutine st_calcPhases
 !!
 !!***
 
-
 subroutine st_ounoiseinit (vectorlength, iseed, variance, vector)
-
- !use Stir_data, ONLY : st_randseed
-
 
  integer, intent(IN)    :: vectorlength, iseed
  real,    intent(IN)    :: variance
@@ -712,8 +700,6 @@ subroutine st_ounoiseinit (vectorlength, iseed, variance, vector)
     call st_grn (grnval)
     vector (i) = grnval * variance
  enddo
-
- return
 
 end subroutine st_ounoiseinit
 
@@ -777,8 +763,6 @@ end subroutine st_ounoiseinit
 
 
 subroutine st_ounoiseupdate (vectorlength, vector, variance, dt, ts)
-
-
  real,    intent(IN)    :: variance, dt, ts
  integer, intent(IN)    :: vectorlength
  real,    intent(INOUT) :: vector (vectorlength)
@@ -792,8 +776,6 @@ subroutine st_ounoiseupdate (vectorlength, vector, variance, dt, ts)
     vector (i) = vector (i) * damping_factor + variance *   &
           sqrt (1.0 - damping_factor**2) * grnval
  enddo
-
- return
 
 end subroutine st_ounoiseupdate
 
@@ -820,8 +802,6 @@ end subroutine st_ounoiseupdate
 !!***
 
 subroutine st_calcAccel(npart,xyzh,fxyzu)
-!  use Stir_data, ONLY : st_maxmodes, st_mode, st_nmodes, st_aka, st_akb, st_solweightnorm, st_ampl
-!  use part, only:massoftype
 #ifdef IND_TIMESTEPS
  use part, only:iactive,iphase
 #endif
@@ -945,9 +925,6 @@ subroutine st_calcAccel(npart,xyzh,fxyzu)
     !$omp end parallel do
 #endif
 
-
-    return
-
  end subroutine st_calcAccel
 
 !! NAME
@@ -1021,8 +998,6 @@ subroutine st_calcAccel(npart,xyzh,fxyzu)
 
   if (Debug) print *, 'stir:  stirring end'
 
-  return
-
  end subroutine forceit
 
 !! NAME
@@ -1051,7 +1026,6 @@ subroutine st_calcAccel(npart,xyzh,fxyzu)
 !!***
  subroutine st_grn (grnval)
 
-
   real, intent(OUT) :: grnval
   real              :: pi, r1, r2, g1
 
@@ -1065,11 +1039,8 @@ subroutine st_calcAccel(npart,xyzh,fxyzu)
 
   grnval = g1
 
-  return
-
  end subroutine st_grn
 
-#ifdef STIR_FROM_FILE
 !! NAME
 !!
 !!  read_stirring_data_from_file
@@ -1106,8 +1077,8 @@ subroutine st_calcAccel(npart,xyzh,fxyzu)
 
   my_file = find_phantom_datafile(infile,'forcing')
 
-  open (unit=42, file=my_file, iostat=ierr, status='OLD', action='READ', &
-        access='SEQUENTIAL', form='UNFORMATTED')
+  open (unit=42, file=my_file, iostat=ierr, status='old', action='read', &
+        access='sequential', form='unformatted')
   ! header contains number of times and number of modes, end time, autocorrelation time, ...
   if (ierr==0) then
      if (Debug) write (*,'(A)') 'reading header...'
@@ -1123,7 +1094,7 @@ subroutine st_calcAccel(npart,xyzh,fxyzu)
   igetstep = floor(time/st_dtfreq)
 
   do istep = 0, nsteps
-     if (Debug) write (*,'(A,I6)') 'step = ', istep
+     if (Debug) write (*,'(a,i6)') 'step = ', istep
      read (unit=42) istepfile, timeinfile, &
                      st_mode    (:, 1:  st_nmodes), &
                      st_aka     (:, 1:  st_nmodes), &
@@ -1131,10 +1102,10 @@ subroutine st_calcAccel(npart,xyzh,fxyzu)
                      st_ampl    (   1:  st_nmodes), &
                      st_OUphases(   1:6*st_nmodes)
 
-     if (istep /= istepfile) write(*,'(A,I6)') 'read_stirring_data_from_file: something wrong! step = ', istep
+     if (istep /= istepfile) write(*,'(a,i6)') 'read_stirring_data_from_file: something wrong! step = ', istep
      if (igetstep==istep) then
         if (id==master) then
-           write(*,'(A,I6,2(A,E20.6))') 'read_stirring_data_from_file: read new forcing pattern, stepinfile = ',&
+           write(*,'(a,i6,2(a,e20.6))') 'read_stirring_data_from_file: read new forcing pattern, stepinfile = ',&
                   istep,' , time = ', time, ' , time in stirring table = ', timeinfile
         endif
         close (unit=42)
@@ -1142,9 +1113,6 @@ subroutine st_calcAccel(npart,xyzh,fxyzu)
      endif
   enddo
 
-  return
-
  end subroutine read_stirring_data_from_file
-#endif
 
 end module forcing

--- a/src/main/forcing.F90
+++ b/src/main/forcing.F90
@@ -684,9 +684,9 @@ end subroutine st_calcPhases
 
 subroutine st_ounoiseinit (vectorlength, iseed, variance, vector)
 
- integer, intent(IN)    :: vectorlength, iseed
- real,    intent(IN)    :: variance
- real,    intent(INOUT) :: vector (vectorlength)
+ integer, intent(in)    :: vectorlength, iseed
+ real,    intent(in)    :: variance
+ real,    intent(inout) :: vector (vectorlength)
  real                    :: grnval
  integer                 :: i
 
@@ -763,9 +763,9 @@ end subroutine st_ounoiseinit
 
 
 subroutine st_ounoiseupdate (vectorlength, vector, variance, dt, ts)
- real,    intent(IN)    :: variance, dt, ts
- integer, intent(IN)    :: vectorlength
- real,    intent(INOUT) :: vector (vectorlength)
+ real,    intent(in)    :: variance, dt, ts
+ integer, intent(in)    :: vectorlength
+ real,    intent(inout) :: vector (vectorlength)
  real                              :: grnval, damping_factor
  integer                           :: i
 
@@ -1026,7 +1026,7 @@ subroutine st_calcAccel(npart,xyzh,fxyzu)
 !!***
  subroutine st_grn (grnval)
 
-  real, intent(OUT) :: grnval
+  real, intent(out) :: grnval
   real              :: pi, r1, r2, g1
 
   pi = 4. * atan (1.)

--- a/src/main/forcing.F90
+++ b/src/main/forcing.F90
@@ -16,16 +16,17 @@ module forcing
 ! :Owner: Daniel Price
 !
 ! :Runtime parameters:
-!   - istir        : *switch to turn stirring on or off at runtime*
-!   - st_amplfac   : *amplitude factor for stirring of turbulence*
-!   - st_decay     : *correlation time for driving*
-!   - st_dtfreq    : *frequency of stirring*
-!   - st_energy    : *energy input/mode*
-!   - st_seed      : *random number generator seed*
-!   - st_solweight : *solenoidal weight*
-!   - st_spectform : *spectral form of stirring*
-!   - st_stirmax   : *maximum stirring wavenumber*
-!   - st_stirmin   : *minimum stirring wavenumber*
+!   - istir          : *switch to turn stirring on or off at runtime*
+!   - st_amplfac     : *amplitude factor for stirring of turbulence*
+!   - st_decay       : *correlation time for driving*
+!   - st_dtfreq      : *frequency of stirring*
+!   - st_energy      : *energy input/mode*
+!   - st_seed        : *random number generator seed*
+!   - st_solweight   : *solenoidal weight*
+!   - st_spectform   : *spectral form of stirring*
+!   - st_stirmax     : *maximum stirring wavenumber*
+!   - st_stirmin     : *minimum stirring wavenumber*
+!   - stir_from_file : *stir using pre-generated file?*
 !
 ! :Dependencies: boundary, datafiles, fileutils, infile_utils, io,
 !   mpiutils, part

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -212,13 +212,16 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
  character(len=*), intent(out) :: logfile,evfile,dumpfile
  logical,          intent(in), optional :: noread
  integer         :: ierr,i,j,nerr,nwarn,ialphaloc,irestart,merge_n,merge_ij(maxptmass)
- real            :: poti,dtf,hfactfile,fextv(3)
+ real            :: poti,hfactfile
  real            :: hi,pmassi,rhoi1
  real            :: dtsinkgas,dtsinksink,fonrmax,dtphi2,dtnew_first,dtinject
  real            :: stressmax,xmin,ymin,zmin,xmax,ymax,zmax,dx,dy,dz,tolu,toll
  real            :: dummy(3)
 #ifdef NONIDEALMHD
  real            :: gmw_nicil
+#endif
+#ifndef GR
+ real            :: dtf,fextv(3)
 #endif
  integer         :: itype,iposinit,ipostmp,ntypes,nderivinit
  logical         :: iexist,read_input_files
@@ -269,8 +272,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
     if (nerr > 0)  call fatal('initial','errors in particle data from file',var='errors',ival=nerr)
 !
 !--if starting from a restart dump, rename the dumpefile to that of the previous non-restart dump
-
-
+!
     irestart = index(dumpfile,'.restart')
     if (irestart > 0) write(dumpfile,'(2a,I5.5)') dumpfile(:irestart-1),'_',idumpfile
  endif

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -678,14 +678,14 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
 !
  if (id==master) then
     if (get_conserv > 0.0) then
-       write(iprint,'(1x,a)') 'Initial mass and box size (in code units):'
+       write(iprint,'(1x,a)') 'Initial mass and extent of particle distribution (in code units):'
     else
-       write(iprint,'(1x,a)') 'Mass and box size (in code units) of this restart:'
+       write(iprint,'(1x,a)') 'Mass and extent of the particle distribution:'
     endif
-    write(iprint,'(2x,a,es18.6)') 'Total mass: ', mtot
-    write(iprint,'(2x,a,es18.6)') 'x-Box size: ', dx
-    write(iprint,'(2x,a,es18.6)') 'y-Box size: ', dy
-    write(iprint,'(2x,a,es18.6)') 'z-Box size: ', dz
+    write(iprint,'(2x,a,es18.6)') '     Total mass : ', mtot
+    write(iprint,'(2x,a,es18.6)') 'x(max) - x(min) : ', dx
+    write(iprint,'(2x,a,es18.6)') 'y(max) - y(min) : ', dy
+    write(iprint,'(2x,a,es18.6)') 'z(max) - z(min) : ', dz
     write(iprint,'(a)') ' '
  endif
 !
@@ -719,15 +719,15 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
 !
 !--Print warnings of units if values are not reasonable
 !
- tolu = 1.0d2
- toll = 1.0d-2
+ tolu = 1.0e2
+ toll = 1.0e-2
  if (get_conserv > 0.0) then
     get_conserv = -1.
     if (id==master) then
        if (abs(etot_in) > tolu ) call warning('initial','consider changing code-units to reduce abs(total energy)')
        if (mtot > tolu .or. mtot < toll) call warning('initial','consider changing code-units to have total mass closer to unity')
-       if (dx > tolu .or. dx < toll .or. dy > tolu .or. dy < toll .or. dz > tolu .or. dz < toll) &
-      call warning('initial','consider changing code-units to have box length closer to unity')
+      ! if (dx > tolu .or. dx < toll .or. dy > tolu .or. dy < toll .or. dz > tolu .or. dz < toll) &
+      !call warning('initial','consider changing code-units to have box length closer to unity')
     endif
  endif
 !
@@ -770,7 +770,6 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
     call get_timings(twall_start,tcpu_start)
  endif
 
- return
 end subroutine startrun
 
 !----------------------------------------------------------------

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -479,12 +479,12 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
 !
  dtsinkgas = huge(dtsinkgas)
  r_crit2   = r_crit*r_crit
- rho_crit  = rho_crit_cgs/unit_density
+ rho_crit  = real(rho_crit_cgs/unit_density)
  r_merge_uncond2 = r_merge_uncond**2
  r_merge_cond2   = r_merge_cond**2
  r_merge2        = max(r_merge_uncond2,r_merge_cond2)
  if (rhofinal_cgs > 0.) then
-    rhofinal1 = unit_density/rhofinal_cgs
+    rhofinal1 = real(unit_density/rhofinal_cgs)
  else
     rhofinal1 = 0.0
  endif

--- a/src/main/inject_asteroidwind.f90
+++ b/src/main/inject_asteroidwind.f90
@@ -15,10 +15,9 @@ module inject
 ! :Owner: David Liptai
 !
 ! :Runtime parameters:
-!   - mdot          : *mass injection rate in grams/second*
-!   - mdot_type     : *injection rate (0=const, 1=cos(t), 2=r^(-2))*
-!   - npartperorbit : *particle injection rate in particles/binary orbit*
-!   - vlag          : *percentage lag in velocity of wind*
+!   - mdot      : *mass injection rate in grams/second*
+!   - mdot_type : *injection rate (0=const, 1=cos(t), 2=r^(-2))*
+!   - vlag      : *percentage lag in velocity of wind*
 !
 ! :Dependencies: binaryutils, externalforces, infile_utils, io, options,
 !   part, partinject, physcon, random, units

--- a/src/main/inject_asteroidwind.f90
+++ b/src/main/inject_asteroidwind.f90
@@ -6,9 +6,11 @@
 !--------------------------------------------------------------------------!
 module inject
 !
-! None
+! Injection module for wind from an orbiting asteroid, as used
+! in Trevascus et al. (2021)
 !
-! :References: None
+! :References:
+!   Trevascus et al. (2021), MNRAS 505, L21-L25
 !
 ! :Owner: David Liptai
 !
@@ -25,8 +27,7 @@ module inject
  use physcon, only:pi
  implicit none
  character(len=*), parameter, public :: inject_type = 'asteroidwind'
- real, public          :: mdot        = 5.e8     ! mass injection rate in grams/second
- real,save    :: dndt_scaling             ! scaling to get ninject correct
+ real, public :: mdot = 5.e8     ! mass injection rate in grams/second
 
  public :: init_inject,inject_particles,write_options_inject,read_options_inject
 
@@ -47,7 +48,6 @@ subroutine init_inject(ierr)
  integer, intent(inout) :: ierr
 
  scaling_set = .false.
-
  ierr = 0
 
 end subroutine init_inject
@@ -81,8 +81,10 @@ subroutine inject_particles(time,dtlast,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
  real, save :: have_injected,t_old
  real, save :: semia
 
- if (nptmass < 2 .and. iexternalforce == 0) call fatal('inject_asteroidwind','not enough point masses for asteroid wind injection')
- if (nptmass > 2) call fatal('inject_asteroidwind','too many point masses for asteroid wind injection')
+ if (nptmass < 2 .and. iexternalforce == 0) &
+    call fatal('inject_asteroidwind','not enough point masses for asteroid wind injection')
+ if (nptmass > 2) &
+    call fatal('inject_asteroidwind','too many point masses for asteroid wind injection')
 
  if (nptmass == 2) then
     pt = 2
@@ -106,15 +108,16 @@ subroutine inject_particles(time,dtlast,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
 
  r         = sqrt(dot_product(r1-r2,r1-r2))
 
-!
-! Add any dependency on radius to mass injection rate (and convert to code units)
-!
+ !
+ ! Add any dependency on radius to mass injection rate (and convert to code units)
+ !
  dmdt      = mdot*mdot_func(r,semia)/(umass/utime) ! Use semi-major axis as r_ref
 
-!-- How many particles do we need to inject?
-!   (Seems to need at least eight gas particles to not crash) <-- This statement may or may not be true...
-!
- if (npartoftype(igas)<8) then
+ !
+ !-- How many particles do we need to inject?
+ !   (Seems to need at least eight gas particles to not crash) <-- This statement may or may not be true...
+ !
+ if (npartoftype(igas) < 8) then
     npinject = 8-npartoftype(igas)
  else
     ! Calculate how many extra particles from previous step to now
@@ -128,9 +131,10 @@ subroutine inject_particles(time,dtlast,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
     have_injected = have_injected + inject_this_step
  endif
 
-!-- Randomly inject particles around the asteroids outer 'radius'
-!-- Only inject them on the side that is facing the central sink
-!
+ !
+ !-- Randomly inject particles around the asteroids outer 'radius'.
+ !   Only inject them on the side that is facing the central sink
+ !
  do i=1,npinject
     xyz       = r2 + rasteroid*get_random_pos_on_sphere(seed)
     vxyz      = (1.-vlag/100)*speed*vhat
@@ -154,7 +158,6 @@ end subroutine inject_particles
 !  of the orbit, not absolute time
 !+
 !-----------------------------------------------------------------------
-
 real function mdot_func(r,r_ref)
  real, intent(in) :: r,r_ref
 
@@ -176,10 +179,11 @@ subroutine write_options_inject(iunit)
  use infile_utils, only:write_inopt
  integer, intent(in) :: iunit
 
- call write_inopt(mdot         ,'mdot'         ,'mass injection rate in grams/second'              ,iunit)
- call write_inopt(npartperorbit,'npartperorbit','particle injection rate in particles/binary orbit',iunit)
- call write_inopt(vlag         ,'vlag'         ,'percentage lag in velocity of wind'               ,iunit)
- call write_inopt(mdot_type    ,'mdot_type'    ,'injection rate (0=const, 1=cos(t), 2=r^(-2))'     ,iunit)
+ call write_inopt(mdot,'mdot','mass injection rate in grams/second',iunit)
+ call write_inopt(npartperorbit,'npartperorbit',&
+                  'particle injection rate in particles/binary orbit',iunit)
+ call write_inopt(vlag,'vlag','percentage lag in velocity of wind',iunit)
+ call write_inopt(mdot_type,'mdot_type','injection rate (0=const, 1=cos(t), 2=r^(-2))',iunit)
 
 end subroutine write_options_inject
 

--- a/src/main/lumin_nsdisc.F90
+++ b/src/main/lumin_nsdisc.F90
@@ -663,12 +663,11 @@ end subroutine set_Lstar
 !----------------------------------------------------
 
 real function get_AccLum( dmdt, Mstar )       !Luminosity from accretion
- use physcon, only:gg
- use units, only:udist,umass,utime
+ use units, only:get_G_code
  real, intent(in) :: dmdt, Mstar
  real :: ggcode, Rstar
 
- ggcode = gg / (udist**3/(utime**2*umass))
+ ggcode = get_G_code()
  Rstar = 1.
 
  get_AccLum =  (ggcode * Mstar * dmdt / Rstar) / LEdd

--- a/src/main/lumin_nsdisc.F90
+++ b/src/main/lumin_nsdisc.F90
@@ -249,7 +249,7 @@ subroutine make_beta_grids(xyzh,particlemass,npart)
  real :: cell_volume, logzero, x, y, z
  integer :: rbin, thbin, phbin, zbin, ipart, totpart
 
- kappa = calc_kappa( frac_X, 2. ) * (umass/(udist*udist))   !kappa in code units
+ kappa = real(calc_kappa( frac_X, 2. ) * (umass/(udist*udist)))   !kappa in code units
 
  logzero = careful_log( 0.0 )
 
@@ -532,8 +532,8 @@ subroutine set_Lstar( BurstProfile, time, dmdt, Mstar )
  real             :: ptime, ptime2
 
 !this assumes c=G=1.
- LEdd = fourpi*Mstar/(calc_kappa( frac_X, 2. ) / ( udist*udist / umass ))
- ptime  = time*utime
+ LEdd = real(fourpi*Mstar/(calc_kappa( frac_X, 2. ) / ( udist*udist / umass )))
+ ptime  = real(time*utime)
  ptime2 = ptime*ptime
 
  select case( BurstProfile )
@@ -743,7 +743,7 @@ real function beta(x,y,z)
  case( 3 )
     r = sqrt(x**2 + y**2)
     H = calc_scaleheight(r)
-    kappa = calc_kappa( frac_X, 2. ) * (umass/(udist*udist))
+    kappa = real(calc_kappa( frac_X, 2. ) * (umass/(udist*udist)))
     tau = 1.0-erf( abs(z) / (roottwo*H) )
     tau = tau * rpiontwo * kappa * calc_sigma(r) * H
     beta = exp(-tau)
@@ -1057,7 +1057,9 @@ real function calc_sigma( r )
  use physcon, only:solarm
  real, intent(in) :: r
  real :: R_in = 1., Mdisc
- Mdisc = 1.4d0*solarm/umass*5.e-16
+
+ Mdisc = real(1.4d0*solarm/umass*5.d-16)
+
  if ( r>r_In ) then
     calc_sigma = sqrt(R_in) * Mdisc * r**(-3./2.)*(1-sqrt(R_in/r))
  else

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -26,7 +26,7 @@ module part
 !
  use dim, only:ndim,maxp,maxsts,ndivcurlv,ndivcurlB,maxvxyzu,maxalpha,&
                maxptmass,maxdvdx,nsinkproperties,mhd,maxmhd,maxBevol,&
-               maxp_h2,nabundances,periodic,&
+               maxp_h2,maxindan,nabundances,periodic,ind_timesteps,&
                maxgrav,ngradh,maxtypes,h2chemistry,gravity,maxp_dustfrac,&
                use_dust,use_dustgrowth,lightcurve,maxlum,nalpha,maxmhdni, &
                maxp_growth,maxdusttypes,maxdustsmall,maxdustlarge, &
@@ -283,15 +283,11 @@ module part
  real, allocatable   :: Bpred(:,:)
  real, allocatable   :: dustproppred(:,:)
  real, allocatable   :: radpred(:,:)
-#ifdef IND_TIMESTEPS
  integer(kind=1), allocatable :: ibin(:)
  integer(kind=1), allocatable :: ibin_old(:)
  integer(kind=1), allocatable :: ibin_wake(:)
  real(kind=4),    allocatable :: dt_in(:)
  real,            allocatable :: twas(:)
-#else
- integer(kind=1)    :: ibin_wake(1)
-#endif
 
  integer(kind=1), allocatable    :: iphase(:)
  integer(kind=1), allocatable    :: iphase_soa(:)
@@ -489,13 +485,11 @@ subroutine allocate_part
  call allocate_array('radpred', radpred, maxirad, maxprad)
  call allocate_array('drad', drad, maxirad, maxprad)
  call allocate_array('radprop', radprop, maxradprop, maxprad)
-#ifdef IND_TIMESTEPS
- call allocate_array('ibin', ibin, maxan)
- call allocate_array('ibin_old', ibin_old, maxan)
- call allocate_array('ibin_wake', ibin_wake, maxan)
- call allocate_array('dt_in', dt_in, maxan)
- call allocate_array('twas', twas, maxan)
-#endif
+ call allocate_array('ibin', ibin, maxindan)
+ call allocate_array('ibin_old', ibin_old, maxindan)
+ call allocate_array('ibin_wake', ibin_wake, maxindan)
+ call allocate_array('dt_in', dt_in, maxindan)
+ call allocate_array('twas', twas, maxindan)
  call allocate_array('iphase', iphase, maxphase)
  call allocate_array('iphase_soa', iphase_soa, maxphase)
  call allocate_array('gradh', gradh, ngradh, maxgradh)
@@ -562,13 +556,11 @@ subroutine deallocate_part
  if (allocated(dustpred))     deallocate(dustpred)
  if (allocated(Bpred))        deallocate(Bpred)
  if (allocated(dustproppred)) deallocate(dustproppred)
-#ifdef IND_TIMESTEPS
  if (allocated(ibin))         deallocate(ibin)
  if (allocated(ibin_old))     deallocate(ibin_old)
  if (allocated(ibin_wake))    deallocate(ibin_wake)
  if (allocated(dt_in))        deallocate(dt_in)
  if (allocated(twas))         deallocate(twas)
-#endif
  if (allocated(nucleation))   deallocate(nucleation)
  if (allocated(tau))          deallocate(tau)
  if (allocated(gamma_chem))   deallocate(gamma_chem)
@@ -648,13 +640,13 @@ subroutine init_part
  dustgasprop(:,:) = 0.
  VrelVf(:)        = 0.
 #endif
-#ifdef IND_TIMESTEPS
- ibin(:)       = 0
- ibin_old(:)   = 0
- ibin_wake(:)  = 0
- dt_in(:)      = 0.
- twas(:)       = 0.
-#endif
+ if (ind_timesteps) then
+    ibin(:)       = 0
+    ibin_old(:)   = 0
+    ibin_wake(:)  = 0
+    dt_in(:)      = 0.
+    twas(:)       = 0.
+ endif
 
  ideadhead = 0
 !
@@ -1168,13 +1160,13 @@ subroutine copy_particle(src,dst,new_part)
  if (maxgradh ==maxp) gradh(:,dst)    = gradh(:,src)
  if (maxphase ==maxp) iphase(dst)   = iphase(src)
  if (maxgrav  ==maxp) poten(dst) = poten(src)
-#ifdef IND_TIMESTEPS
- ibin(dst)       = ibin(src)
- ibin_old(dst)   = ibin_old(src)
- ibin_wake(dst)  = ibin_wake(src)
- dt_in(dst)      = dt_in(src)
- twas(dst)       = twas(src)
-#endif
+ if (ind_timesteps) then
+    ibin(dst)       = ibin(src)
+    ibin_old(dst)   = ibin_old(src)
+    ibin_wake(dst)  = ibin_wake(src)
+    dt_in(dst)      = dt_in(src)
+    twas(dst)       = twas(src)
+ endif
  if (use_dust) then
     dustfrac(:,dst) = dustfrac(:,src)
     dustevol(:,dst) = dustevol(:,src)
@@ -1251,15 +1243,13 @@ subroutine copy_particle_all(src,dst,new_part)
  if (maxphase ==maxp) iphase_soa(dst) = iphase_soa(src)
  if (maxgrav  ==maxp) poten(dst) = poten(src)
  if (maxlum   ==maxp) luminosity(dst) = luminosity(src)
-#ifdef IND_TIMESTEPS
- if (maxan==maxp) then
+ if (maxindan==maxp) then
     ibin(dst)       = ibin(src)
     ibin_old(dst)   = ibin_old(src)
     ibin_wake(dst)  = ibin_wake(src)
     dt_in(dst)      = dt_in(src)
     twas(dst)       = twas(src)
  endif
-#endif
  if (use_dust) then
     if (maxp_dustfrac==maxp) dustfrac(:,dst)  = dustfrac(:,src)
     dustevol(:,dst)  = dustevol(:,src)
@@ -1499,13 +1489,13 @@ subroutine fill_sendbuf(i,xtemp)
     if (maxgrav==maxp) then
        call fill_buffer(xtemp, poten(i),nbuf)
     endif
-#ifdef IND_TIMESTEPS
-    call fill_buffer(xtemp,ibin(i),nbuf)
-    call fill_buffer(xtemp,ibin_old(i),nbuf)
-    call fill_buffer(xtemp,ibin_wake(i),nbuf)
-    call fill_buffer(xtemp,dt_in(i),nbuf)
-    call fill_buffer(xtemp,twas(i),nbuf)
-#endif
+    if (ind_timesteps) then
+       call fill_buffer(xtemp,ibin(i),nbuf)
+       call fill_buffer(xtemp,ibin_old(i),nbuf)
+       call fill_buffer(xtemp,ibin_wake(i),nbuf)
+       call fill_buffer(xtemp,dt_in(i),nbuf)
+       call fill_buffer(xtemp,twas(i),nbuf)
+    endif
     call fill_buffer(xtemp,iorig(i),nbuf)
  endif
  if (nbuf /= ipartbufsize) call fatal('fill_sendbuf','error in send buffer size')
@@ -1581,13 +1571,13 @@ subroutine unfill_buffer(ipart,xbuf)
  if (maxgrav==maxp) then
     poten(ipart)        = real(unfill_buf(xbuf,j),kind=kind(poten))
  endif
-#ifdef IND_TIMESTEPS
- ibin(ipart)            = nint(unfill_buf(xbuf,j),kind=1)
- ibin_old(ipart)        = nint(unfill_buf(xbuf,j),kind=1)
- ibin_wake(ipart)       = nint(unfill_buf(xbuf,j),kind=1)
- dt_in(ipart)           = real(unfill_buf(xbuf,j),kind=kind(dt_in))
- twas(ipart)            = unfill_buf(xbuf,j)
-#endif
+ if (ind_timesteps) then
+    ibin(ipart)         = nint(unfill_buf(xbuf,j),kind=1)
+    ibin_old(ipart)     = nint(unfill_buf(xbuf,j),kind=1)
+    ibin_wake(ipart)    = nint(unfill_buf(xbuf,j),kind=1)
+    dt_in(ipart)        = real(unfill_buf(xbuf,j),kind=kind(dt_in))
+    twas(ipart)         = unfill_buf(xbuf,j)
+ endif
  iorig(ipart)           = nint(unfill_buf(xbuf,j),kind=8)
 
 !--just to be on the safe side, set other things to zero

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -727,7 +727,7 @@ pure subroutine rhoanddhdrho(hi,hi1,rhoi,rho1i,dhdrhoi,pmassi)
  real, parameter :: third = 1./3.
 
  hi1 = 1./abs(hi)
- rhoi = pmassi*(hfact*hi1)**3
+ rhoi = real(pmassi*(hfact*hi1)**3)
  rho1i = 1./rhoi
  dhdrhoi = -third*hi*rho1i
 

--- a/src/main/photoevap.f90
+++ b/src/main/photoevap.f90
@@ -18,7 +18,7 @@ module photoevap
 !   - mu_cgs         : *Mean molecular weight*
 !   - recombrate_cgs : *Recombination rate (alpha)*
 !
-! :Dependencies: allocutils, dim, eos, externalforces, infile_utils,
+! :Dependencies: allocutils, dim, eos, externalforces, infile_utils, io,
 !   physcon, units
 !
 

--- a/src/main/photoevap.f90
+++ b/src/main/photoevap.f90
@@ -90,12 +90,15 @@ subroutine allocate_photoevap
  call allocate_array('Rnum', Rnum, maxp)
  call allocate_array('Thetanum', Thetanum, maxp)
  call allocate_array('Phinum', Phinum, maxp)
+
 end subroutine allocate_photoevap
 
 subroutine deallocate_photoevap
+
  deallocate(Rnum)
  deallocate(Thetanum)
  deallocate(Phinum)
+
 end subroutine deallocate_photoevap
 
 !----------------------------------------------------------------
@@ -340,7 +343,7 @@ subroutine photo_ionize(vxyzu,npart)
  real     :: temperature,tempi
 
  if ( size(vxyzu,1) /= 4 ) then
-    call fatal('photoevap','no u in vxyzu variable: compile with ISOTHERMAL=no'
+    call fatal('photoevap','no u in vxyzu variable: compile with ISOTHERMAL=no')
  endif
 
 !$omp parallel do default(none)          &

--- a/src/main/physcon.f90
+++ b/src/main/physcon.f90
@@ -20,12 +20,12 @@ module physcon
 !
 !--Mathematical constants
 !
- real(kind=8), parameter :: pi       =  3.1415926536d0
- real(kind=8), parameter :: twopi    =  6.2831853072d0
- real(kind=8), parameter :: fourpi   = 12.5663706144d0
- real(kind=8), parameter :: piontwo  =  1.5707963268d0
- real(kind=8), parameter :: rpiontwo =  1.2533141373d0          !square root of (Pi/2)
- real(kind=8), parameter :: roottwo  =  1.4142135624d0
+ real, parameter :: pi       =  4.*atan(1.)            ! use real not real*8
+ real, parameter :: twopi    =  8.*atan(1.)            ! for these to avoid
+ real, parameter :: fourpi   = 16.*atan(1.)            ! type conversion errors
+ real, parameter :: piontwo  =  2.*atan(1.)            ! in real expressions
+ real, parameter :: rpiontwo =  sqrt(piontwo)          ! square root of (Pi/2)
+ real, parameter :: roottwo  =  sqrt(2.)               ! square root of two
 !
 !--Physical constants
 !

--- a/src/main/physcon.f90
+++ b/src/main/physcon.f90
@@ -18,14 +18,14 @@ module physcon
 !
  implicit none
 !
-!--Mathematical constants
+!--Mathematical constants (keep these in variable precision to avoid warnings)
 !
- real, parameter :: pi       =  4.*atan(1.)            ! use real not real*8
- real, parameter :: twopi    =  8.*atan(1.)            ! for these to avoid
- real, parameter :: fourpi   = 16.*atan(1.)            ! type conversion errors
- real, parameter :: piontwo  =  2.*atan(1.)            ! in real expressions
- real, parameter :: rpiontwo =  sqrt(piontwo)          ! square root of (Pi/2)
- real, parameter :: roottwo  =  sqrt(2.)               ! square root of two
+ real, parameter :: pi       =  3.1415926536d0
+ real, parameter :: twopi    =  6.2831853072d0
+ real, parameter :: fourpi   = 12.5663706144d0
+ real, parameter :: piontwo  =  1.5707963268d0
+ real, parameter :: rpiontwo =  1.2533141373d0          !square root of (Pi/2)
+ real, parameter :: roottwo  =  1.4142135624d0
 !
 !--Physical constants
 !

--- a/src/main/random.f90
+++ b/src/main/random.f90
@@ -109,9 +109,8 @@ function get_random ( s1, s2 )
     z = z + 2147483562
  endif
 
- get_random = real ( z ) / 2147483563.0D+00
+ get_random = real ( z / 2147483563.0D+00 )
 
- return
 end function get_random
 
 !!-------------------------------------------------------------------------

--- a/src/main/readwrite_dumps_fortran.F90
+++ b/src/main/readwrite_dumps_fortran.F90
@@ -1795,8 +1795,8 @@ subroutine unfill_rheader(hdr,phantomdump,ntypesinfile,nptmass,&
     call extract('graindens',graindens(1:ndusttypes),hdr,ierrs(2))
     if (any(ierrs(1:2) /= 0)) then
        write(*,*) 'ERROR reading grain size/density from file header'
-       grainsize(1) = grainsizecgs/udist
-       graindens(1) = graindenscgs/unit_density
+       grainsize(1) = real(grainsizecgs/udist)
+       graindens(1) = real(graindenscgs/unit_density)
     endif
  endif
 

--- a/src/main/step_leapfrog.F90
+++ b/src/main/step_leapfrog.F90
@@ -104,14 +104,14 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
                           iamboundary,get_ntypes,npartoftypetot,&
                           dustfrac,dustevol,ddustevol,eos_vars,alphaind,nptmass,&
                           dustprop,ddustprop,dustproppred,ndustsmall,pxyzu,dens,metrics,ics
- use cooling,        only:cooling_in_step,ufloor
  use options,        only:avdecayconst,alpha,ieos,alphamax
  use deriv,          only:derivs
  use timestep,       only:dterr,bignumber,tolv
  use mpiutils,       only:reduceall_mpi
- use part,           only:nptmass,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,ibin_wake
+ use part,           only:nptmass,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass
  use io_summary,     only:summary_printout,summary_variable,iosumtvi,iowake, &
                           iosumflrp,iosumflrps,iosumflrc
+ use cooling,        only:ufloor
 #ifdef KROME
  use part,           only:gamma_chem
 #endif
@@ -127,6 +127,9 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
  use metric_tools,   only:imet_minkowski,imetric
  use cons2prim,      only:cons2primall
  use extern_gr,      only:get_grforce_all
+#else
+ use cooling,        only:cooling_in_step
+ use part,           only:ibin_wake
 #endif
  use timing,         only:increment_timer,get_timings,itimer_extf
  use growth,         only:check_dustprop

--- a/src/main/step_leapfrog.F90
+++ b/src/main/step_leapfrog.F90
@@ -28,7 +28,7 @@ module step_lf_global
 !   options, part, ptmass, ptmass_radiation, timestep, timestep_ind,
 !   timestep_sts, timing
 !
- use dim,  only:maxp,maxvxyzu,do_radiation
+ use dim,  only:maxp,maxvxyzu,do_radiation,ind_timesteps
  use part, only:vpred,Bpred,dustpred,ppred
  use part, only:radpred
  use timestep_ind, only:maxbins,itdt,ithdt,itdt1,ittwas
@@ -45,13 +45,10 @@ contains
 !+
 !------------------------------------------------------------
 subroutine init_step(npart,time,dtmax)
-#ifdef IND_TIMESTEPS
  use timestep_ind, only:get_dt,nbinmax
- use part,         only:ibin,twas,maxphase,maxp,iphase,iamboundary,iamtype
-#endif
+ use part,         only:ibin,twas,iphase,iamboundary,iamtype
  integer, intent(in) :: npart
  real,    intent(in) :: time,dtmax
-#ifdef IND_TIMESTEPS
  integer             :: i
  !
  ! first time through, move all particles on shortest timestep
@@ -59,32 +56,32 @@ subroutine init_step(npart,time,dtmax)
  ! Keep boundary particles on level 0 since forces are never calculated
  ! and to prevent boundaries from limiting the timestep
  !
- if (time < tiny(time)) then
+ if (ind_timesteps) then
+    if (time < tiny(time)) then
+       !$omp parallel do schedule(static) private(i)
+       do i=1,npart
+          ibin(i) = nbinmax
+          if (iamboundary(iamtype(iphase(i)))) ibin(i) = 0
+       enddo
+    endif
+    !
+    ! twas is set so that at start of step we predict
+    ! forwards to half of current timestep
+    !
     !$omp parallel do schedule(static) private(i)
     do i=1,npart
-       ibin(i) = nbinmax
-       if (maxphase==maxp) then
-          if (iamboundary(iamtype(iphase(i)))) ibin(i) = 0
-       endif
+       twas(i) = time + 0.5*get_dt(dtmax,ibin(i))
+    enddo
+    !
+    ! For each ibin option, calculate dt, dt/2, 1/dt and twas
+    !
+    do i=0,maxbins
+       ibin_dts(itdt,  i) = get_dt(dtmax,int(i,kind=1))
+       ibin_dts(ithdt, i) = 0.5*ibin_dts(itdt,i)
+       ibin_dts(itdt1, i) = 1.0/ibin_dts(itdt,i)
+       ibin_dts(ittwas,i) = time + 0.5*get_dt(dtmax,int(i,kind=1))
     enddo
  endif
-!
-! twas is set so that at start of step we predict
-! forwards to half of current timestep
-!
- !$omp parallel do schedule(static) private(i)
- do i=1,npart
-    twas(i) = time + 0.5*get_dt(dtmax,ibin(i))
- enddo
- !
- ! For each ibin option, calculate dt, dt/2, 1/dt and twas
- do i=0,maxbins
-    ibin_dts(itdt,  i) = get_dt(dtmax,int(i,kind=1))
-    ibin_dts(ithdt, i) = 0.5*ibin_dts(itdt,i)
-    ibin_dts(itdt1, i) = 1.0/ibin_dts(itdt,i)
-    ibin_dts(ittwas,i) = time + 0.5*get_dt(dtmax,int(i,kind=1))
- enddo
-#endif
 
 end subroutine init_step
 
@@ -115,13 +112,10 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
 #ifdef KROME
  use part,           only:gamma_chem
 #endif
-#ifdef IND_TIMESTEPS
  use timestep,       only:dtmax,dtmax_ifactor,dtdiff
- use timestep_ind,   only:get_dt,nbinmax,decrease_dtmax,ibinnow
+ use timestep_ind,   only:get_dt,nbinmax,decrease_dtmax,ibinnow,dt_too_small
  use timestep_sts,   only:sts_get_dtau_next,use_sts,ibin_sts,sts_it_n
- use part,           only:ibin,ibin_old,twas,iactive
-#endif
- use timestep_ind,   only:dt_too_small
+ use part,           only:ibin,ibin_old,twas,iactive,ibin_wake
 #ifdef GR
  use part,           only:metricderivs
  use metric_tools,   only:imet_minkowski,imetric
@@ -129,14 +123,12 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
  use extern_gr,      only:get_grforce_all
 #else
  use cooling,        only:cooling_in_step
- use part,           only:ibin_wake
 #endif
  use timing,         only:increment_timer,get_timings,itimer_extf
  use growth,         only:check_dustprop
  use damping,        only:idamp
-
  use cons2primsolver, only:conservative2primitive,primitive2conservative
- use eos, only:equationofstate
+ use eos,             only:equationofstate
 
  integer, intent(inout) :: npart
  integer, intent(in)    :: nactive
@@ -150,12 +142,8 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
  real               :: v2mean,hdti
  real(kind=4)       :: t1,t2,tcpu1,tcpu2
  real               :: pxi,pyi,pzi,p2i,p2mean
-#ifdef IND_TIMESTEPS
  real               :: dtsph_next,dti,time_now
  logical, parameter :: allow_waking = .true.
-#else
- integer(kind=1), parameter :: nbinmax = 0
-#endif
  integer, parameter :: maxits = 30
  logical            :: converged,store_itype
 !
@@ -166,14 +154,12 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
  dterr  = bignumber
 
 ! determine twas for each ibin
-#ifdef IND_TIMESTEPS
- if (sts_it_n) then
+ if (ind_timesteps .and. sts_it_n) then
     time_now = timei + dtsph
     do i=0,maxbins
        ibin_dts(ittwas,i) = (int(time_now*ibin_dts(itdt1,i),kind=8) + 0.5)*ibin_dts(itdt,i)
     enddo
  endif
-#endif
 
 !--------------------------------------
 ! velocity predictor step, using dtsph
@@ -190,23 +176,21 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
  !$omp shared(rad,drad,pxyzu)&
  !$omp shared(Bevol,dBevol,dustevol,ddustevol,use_dustfrac) &
  !$omp shared(dustprop,ddustprop,dustproppred,ufloor) &
-#ifdef IND_TIMESTEPS
  !$omp shared(ibin,ibin_old,twas,timei) &
-#endif
  !$omp firstprivate(itype) &
  !$omp private(i,hdti) &
  !$omp reduction(+:nvfloorp)
  predictor: do i=1,npart
     if (.not.isdead_or_accreted(xyzh(4,i))) then
-#ifdef IND_TIMESTEPS
-       if (iactive(iphase(i))) ibin_old(i) = ibin(i) ! only required for ibin_neigh in force.F90
-       !
-       !--synchronise all particles to their half timesteps
-       !
-       hdti = twas(i) - timei
-#else
-       hdti = hdtsph
-#endif
+       if (ind_timesteps) then
+          if (iactive(iphase(i))) ibin_old(i) = ibin(i) ! only required for ibin_neigh in force.F90
+          !
+          !--synchronise all particles to their half timesteps
+          !
+          hdti = twas(i) - timei
+       else
+          hdti = hdtsph
+       endif
        if (store_itype) itype = iamtype(iphase(i))
        if (iamboundary(itype)) cycle predictor
        !
@@ -282,9 +266,7 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
 !$omp shared(dustevol,ddustprop,dustprop,dustproppred,dustfrac,ddustevol,dustpred,use_dustfrac) &
 !$omp shared(alphaind,ieos,alphamax,ndustsmall,ialphaloc) &
 !$omp shared(eos_vars,ufloor) &
-#ifdef IND_TIMESTEPS
 !$omp shared(twas,timei) &
-#endif
 !$omp shared(rad,drad,radpred)&
 !$omp private(hi,rhoi,tdecay1,source,ddenom,hdti) &
 !$omp private(i,spsoundi,alphaloci,divvdti) &
@@ -319,11 +301,11 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
        ! force evaluation. These have already been updated to the
        ! half step, so only need a half step (0.5*dtsph) here
        !
-#ifdef IND_TIMESTEPS
-       hdti = timei - twas(i)   ! interpolate to end time
-#else
-       hdti = 0.5*dtsph
-#endif
+       if (ind_timesteps) then
+          hdti = timei - twas(i)   ! interpolate to end time
+       else
+          hdti = 0.5*dtsph
+       endif
 
        if (gr) then
           ppred(:,i) = pxyzu(:,i) + hdti*fxyzu(:,i)
@@ -409,12 +391,12 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
 !
 ! if using super-timestepping, determine what dt will be used on the next loop
 !
-#ifdef IND_TIMESTEPS
- if ( use_sts ) call sts_get_dtau_next(dtsph_next,dtsph,dtmax,dtdiff,nbinmax)
- if (dtmax_ifactor /=0 .and. sts_it_n) then
-    call decrease_dtmax(npart,maxbins,timei-dtsph,dtmax_ifactor,dtmax,ibin,ibin_wake,ibin_sts,ibin_dts)
+ if (ind_timesteps) then
+    if ( use_sts ) call sts_get_dtau_next(dtsph_next,dtsph,dtmax,dtdiff,nbinmax)
+    if (dtmax_ifactor /=0 .and. sts_it_n) then
+       call decrease_dtmax(npart,maxbins,timei-dtsph,dtmax_ifactor,dtmax,ibin,ibin_wake,ibin_sts,ibin_dts)
+    endif
  endif
-#endif
 !
 !-------------------------------------------------------------------------
 !  leapfrog corrector step: most of the time we should not need to take
@@ -444,11 +426,9 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
 !$omp shared(dustprop,ddustprop,dustproppred) &
 !$omp shared(xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,nptmass,massoftype) &
 !$omp shared(dtsph,ieos,ufloor) &
-#ifdef IND_TIMESTEPS
 !$omp shared(ibin,ibin_old,ibin_sts,twas,timei,use_sts,dtsph_next,ibin_wake,sts_it_n) &
 !$omp shared(ibin_dts,nbinmax,ibinnow) &
 !$omp private(dti,hdti) &
-#endif
 !$omp shared(rad,radpred,drad)&
 !$omp private(i,vxi,vyi,vzi,vxoldi,vyoldi,vzoldi) &
 !$omp private(pxi,pyi,pzi,p2i) &
@@ -461,137 +441,137 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
        if (.not.isdead_or_accreted(xyzh(4,i))) then
           if (store_itype) itype = iamtype(iphase(i))
           if (iamboundary(itype)) cycle corrector
-#ifdef IND_TIMESTEPS
-          !
-          !--update active particles
-          !
-          if (iactive(iphase(i))) then
-             ibin_wake(i) = 0       ! cannot wake active particles
-             hdti = timei - twas(i) ! = 0.5*get_dt(dtmax,ibin_old(i)) if .not.use_sts & dtmax has not changed & particle was not just woken up
-             if (use_sts) then
-                if (ibin(i) < ibin_sts(i)) ibin(i) = min(ibin_sts(i), nbinmax ) ! increase ibin if needed for super timestepping
-                if (.not.sts_it_n .or. (sts_it_n .and. ibin_sts(i) > ibin(i))) then
-                   dti = hdti + 0.5*dtsph_next
+          if (ind_timesteps) then
+             !
+             !--update active particles
+             !
+             if (iactive(iphase(i))) then
+                ibin_wake(i) = 0       ! cannot wake active particles
+                hdti = timei - twas(i) ! = 0.5*get_dt(dtmax,ibin_old(i)) if .not.use_sts & dtmax has not changed & particle was not just woken up
+                if (use_sts) then
+                   if (ibin(i) < ibin_sts(i)) ibin(i) = min(ibin_sts(i), nbinmax ) ! increase ibin if needed for super timestepping
+                   if (.not.sts_it_n .or. (sts_it_n .and. ibin_sts(i) > ibin(i))) then
+                      dti = hdti + 0.5*dtsph_next
+                   else
+                      dti = hdti + ibin_dts(ithdt,ibin(i))
+                   endif
                 else
                    dti = hdti + ibin_dts(ithdt,ibin(i))
                 endif
-             else
-                dti = hdti + ibin_dts(ithdt,ibin(i))
+
+                if (gr) then
+                   pxyzu(:,i) = pxyzu(:,i) + dti*fxyzu(:,i)
+                else
+                   vxyzu(:,i) = vxyzu(:,i) + dti*fxyzu(:,i)
+                endif
+
+                if (use_dustgrowth .and. itype==idust) dustprop(:,i) = dustprop(:,i) + dti*ddustprop(:,i)
+                if (itype==igas) then
+                   if (mhd)          Bevol(:,i) = Bevol(:,i) + dti*dBevol(:,i)
+                   if (do_radiation) rad(:,i)   = rad(:,i)   + dti*drad(:,i)
+                   if (use_dustfrac) then
+                      dustevol(:,i) = dustevol(:,i) + dti*ddustevol(:,i)
+                      if (use_dustgrowth) dustprop(:,i) = dustprop(:,i) + dti*ddustprop(:,i)
+                   endif
+                endif
+                twas(i) = twas(i) + dti
              endif
+             !
+             !--synchronise all particles
+             !
+             hdti = timei - twas(i)
 
              if (gr) then
-                pxyzu(:,i) = pxyzu(:,i) + dti*fxyzu(:,i)
+                pxyzu(:,i) = pxyzu(:,i) + hdti*fxyzu(:,i)
              else
-                vxyzu(:,i) = vxyzu(:,i) + dti*fxyzu(:,i)
+                vxyzu(:,i) = vxyzu(:,i) + hdti*fxyzu(:,i)
              endif
 
-             if (use_dustgrowth .and. itype==idust) dustprop(:,i) = dustprop(:,i) + dti*ddustprop(:,i)
-             if (itype==igas) then
-                if (mhd)          Bevol(:,i) = Bevol(:,i) + dti*dBevol(:,i)
-                if (do_radiation) rad(:,i)   = rad(:,i)   + dti*drad(:,i)
-                if (use_dustfrac) then
-                   dustevol(:,i) = dustevol(:,i) + dti*ddustevol(:,i)
-                   if (use_dustgrowth) dustprop(:,i) = dustprop(:,i) + dti*ddustprop(:,i)
+             !--floor the thermal energy if requested and required
+             if (ufloor > 0.) then
+                if (vxyzu(4,i) < ufloor) then
+                   vxyzu(4,i) = ufloor
+                   nvfloorc   = nvfloorc + 1
                 endif
              endif
-             twas(i) = twas(i) + dti
-          endif
-          !
-          !--synchronise all particles
-          !
-          hdti = timei - twas(i)
 
-          if (gr) then
-             pxyzu(:,i) = pxyzu(:,i) + hdti*fxyzu(:,i)
-          else
-             vxyzu(:,i) = vxyzu(:,i) + hdti*fxyzu(:,i)
-          endif
-
-          !--floor the thermal energy if requested and required
-          if (ufloor > 0.) then
-             if (vxyzu(4,i) < ufloor) then
-                vxyzu(4,i) = ufloor
-                nvfloorc   = nvfloorc + 1
+             if (itype==idust .and. use_dustgrowth) dustprop(:,i) = dustprop(:,i) + hdti*ddustprop(:,i)
+             if (itype==igas) then
+                if (mhd)          Bevol(:,i) = Bevol(:,i) + hdti*dBevol(:,i)
+                if (do_radiation) rad(:,i)   = rad(:,i)   + hdti*drad(:,i)
+                if (use_dustfrac) then
+                   dustevol(:,i) = dustevol(:,i) + hdti*ddustevol(:,i)
+                   if (use_dustgrowth) dustprop(:,i) = dustprop(:,i) + hdti*ddustprop(:,i)
+                endif
              endif
-          endif
-
-          if (itype==idust .and. use_dustgrowth) dustprop(:,i) = dustprop(:,i) + hdti*ddustprop(:,i)
-          if (itype==igas) then
-             if (mhd)          Bevol(:,i) = Bevol(:,i) + hdti*dBevol(:,i)
-             if (do_radiation) rad(:,i)   = rad(:,i)   + hdti*drad(:,i)
-             if (use_dustfrac) then
-                dustevol(:,i) = dustevol(:,i) + hdti*ddustevol(:,i)
-                if (use_dustgrowth) dustprop(:,i) = dustprop(:,i) + hdti*ddustprop(:,i)
-             endif
-          endif
-          !
-          !--Wake inactive particles for next step, if required
-          !
-          if (sts_it_n .and. ibin_wake(i) > ibin(i) .and. allow_waking) then
-             ibin_wake(i) = min(int(nbinmax,kind=1),ibin_wake(i))
-             nwake        = nwake + 1
-             twas(i)      = ibin_dts(ittwas,ibin_wake(i))
-             ibin(i)      = ibin_wake(i)
-             ibin_wake(i) = 0 ! reset flag
-          endif
-#else
-          !
-          ! For velocity-dependent forces compare the new v
-          ! with the predicted v used in the force evaluation.
-          ! Determine whether or not we need to iterate.
-          !
-
-          if (gr) then
-             pxi = pxyzu(1,i) + hdtsph*fxyzu(1,i)
-             pyi = pxyzu(2,i) + hdtsph*fxyzu(2,i)
-             pzi = pxyzu(3,i) + hdtsph*fxyzu(3,i)
-             eni = pxyzu(4,i) + hdtsph*fxyzu(4,i)
-
-             erri = (pxi - ppred(1,i))**2 + (pyi - ppred(2,i))**2 + (pzi - ppred(3,i))**2
-             errmax = max(errmax,erri)
-
-             p2i = pxi*pxi + pyi*pyi + pzi*pzi
-             p2mean = p2mean + p2i
-             np = np + 1
-
-             pxyzu(1,i) = pxi
-             pxyzu(2,i) = pyi
-             pxyzu(3,i) = pzi
-             pxyzu(4,i) = eni
-          else
-             vxi = vxyzu(1,i) + hdtsph*fxyzu(1,i)
-             vyi = vxyzu(2,i) + hdtsph*fxyzu(2,i)
-             vzi = vxyzu(3,i) + hdtsph*fxyzu(3,i)
-             if (maxvxyzu >= 4) eni = vxyzu(4,i) + hdtsph*fxyzu(4,i)
-
-             erri = (vxi - vpred(1,i))**2 + (vyi - vpred(2,i))**2 + (vzi - vpred(3,i))**2
-             !if (erri > errmax) print*,id,' errmax = ',erri,' part ',i,vxi,vxoldi,vyi,vyoldi,vzi,vzoldi
-             errmax = max(errmax,erri)
-
-             v2i    = vxi*vxi + vyi*vyi + vzi*vzi
-             v2mean = v2mean + v2i
-             np     = np + 1
-
-             vxyzu(1,i) = vxi
-             vxyzu(2,i) = vyi
-             vxyzu(3,i) = vzi
-             !--this is the energy equation if non-isothermal
-             if (maxvxyzu >= 4) vxyzu(4,i) = eni
-          endif
-
-          if (itype==idust .and. use_dustgrowth) dustprop(:,i) = dustprop(:,i) + hdtsph*ddustprop(:,i)
-          if (itype==igas) then
              !
-             ! corrector step for magnetic field and dust
+             !--Wake inactive particles for next step, if required
              !
-             if (mhd)          Bevol(:,i) = Bevol(:,i)  + hdtsph*dBevol(:,i)
-             if (do_radiation) rad(:,i)   = rad(:,i) + hdtsph*drad(:,i)
-             if (use_dustfrac) then
-                dustevol(:,i) = dustevol(:,i) + hdtsph*ddustevol(:,i)
-                if (use_dustgrowth) dustprop(:,i) = dustprop(:,i) + hdtsph*ddustprop(:,i)
+             if (sts_it_n .and. ibin_wake(i) > ibin(i) .and. allow_waking) then
+                ibin_wake(i) = min(int(nbinmax,kind=1),ibin_wake(i))
+                nwake        = nwake + 1
+                twas(i)      = ibin_dts(ittwas,ibin_wake(i))
+                ibin(i)      = ibin_wake(i)
+                ibin_wake(i) = 0 ! reset flag
+             endif
+          else  ! not individual timesteps == global timestepping
+             !
+             ! For velocity-dependent forces compare the new v
+             ! with the predicted v used in the force evaluation.
+             ! Determine whether or not we need to iterate.
+             !
+
+             if (gr) then
+                pxi = pxyzu(1,i) + hdtsph*fxyzu(1,i)
+                pyi = pxyzu(2,i) + hdtsph*fxyzu(2,i)
+                pzi = pxyzu(3,i) + hdtsph*fxyzu(3,i)
+                eni = pxyzu(4,i) + hdtsph*fxyzu(4,i)
+
+                erri = (pxi - ppred(1,i))**2 + (pyi - ppred(2,i))**2 + (pzi - ppred(3,i))**2
+                errmax = max(errmax,erri)
+
+                p2i = pxi*pxi + pyi*pyi + pzi*pzi
+                p2mean = p2mean + p2i
+                np = np + 1
+
+                pxyzu(1,i) = pxi
+                pxyzu(2,i) = pyi
+                pxyzu(3,i) = pzi
+                pxyzu(4,i) = eni
+             else
+                vxi = vxyzu(1,i) + hdtsph*fxyzu(1,i)
+                vyi = vxyzu(2,i) + hdtsph*fxyzu(2,i)
+                vzi = vxyzu(3,i) + hdtsph*fxyzu(3,i)
+                if (maxvxyzu >= 4) eni = vxyzu(4,i) + hdtsph*fxyzu(4,i)
+
+                erri = (vxi - vpred(1,i))**2 + (vyi - vpred(2,i))**2 + (vzi - vpred(3,i))**2
+                !if (erri > errmax) print*,id,' errmax = ',erri,' part ',i,vxi,vxoldi,vyi,vyoldi,vzi,vzoldi
+                errmax = max(errmax,erri)
+
+                v2i    = vxi*vxi + vyi*vyi + vzi*vzi
+                v2mean = v2mean + v2i
+                np     = np + 1
+
+                vxyzu(1,i) = vxi
+                vxyzu(2,i) = vyi
+                vxyzu(3,i) = vzi
+                !--this is the energy equation if non-isothermal
+                if (maxvxyzu >= 4) vxyzu(4,i) = eni
+             endif
+
+             if (itype==idust .and. use_dustgrowth) dustprop(:,i) = dustprop(:,i) + hdtsph*ddustprop(:,i)
+             if (itype==igas) then
+                !
+                ! corrector step for magnetic field and dust
+                !
+                if (mhd)          Bevol(:,i) = Bevol(:,i)  + hdtsph*dBevol(:,i)
+                if (do_radiation) rad(:,i)   = rad(:,i) + hdtsph*drad(:,i)
+                if (use_dustfrac) then
+                   dustevol(:,i) = dustevol(:,i) + hdtsph*ddustevol(:,i)
+                   if (use_dustgrowth) dustprop(:,i) = dustprop(:,i) + hdtsph*ddustprop(:,i)
+                endif
              endif
           endif
-#endif
        endif
     enddo corrector
 !$omp enddo
@@ -618,9 +598,20 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
           if (store_itype) itype = iamtype(iphase(i))
           if (iamboundary(itype)) cycle until_converged
 
-#ifdef IND_TIMESTEPS
-          if (iactive(iphase(i))) then
+          if (ind_timesteps) then
+             if (iactive(iphase(i))) then
 
+                if (gr) then
+                   ppred(:,i) = pxyzu(:,i)
+                else
+                   vpred(:,i) = vxyzu(:,i)
+                endif
+                if (use_dustgrowth) dustproppred(:,i) = dustprop(:,i)
+                if (mhd)          Bpred(:,i)  = Bevol(:,i)
+                if (use_dustfrac) dustpred(:,i) = dustevol(:,i)
+                if (do_radiation) radpred(:,i) = rad(:,i)
+             endif
+          else
              if (gr) then
                 ppred(:,i) = pxyzu(:,i)
              else
@@ -630,36 +621,24 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
              if (mhd)          Bpred(:,i)  = Bevol(:,i)
              if (use_dustfrac) dustpred(:,i) = dustevol(:,i)
              if (do_radiation) radpred(:,i) = rad(:,i)
-          endif
-#else
-          if (gr) then
-             ppred(:,i) = pxyzu(:,i)
-          else
-             vpred(:,i) = vxyzu(:,i)
-          endif
-          if (use_dustgrowth) dustproppred(:,i) = dustprop(:,i)
-          if (mhd)          Bpred(:,i)  = Bevol(:,i)
-          if (use_dustfrac) dustpred(:,i) = dustevol(:,i)
-          if (do_radiation) radpred(:,i) = rad(:,i)
-          !
-          ! shift v back to the half step
-          !
-          if (gr) then
-             pxyzu(:,i) = pxyzu(:,i) - hdtsph*fxyzu(:,i)
-          else
-             vxyzu(:,i) = vxyzu(:,i) - hdtsph*fxyzu(:,i)
-          endif
-          if (itype==idust .and. use_dustgrowth) dustprop(:,i) = dustprop(:,i) - hdtsph*ddustprop(:,i)
-          if (itype==igas) then
-             if (mhd)          Bevol(:,i)  = Bevol(:,i)  - hdtsph*dBevol(:,i)
-             if (use_dustfrac) then
-                dustevol(:,i) = dustevol(:,i) - hdtsph*ddustevol(:,i)
-                if (use_dustgrowth) dustprop(:,i) = dustprop(:,i) - hdtsph*ddustprop(:,i)
+             !
+             ! shift v back to the half step
+             !
+             if (gr) then
+                pxyzu(:,i) = pxyzu(:,i) - hdtsph*fxyzu(:,i)
+             else
+                vxyzu(:,i) = vxyzu(:,i) - hdtsph*fxyzu(:,i)
              endif
-             if (do_radiation) rad(:,i) = rad(:,i) - hdtsph*drad(:,i)
+             if (itype==idust .and. use_dustgrowth) dustprop(:,i) = dustprop(:,i) - hdtsph*ddustprop(:,i)
+             if (itype==igas) then
+                if (mhd)          Bevol(:,i)  = Bevol(:,i)  - hdtsph*dBevol(:,i)
+                if (use_dustfrac) then
+                   dustevol(:,i) = dustevol(:,i) - hdtsph*ddustevol(:,i)
+                   if (use_dustgrowth) dustprop(:,i) = dustprop(:,i) - hdtsph*ddustprop(:,i)
+                endif
+                if (do_radiation) rad(:,i) = rad(:,i) - hdtsph*drad(:,i)
+             endif
           endif
-
-#endif
        enddo until_converged
 !$omp end parallel do
 
@@ -701,7 +680,6 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
  call cons2primall(npart,xyzh,metrics,pxyzu,vxyzu,dens,eos_vars)
 #endif
 
- return
 end subroutine step
 
 #ifdef GR
@@ -1436,9 +1414,8 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
              fxi = fext(1,i)
              fyi = fext(2,i)
              fzi = fext(3,i)
-#ifdef IND_TIMESTEPS
-             ibin_wakei = ibin_wake(i)
-#endif
+             if (ind_timesteps) ibin_wakei = ibin_wake(i)
+
              call ptmass_accrete(1,nptmass,xyzh(1,i),xyzh(2,i),xyzh(3,i),xyzh(4,i),&
                                  vxyzu(1,i),vxyzu(2,i),vxyzu(3,i),fxi,fyi,fzi,&
                                  itype,pmassi,xyzmh_ptmass,vxyz_ptmass,&
@@ -1446,10 +1423,8 @@ subroutine step_extern(npart,ntypes,dtsph,dtextforce,xyzh,vxyzu,fext,fxyzu,time,
              if (accreted) then
                 naccreted = naccreted + 1
                 cycle accreteloop
-#ifdef IND_TIMESTEPS
              else
-                ibin_wake(i) = ibin_wakei
-#endif
+                if (ind_timesteps) ibin_wake(i) = ibin_wakei
              endif
              if (nfaili > 1) nfail = nfail + 1
           endif
@@ -1534,9 +1509,7 @@ end subroutine step_extern
 !-----------------------------------------------------
 subroutine check_velocity_error(errmax,v2mean,np,its,tolv,dt,timei,idamp,dterr,errmaxmean,converged)
  use io,         only:id,master,iprint,iverbose,warning
-#ifndef IND_TIMESTEPS
  use timestep,   only:dtcourant,dtforce,bignumber
-#endif
  use mpiutils,   only:reduceall_mpi
  use io_summary, only:summary_variable,iosumtve,iosumtvv
  real,    intent(inout) :: errmax,v2mean,errmaxmean
@@ -1545,9 +1518,7 @@ subroutine check_velocity_error(errmax,v2mean,np,its,tolv,dt,timei,idamp,dterr,e
  real,    intent(out)   :: dterr
  logical, intent(out)   :: converged
  real            :: errtol,vmean
-#ifndef IND_TIMESTEPS
  real            :: dtf
-#endif
  integer(kind=8) :: nptot
 !
 !  Check v^1 against the predicted velocity
@@ -1576,18 +1547,18 @@ subroutine check_velocity_error(errmax,v2mean,np,its,tolv,dt,timei,idamp,dterr,e
  errtol = tolv
  dterr = huge(dterr)
  if (tolv < 1.e2 .and. idamp == 0) then
-#ifndef IND_TIMESTEPS
-    dtf = min(dtcourant,dtforce)
-    !--if errors are controlling the timestep
-    if (dtf > dt .and. dtf < bignumber) then
-       errtol = errtol*(dt/dtf)**2
-    endif
-    if (its==1) then
-       if (errtol > tiny(errtol) .and. errmax > epsilon(errmax)) then ! avoid divide-by-zero
-          dterr = dt*sqrt(errtol/errmax)
+    if (.not.ind_timesteps) then
+       dtf = min(dtcourant,dtforce)
+       !--if errors are controlling the timestep
+       if (dtf > dt .and. dtf < bignumber) then
+          errtol = errtol*(dt/dtf)**2
+       endif
+       if (its==1) then
+          if (errtol > tiny(errtol) .and. errmax > epsilon(errmax)) then ! avoid divide-by-zero
+             dterr = dt*sqrt(errtol/errmax)
+          endif
        endif
     endif
-#endif
  endif
 !
 ! if the error in the predicted velocity exceeds the tolerance, take iterations

--- a/src/main/step_supertimestep.F90
+++ b/src/main/step_supertimestep.F90
@@ -63,7 +63,7 @@ subroutine step_sts(npart,nactive,time,dt,dtextforce,dtnew,iprint)
  real,    intent(in)    :: time,dt
  real,    intent(inout) :: dtextforce
  real,    intent(out)   :: dtnew
- real, parameter        :: time_tol = 1.0d-8
+ real, parameter        :: time_tol = 1.0e-8
  integer                :: nactive_sts
 #ifndef IND_TIMESTEPS
  integer(kind=1), parameter :: nbinmax = 0  ! The simplest way to keep everything clean

--- a/src/main/units.f90
+++ b/src/main/units.f90
@@ -11,7 +11,8 @@ module units
 !   the units are printed in the dump file header
 !   and log output is scaled in these units)
 !
-! :References: None
+! :References:
+!   Price & Monaghan (2004) MNRAS 348, 123 (section 7.1.1 on MHD units)
 !
 ! :Owner: Daniel Price
 !
@@ -276,10 +277,10 @@ end function is_digit
 !  Gravitational constant in code units
 !+
 !---------------------------------------------------------------------------
-real(kind=8) function get_G_code() result(G_code)
+real function get_G_code() result(G_code)
  use physcon, only:gg
 
- G_code = gg*umass*utime**2/udist**3
+ G_code = real(gg*umass*utime**2/udist**3)
 
 end function get_G_code
 
@@ -288,10 +289,10 @@ end function get_G_code
 !  speed of light in code units
 !+
 !---------------------------------------------------------------------------
-real(kind=8) function get_c_code() result(c_code)
+real function get_c_code() result(c_code)
  use physcon, only:c
 
- c_code = c*utime/udist
+ c_code = real(c*utime/udist)
 
 end function get_c_code
 
@@ -300,10 +301,10 @@ end function get_c_code
 !  radiation constant
 !+
 !---------------------------------------------------------------------------
-real(kind=8) function get_radconst_code() result(radconst_code)
+real function get_radconst_code() result(radconst_code)
  use physcon, only:radconst
 
- radconst_code = radconst/unit_energ*udist**3
+ radconst_code = real(radconst/unit_energ*udist**3)
 
 end function get_radconst_code
 
@@ -312,10 +313,10 @@ end function get_radconst_code
 !  speed of light in code units
 !+
 !---------------------------------------------------------------------------
-real(kind=8) function get_kbmh_code() result(kbmh_code)
+real function get_kbmh_code() result(kbmh_code)
  use physcon, only:kb_on_mh
 
- kbmh_code = kb_on_mh/unit_velocity**2
+ kbmh_code = real(kb_on_mh/unit_velocity**2)
 
 end function get_kbmh_code
 
@@ -326,7 +327,7 @@ end function get_kbmh_code
 !---------------------------------------------------------------------------
 logical function G_is_unity()
 
- G_is_unity = abs(get_G_code() - 1.d0) < 1.d-12
+ G_is_unity = abs(get_G_code() - 1.) < 1.e-12
 
 end function G_is_unity
 
@@ -337,7 +338,7 @@ end function G_is_unity
 !---------------------------------------------------------------------------
 logical function c_is_unity()
 
- c_is_unity = abs(get_c_code() - 1.d0) < 1.d-12
+ c_is_unity = abs(get_c_code() - 1.) < 1.e-12
 
 end function c_is_unity
 !---------------------------------------------------------------------------

--- a/src/main/utils_dumpfiles.f90
+++ b/src/main/utils_dumpfiles.f90
@@ -172,7 +172,6 @@ function get_dumpname(filename,id)
 
  write(get_dumpname,"(a,a5,i3.3)") trim(filename),'_part',id+1
 
- return
 end function get_dumpname
 
 !--------------------------------------------------------------------
@@ -191,7 +190,6 @@ subroutine skipblock(iunit,nums1,nums2,nums3,nums4,tagged,ierr)
  nskip = sum(nums1)+sum(nums2)+sum(nums3)+sum(nums4)
  call skip_arrays(iunit,nskip,tagged,ierr)
 
- return
 end subroutine skipblock
 
 !--------------------------------------------------------------------
@@ -313,6 +311,9 @@ subroutine extracthdr_int4(tag,val,hdr,ierr,default)
 
 end subroutine extracthdr_int4
 
+!-----------------------------------------------
+! extraction of single int*8 value from header
+!-----------------------------------------------
 subroutine extracthdr_int8(tag,val,hdr,ierr,default)
  character(len=*), intent(in)  :: tag
  integer(kind=8),  intent(out) :: val
@@ -342,6 +343,9 @@ subroutine extracthdr_int8(tag,val,hdr,ierr,default)
 
 end subroutine extracthdr_int8
 
+!-----------------------------------------------
+! extraction of single real*4 value from header
+!-----------------------------------------------
 subroutine extracthdr_real4(tag,val,hdr,ierr,default)
  character(len=*), intent(in)  :: tag
  real(kind=4),     intent(out) :: val
@@ -370,6 +374,9 @@ subroutine extracthdr_real4(tag,val,hdr,ierr,default)
  endif
 end subroutine extracthdr_real4
 
+!-----------------------------------------------
+! extraction of single real*8 value from header
+!-----------------------------------------------
 subroutine extracthdr_real8(tag,val,hdr,ierr,default)
  character(len=*), intent(in)  :: tag
  real(kind=8),     intent(out) :: val
@@ -381,7 +388,7 @@ subroutine extracthdr_real8(tag,val,hdr,ierr,default)
 
  if (present(default)) then
     def = default
-    rdef = default
+    rdef = real(default)
  else
     def = 0.d0
     rdef = 0.
@@ -425,6 +432,9 @@ subroutine extracthdr_int4arr(tag,val,hdr,ierr)
 
 end subroutine extracthdr_int4arr
 
+!------------------------------------------
+! extraction of int*8 arrays from header
+!------------------------------------------
 subroutine extracthdr_int8arr(tag,val,hdr,ierr)
  character(len=*), intent(in)  :: tag
  integer(kind=8),  intent(out) :: val(:)
@@ -445,6 +455,9 @@ subroutine extracthdr_int8arr(tag,val,hdr,ierr)
 
 end subroutine extracthdr_int8arr
 
+!------------------------------------------
+! extraction of real*4 arrays from header
+!------------------------------------------
 subroutine extracthdr_real4arr(tag,val,hdr,ierr)
  character(len=*), intent(in)  :: tag
  real(kind=4),     intent(out) :: val(:)
@@ -464,6 +477,9 @@ subroutine extracthdr_real4arr(tag,val,hdr,ierr)
  endif
 end subroutine extracthdr_real4arr
 
+!------------------------------------------
+! extraction of real*8 arrays from header
+!------------------------------------------
 subroutine extracthdr_real8arr(tag,val,hdr,ierr)
  character(len=*), intent(in)  :: tag
  real(kind=8),     intent(out) :: val(:)
@@ -1177,7 +1193,6 @@ subroutine open_dumpfile_r(iunit,filename,fileid,ierr,singleprec,requiretags)
     endif
  endif
 
- return
 end subroutine open_dumpfile_r
 
 !-------------------------------------------------------

--- a/src/main/utils_healpix.f90
+++ b/src/main/utils_healpix.f90
@@ -29,12 +29,12 @@ module healpix
 !
  implicit none
  character(len=*), parameter, public :: healpix_version = '3.80'
- integer, parameter, public :: i4b = SELECTED_INT_kind(9)
- integer, parameter, public :: i8b = SELECTED_INT_kind(16)
- integer, parameter, public :: i2b = SELECTED_INT_kind(4)
- integer, parameter, public :: i1b = SELECTED_INT_kind(2)
- integer, parameter, public :: sp  = SELECTED_REAL_kind(5,30)
- integer, parameter, public :: dp  = SELECTED_REAL_kind(12,200)
+ integer, parameter, public :: i4b = selected_int_kind(9)
+ integer, parameter, public :: i8b = selected_int_kind(16)
+ integer, parameter, public :: i2b = selected_int_kind(4)
+ integer, parameter, public :: i1b = selected_int_kind(2)
+ integer, parameter, public :: sp  = selected_real_kind(5,30)
+ integer, parameter, public :: dp  = selected_real_kind(12,200)
  integer, parameter, public :: lgt = kind(.TRUE.)
  integer, parameter, public :: spc = kind((1.0_sp, 1.0_sp))
  integer, parameter, public :: dpc = kind((1.0_dp, 1.0_dp))

--- a/src/main/utils_healpix.f90
+++ b/src/main/utils_healpix.f90
@@ -383,6 +383,7 @@ subroutine pix2vec_nest  (nside, ipix, vector, vertex)
     diff_phi = 0 ! phi_nv = phi_sv = phisth * 1}
     iphi_rat = (jp-1) / nr      ! in {0,1,2,3}
     iphi_mod = mod(jp-1,nr)
+    phi_up   = 0.
     if (nr > 1) phi_up = HALFPI * (iphi_rat +  iphi_mod   /real(nr-1))
     phi_dn             = HALFPI * (iphi_rat + (iphi_mod+1)/real(nr+1))
     if (jr < nside) then            ! North polar cap

--- a/src/main/utils_healpix.f90
+++ b/src/main/utils_healpix.f90
@@ -88,6 +88,7 @@ module healpix
  integer(i4b), parameter :: oddbits=89478485   ! 2^0 + 2^2 + 2^4+..+2^26
  integer(i4b), parameter :: evenbits=178956970 ! 2^1 + 2^3 + 2^4+..+2^27
  integer(kind=i4b), private, parameter :: ns_max=268435456! 2^28
+
 contains
 
 !! Returns i with even and odd bit positions interchanged.
@@ -137,10 +138,9 @@ subroutine vec2pix_nest  (nside, vector, ipix)
  real,              intent(in), dimension(1:) :: vector
  integer(kind=MKD), intent(out)               :: ipix
 
- integer(kind=MKD) :: ipf, scale, scale_factor
- real(kind=DP)     ::  z, za, tt, tp, tmp, dnorm, phi
- integer(kind=I4B) ::  jp, jm, ifp, ifm, face_num, &
- &     ix, iy, ix_low, iy_low, ntt, i, ismax
+ integer(kind=MKD) :: ipf,scale,scale_factor
+ real(kind=DP)     :: z,za,tt,tp,tmp,dnorm,phi
+ integer(kind=I4B) :: jp,jm,ifp,ifm,face_num,ix,iy,ix_low,iy_low,ntt,i,ismax
  character(len=*), parameter :: code = "vec2pix_nest"
 
  !-----------------------------------------------------------------------
@@ -227,7 +227,6 @@ subroutine vec2pix_nest  (nside, vector, ipix)
  endif
  ipix = ipf + face_num* int(nside,MKD) * nside    ! in {0, 12*nside**2 - 1}
 
- return
 end subroutine vec2pix_nest
 
 !=======================================================================
@@ -434,7 +433,6 @@ subroutine pix2vec_nest  (nside, ipix, vector, vertex)
     vertex(3,3) = z_sv
  endif
 
- return
 end subroutine pix2vec_nest
 
 !=======================================================================
@@ -480,7 +478,6 @@ function npix2nside  (npix) result(nside_result)
  endif
 
  nside_result = nside
- return
 
 end function npix2nside
 
@@ -508,17 +505,16 @@ function nside2npix(nside) result(npix_result)
  endif
  npix_result = npix
 
- return
 end function nside2npix
 
- !=======================================================================
- ! CHEAP_ISQRT
- !       Returns exact Floor(sqrt(x)) where x is a (64 bit) integer.
- !             y^2 <= x < (y+1)^2         (1)
- !       The double precision floating point operation is not accurate enough
- !       when dealing with 64 bit integers, especially in the vicinity of
- !       perfect squares.
- !=======================================================================
+!=======================================================================
+! CHEAP_ISQRT
+!       Returns exact Floor(sqrt(x)) where x is a (64 bit) integer.
+!             y^2 <= x < (y+1)^2         (1)
+!       The double precision floating point operation is not accurate enough
+!        when dealing with 64 bit integers, especially in the vicinity of
+!       perfect squares.
+!=======================================================================
 function cheap_isqrt(lin) result (lout)
  integer(i4b), intent(in) :: lin
  integer(i4b) :: lout
@@ -562,7 +558,6 @@ subroutine mk_pix2xy()
     pix2y(kpix) = IY     ! in 0,31
  enddo
 
- return
 end subroutine mk_pix2xy
  !=======================================================================
 subroutine mk_xy2pix1()
@@ -596,10 +591,8 @@ subroutine mk_xy2pix1()
           ip = ip*4
        endif
     enddo
-
  enddo
 
- return
 end subroutine mk_xy2pix1
 
 subroutine fatal_error (msg)
@@ -611,15 +604,18 @@ subroutine fatal_error (msg)
     print *,'Fatal error'
  endif
  call exit_with_status(1)
+
 end subroutine fatal_error
 
 ! ===========================================================
 subroutine exit_with_status (code, msg)
  integer(i4b), intent(in) :: code
  character (len=*), intent(in), optional :: msg
+
  if (present(msg)) print *,trim(msg)
  print *,'program exits with exit code ', code
  call exit (code)
+
 end subroutine exit_with_status
 
 !====================================================================
@@ -1053,7 +1049,6 @@ subroutine neighbours_nest(nside, ipix, n, nneigh)
     end select ! south
  endif
 
- return
 end subroutine neighbours_nest
 
 
@@ -1110,11 +1105,9 @@ subroutine pix2xy_nest  (nside, ipf_in, ix, iy)
     iy = iy + scale * pix2y(ipf) ! corrected 2012-08-27
  endif
 
- return
-
 end subroutine pix2xy_nest
 
-!  =======================================================================
+!=======================================================================
 !     gives the pixel number ipix (NESTED)
 !     corresponding to ix, iy and face_num
 !
@@ -1162,7 +1155,7 @@ subroutine xy2pix_nest(nside, ix_in, iy_in, face_num, ipix)
     ipf =  ipf + (x2pix1(ix)+y2pix1(iy)) * scale
  endif
  ipix = ipf + face_num* int(nside,MKD) * nside    ! in {0, 12*nside**2 - 1}
- return
+
 end subroutine xy2pix_nest
 
 end module healpix

--- a/src/main/utils_indtimesteps.F90
+++ b/src/main/utils_indtimesteps.F90
@@ -219,7 +219,7 @@ subroutine get_newbin(dti,dtmax,ibini,allow_decrease,limit_maxbin,dtchar)
  integer         :: ibin_newi
  logical         :: iallow_decrease,ilimit_maxbin
  real, parameter :: vsmall = epsilon(vsmall)
- real, parameter :: dlog2 = 1.4426950408889634d0 ! dlog2 = 1./log(2.)
+ real(kind=8), parameter :: dlog2 = 1.4426950408889634d0 ! dlog2 = 1./log(2.)
  character(len=12) :: str
 
  if (present(allow_decrease)) then
@@ -513,7 +513,7 @@ subroutine print_dtind_efficiency(iverbose,nalive,nmoved,tall,tlast,icall)
     if (nmoved==nalive .and. icall==1) then
        tall = tlast
     elseif (tall > 0.) then
-       fracactive = nmoved/real(nalive)
+       fracactive = real(nmoved)/real(nalive)
        speedup = tlast/tall
        if (speedup > 0.) then
           efficiency = 100.*fracactive/speedup

--- a/src/main/utils_indtimesteps.F90
+++ b/src/main/utils_indtimesteps.F90
@@ -47,7 +47,6 @@ pure real function get_dt(dtmax,ibini)
 
 end function get_dt
 
-#ifdef IND_TIMESTEPS
 !----------------------------------------------------------------
 !+
 !  If dt is read in from a dump file, then initialise ibin & ibin_old.
@@ -158,7 +157,6 @@ subroutine set_active_particles(npart,nactive,nalive,iphase,ibin,xyzh)
  endif
 
 end subroutine set_active_particles
-#endif
 
 !----------------------------------------------------------------
 !+

--- a/src/main/utils_raytracer.f90
+++ b/src/main/utils_raytracer.f90
@@ -372,7 +372,7 @@ end subroutine get_tau_on_ray
  !+
  !--------------------------------------------------------------------------
 subroutine ray_tracer(primary, ray, xyzh, kappa, Rstar, tau_along_ray, dist_along_ray, len, maxDistance)
- use units, only:umass,udist
+ use units, only:unit_opacity
  real, intent(in)     :: primary(3), ray(3), Rstar, xyzh(:,:), kappa(:)
  real, optional       :: maxDistance
  real, intent(out)    :: dist_along_ray(:), tau_along_ray(:)
@@ -400,11 +400,12 @@ subroutine ray_tracer(primary, ray, xyzh, kappa, Rstar, tau_along_ray, dist_alon
     dtaudr            = (nextdtaudr+previousdtaudr)/2.
     previousdtaudr    = nextdtaudr
     !fix units for tau (kappa is in cgs while rho & r are in code units)
-    tau_along_ray(i)  = tau_along_ray(i-1)+dr*dtaudr*umass/(udist**2)
+    tau_along_ray(i)  = tau_along_ray(i-1) + real(dr*dtaudr/unit_opacity)
     dist_along_ray(i) = distance
     dr                = next_dr
  enddo
  len = i
+
 end subroutine ray_tracer
 
 logical function hasNext(inext, tau, distance, maxDistance)

--- a/src/main/utils_spline.f90
+++ b/src/main/utils_spline.f90
@@ -58,7 +58,7 @@ subroutine spline_eval(nval, positions, values, nnew, new_positions, new_values)
 ! anything fancier should probably be handled in the caller.
     if (pt  <  positions(1) .or. pt  >  positions(nval)) then
        index         = -1
-       new_values(i) = 0d0
+       new_values(i) = 0.
     elseif (pt == positions(nval)) then
 ! Another special case, but this one is easy to deal with
        index         = -1
@@ -117,9 +117,9 @@ subroutine spline_coefficients(nval, values, coefficients)
  do i = 1, nval-1
     coefficients(1,i) = values(i)
     coefficients(2,i) = derivatives(i)
-    coefficients(3,i) = 3d0 * (values(i+1) - values(i)) - &
-                        2d0 * derivatives(i) - derivatives(i+1)
-    coefficients(4,i) = 2d0 * (values(i) - values(i+1)) +  &
+    coefficients(3,i) = 3. * (values(i+1) - values(i)) - &
+                        2. * derivatives(i) - derivatives(i+1)
+    coefficients(4,i) = 2. * (values(i) - values(i+1)) +  &
                         derivatives(i) + derivatives(i+1)
  enddo
 
@@ -158,21 +158,21 @@ subroutine spline_derivatives(nval, values, derivatives)
 
  do i = 1, nval
     do j = 1, nval+1
-       Cc(I,J) = 0d0
+       Cc(I,J) = 0.
     enddo
     if (i == 1) then
-       Cc(i,i)      = 2d0
-       Cc(i,i+1)    = 1d0
-       Cc(i,nval+1) = 3d0 * (values(2) - values(1))
+       Cc(i,i)      = 2.
+       Cc(i,i+1)    = 1.
+       Cc(i,nval+1) = 3. * (values(2) - values(1))
     elseif (i == nval) then
-       Cc(i,i-1)    = 1d0
-       Cc(i,i)      = 2d0
-       Cc(i,nval+1) = 3d0 * (values(nval) - values(nval-1))
+       Cc(i,i-1)    = 1.
+       Cc(i,i)      = 2.
+       Cc(i,nval+1) = 3. * (values(nval) - values(nval-1))
     else
-       Cc(i,i-1)    = 1d0
-       Cc(i,i)      = 4d0
-       Cc(i,i+1)    = 1d0
-       Cc(i,nval+1) = 3d0 * (values(i+1) - values(i-1))
+       Cc(i,i-1)    = 1.
+       Cc(i,i)      = 4.
+       Cc(i,i+1)    = 1.
+       Cc(i,nval+1) = 3. * (values(i+1) - values(i-1))
     endif
  enddo
 
@@ -189,7 +189,7 @@ subroutine spline_derivatives(nval, values, derivatives)
  derivatives(nval) = Cc(nval,nval+1) / Cc(nval,nval)
 
  do i = nval-1, 1, -1
-    sum = 0d0
+    sum = 0.
     do j = i+1, nval
        sum = sum + Cc(i,j) * derivatives(j)
     enddo

--- a/src/main/utils_supertimestep.F90
+++ b/src/main/utils_supertimestep.F90
@@ -42,9 +42,9 @@ module timestep_sts
 #endif
  integer,         parameter :: dtcoef_max   =   18    ! The maximum number of dtdiff coefficients (retest if changed)
  integer,         parameter :: ndtau_max    =  256    ! The maximum number Nsts*Nmega allowed
- real,            private   :: nu_min       =  1.0d-4 ! The minimum allowed nu (retest if changed)
+ real,            private   :: nu_min       =  1.0e-4 ! The minimum allowed nu (retest if changed)
  real,            private   :: sts_max_rat  = 20.0    ! The maximum ratio of dtau(1) to dtdiff (retest if changed)
- real,            public    :: bigdt        =  1.0d29 ! =bignumber; duplicated here to avoid continually passing it
+ real,            public    :: bigdt        =  1.0e29 ! =bignumber; duplicated here to avoid continually passing it
  !
  integer,         parameter :: iNosts       =  0      ! No super-timestepping required
  integer,         parameter :: iNsts        =  1      ! can use N \propto sqrt(dt/dtdiff)
@@ -190,15 +190,15 @@ pure subroutine sts_init_nu(nu_col,dtdiffcoef_in,ierr)
        nurat = tol*2.0
        ! Iterate
        do while (ctr < ctrmax .and. nurat > tol)
-          A     =                    (1.0d0+sqrt(nuold))**twoN
-          B     =                    (1.0d0-sqrt(nuold))**twoN
-          dAdnu =  realN/sqrt(nuold)*(1.0d0+sqrt(nuold))**(twoN-1)
-          dBdnu = -realN/sqrt(nuold)*(1.0d0-sqrt(nuold))**(twoN-1)
-          f     = 2.0d0*nuold**1.5*(A+B)*realN*dtdiffcoef_in - nuold*(A-B)
-          dfdnu = realN*sqrt(nuold)*dtdiffcoef_in*(3.0d0*(A+B)+2.0d0*nuold*(dAdnu+dBdnu))   &
+          A     =                    (1.+sqrt(nuold))**twoN
+          B     =                    (1.-sqrt(nuold))**twoN
+          dAdnu =  realN/sqrt(nuold)*(1.+sqrt(nuold))**(twoN-1)
+          dBdnu = -realN/sqrt(nuold)*(1.-sqrt(nuold))**(twoN-1)
+          f     = 2.*nuold**1.5*(A+B)*realN*dtdiffcoef_in - nuold*(A-B)
+          dfdnu = realN*sqrt(nuold)*dtdiffcoef_in*(3.*(A+B)+2.*nuold*(dAdnu+dBdnu))   &
                 - (A-B+nuold*(dAdnu-dBdnu))
           nunew = nuold - f/dfdnu
-          nurat = abs( 1.0d0 - nunew/nuold )
+          nurat = abs( 1. - nunew/nuold )
           nuold = nunew
           ctr   = ctr + 1
           if (nunew > 1.0 .or. nunew < epsilon(nunew)) then
@@ -470,7 +470,7 @@ pure function sts_get_dtau(j,N,nu0,dtdiff_in)
  real, parameter      :: pibytwo = 2.*atan(1.)
 
  sts_get_dtau = dtdiff_in /&
-                ((nu0-1.0d0)*cos(pibytwo*real(2*j-1)/real(N)) + 1.0d0+nu0)
+                ((nu0-1.)*cos(pibytwo*real(2*j-1)/real(N)) + 1.+nu0)
 
 end function sts_get_dtau
 !----------------------------------------------------------------

--- a/src/main/utils_tables.f90
+++ b/src/main/utils_tables.f90
@@ -19,6 +19,7 @@ module table_utils
  implicit none
 
  public :: yinterp, linspace, logspace, diff, flip_array, interpolator
+ public :: find_nearest_index, interp_1d
 
  private
 
@@ -27,7 +28,11 @@ contains
 !----------------------------------------------------
 !+
 !  Function to linearly interpolate values from
-!  from an array
+!  from an array. Given x it finds the position
+!  in the table of x values (xtab) and interpolates
+!  the value of y from the table of y values (ytab)
+!  to return the y value corresponding to the
+!  position x
 !+
 !----------------------------------------------------
 pure real function yinterp(ytab,xtab,x)
@@ -160,5 +165,47 @@ subroutine diff(array, darray)
  enddo
 
 end subroutine diff
+
+!-----------------------------------------------------------------------
+!+
+!  Find index of nearest lower value in array
+!+
+!-----------------------------------------------------------------------
+subroutine find_nearest_index(arr,val,indx)
+ real, intent(in)     :: arr(:), val
+ integer, intent(out) :: indx
+ integer              :: istart,istop,i
+
+ istart = 1
+ istop  = size(arr)
+ indx = istart
+ if (val >= arr(istop)) then
+    indx = istop-1   ! -1 to avoid array index overflow
+ elseif (val <= arr(istart)) then
+    indx = istart
+ else
+    i = istart
+    do while (i <= istop)
+       if (arr(i)>val) then
+          indx = i-1
+          exit
+       endif
+       i = i+1
+    enddo
+ endif
+
+end subroutine find_nearest_index
+
+!-----------------------------------------------------------------------
+!+
+!  1D linear interpolation routine
+!+
+!-----------------------------------------------------------------------
+real function interp_1d(x,x1,x2,y1,y2)
+ real, intent(in)  :: x, x1, x2, y1, y2
+
+ interp_1d = y1 + (x-x1)*(y2-y1)/(x2-x1)
+
+end function interp_1d
 
 end module table_utils

--- a/src/main/wind.F90
+++ b/src/main/wind.F90
@@ -15,7 +15,8 @@ module wind
 ! :Runtime parameters: None
 !
 ! :Dependencies: cooling_solver, dim, dust_formation, eos, io, options,
-!   part, physcon, ptmass_radiation, timestep, units, wind_equations
+!   part, physcon, ptmass_radiation, table_utils, timestep, units,
+!   wind_equations
 !
 
 !#define CALC_HYDRO_THEN_CHEM

--- a/src/main/wind.F90
+++ b/src/main/wind.F90
@@ -20,8 +20,8 @@ module wind
 
 !#define CALC_HYDRO_THEN_CHEM
 
- use part,only: n_nucleation,idJstar,idK0,idK1,idK2,idK3,idmu,idgamma,idsat,idkappa,idalpha
-
+ use part, only:n_nucleation,idJstar,idK0,idK1,idK2,idK3,idmu,idgamma,idsat,idkappa,idalpha
+ use dim,  only:isothermal
  implicit none
  public :: setup_wind
  public :: wind_state,save_windprofile,interp_wind_profile!,wind_profile
@@ -47,6 +47,7 @@ module wind
     integer :: spcode, nsteps
     logical :: dt_force, error, find_sonic_solution
  end type wind_state
+
 contains
 
 subroutine setup_wind(Mstar_cg, Mdot_code, u_to_T, r0, T0, v0, rsonic, tsonic, stype)
@@ -151,11 +152,11 @@ subroutine init_wind(r0, v0, T0, time_end, state)
  state%JKmuS(idgamma) = state%gamma
  state%dalpha_dr = 0.
  state%p = state%rho*Rg*state%Tg/state%mu
-#ifdef ISOTHERMAL
- state%u = 1.
-#else
- state%u = state%p/((state%gamma-1.)*state%rho)
-#endif
+ if (isothermal) then
+    state%u = 1.
+ else
+    state%u = state%p/((state%gamma-1.)*state%rho)
+ endif
  state%c = sqrt(state%gamma*Rg*state%Tg/state%mu)
  state%dt_force = .false.
  state%error    = .false.
@@ -223,9 +224,7 @@ subroutine wind_step(state)
 
  state%c    = sqrt(state%gamma*Rg*state%Tg/state%mu)
  state%p    = state%rho*Rg*state%Tg/state%mu
-#ifndef ISOTHERMAL
- state%u    = state%p/((state%gamma-1.)*state%rho)
-#endif
+ if (.not.isothermal) state%u    = state%p/((state%gamma-1.)*state%rho)
  !state%Tg   = state%p/(state%rho*Rg)*state%mu
 
  state%tau_lucy = state%tau_lucy &
@@ -328,9 +327,7 @@ subroutine wind_step(state)
  state%c    = sqrt(state%gamma*Rg*state%Tg/state%mu)
  state%rho  = Mdot_cgs/(4.*pi*state%r**2*state%v)
  state%p    = state%rho*Rg*state%Tg/state%mu
-#ifndef ISOTHERMAL
- state%u    = state%p/((state%gamma-1.)*state%rho)
-#endif
+ if (.not.isothermal) state%u    = state%p/((state%gamma-1.)*state%rho)
 
  if (idust_opacity == 2) then
     state%kappa = calc_kappa_dust(state%JKmuS(idK3), state%Tdust, state%rho)
@@ -440,9 +437,8 @@ subroutine wind_profile(local_time,r,v,u,rho,e,GM,T0,fdone,JKmuS)
  v   = state%v/unit_velocity
  rho = state%rho/unit_density
  !u = state%Tg * u_to_temperature_ratio
-#ifndef ISOTHERMAL
- u  = state%p/((state%gamma-1.)*rho)/unit_pressure
-#endif
+ if (.not.isothermal) u  = state%p/((state%gamma-1.)*rho)/unit_pressure
+
  e = .5*v**2 - GM/r + state%gamma*u
  if (idust_opacity == 2) then
     JKmuS(1:n_nucleation-1) = state%JKmuS(1:n_nucleation-1)
@@ -497,9 +493,7 @@ subroutine get_initial_wind_speed(r0, T0, v0, rsonic, tsonic, stype)
     print *, ' * Mstar      = ',Mstar_cgs/1.9891d33
     print *, ' * Twind      = ',T0
     print *, ' * Rstar(au)  = ',r0/1.496d13,r0/69600000000.
-#ifndef ISOTHERMAL
-    print *, ' * gamma      = ',gamma
-#endif
+    if (.not.isothermal) print *, ' * gamma      = ',gamma
     print *, ' * mu         = ',gmw
     print *, ' * cs  (km/s) = ',cs/1e5
     print *, ' * vesc(km/s) = ',vesc/1e5
@@ -725,10 +719,11 @@ end subroutine get_initial_radius
 !-----------------------------------------------------------------------
 subroutine interp_wind_profile(time, local_time, r, v, u, rho, e, GM, fdone, JKmuS)
  !in/out variables in code units (except Jstar,K)
- use units,    only:udist, utime, unit_velocity, unit_density, unit_ergg
+ use units,          only:udist,utime,unit_velocity,unit_density,unit_ergg
  use dust_formation, only:idust_opacity
- use part,     only:idgamma
- use eos,      only:gamma
+ use part,           only:idgamma
+ use eos,            only:gamma
+ use table_utils,    only:find_nearest_index,interp_1d
 
  real, intent(in)  :: time, local_time, GM
  !real, intent(inout) :: r, v
@@ -743,11 +738,11 @@ subroutine interp_wind_profile(time, local_time, r, v, u, rho, e, GM, fdone, JKm
 
  r   = interp_1d(ltime,trvurho_1D(1,indx),trvurho_1D(1,indx+1),trvurho_1D(2,indx),trvurho_1D(2,indx+1))/udist
  v   = interp_1d(ltime,trvurho_1D(1,indx),trvurho_1D(1,indx+1),trvurho_1D(3,indx),trvurho_1D(3,indx+1))/unit_velocity
-#ifndef ISOTHERMAL
- u   = interp_1d(ltime,trvurho_1D(1,indx),trvurho_1D(1,indx+1),trvurho_1D(4,indx),trvurho_1D(4,indx+1))/unit_ergg
-#else
- u   = 0.
-#endif
+ if (isothermal) then
+    u = 0.
+ else
+    u = interp_1d(ltime,trvurho_1D(1,indx),trvurho_1D(1,indx+1),trvurho_1D(4,indx),trvurho_1D(4,indx+1))/unit_ergg
+ endif
  rho = interp_1d(ltime,trvurho_1D(1,indx),trvurho_1D(1,indx+1),trvurho_1D(5,indx),trvurho_1D(5,indx+1))/unit_density
 
  if (idust_opacity == 2) then
@@ -766,46 +761,8 @@ subroutine interp_wind_profile(time, local_time, r, v, u, rho, e, GM, fdone, JKm
  else
     fdone = ltime/(local_time*utime)
  endif
+
 end subroutine interp_wind_profile
-
-!-----------------------------------------------------------------------
-!+
-!  Find index of nearest lower value in array
-!+
-!-----------------------------------------------------------------------
-subroutine find_nearest_index(arr,val,indx)
- real, intent(in)     :: arr(:), val
- integer, intent(out) :: indx
- integer              :: istart,istop,i
-
- istart = 1
- istop  = size(arr)
- if (val >= arr(istop)) then
-    indx = istop-1   ! -1 to avoid array index overflow
- elseif (val <= arr(istart)) then
-    indx = istart
- else
-    i = istart
-    do while (i <= istop)
-       if (arr(i)>val) then
-          indx = i-1
-          exit
-       endif
-       i = i+1
-    enddo
- endif
-end subroutine find_nearest_index
-
-!-----------------------------------------------------------------------
-!+
-!  1D linear interpolation routine
-!+
-!-----------------------------------------------------------------------
-real function interp_1d(x,x1,x2,y1,y2)
- real, intent(in)  :: x, x1, x2, y1, y2
-
- interp_1d = y1 + (x-x1)*(y2-y1)/(x2-x1)
-end function interp_1d
 
 !-----------------------------------------------------------------------
 !
@@ -842,7 +799,7 @@ subroutine save_windprofile(r0, v0, T0, rout, tend, tcross, filename)
 
  eps       = 0.01
  iter      = 0
- itermax   = int(huge(itermax)/10) !this number is huge but may be needed for RK6 solver
+ itermax   = int(huge(itermax)/10.) !this number is huge but may be needed for RK6 solver
  tcross    = 1.d99
  writeline = 0
 
@@ -902,6 +859,7 @@ subroutine save_windprofile(r0, v0, T0, rout, tend, tcross, filename)
     JKmuS_1D(:,:) = JKmuS_temp(:,1:writeline)
     deallocate(JKmuS_temp)
  endif
+
 end subroutine save_windprofile
 
 subroutine filewrite_header(iunit,nwrite)
@@ -934,6 +892,7 @@ subroutine filewrite_header(iunit,nwrite)
        write(iunit,'('// adjustl(fmt) //'(a12))') 't','r','v','T','c','p','u','rho','alpha','a','mu','kappa','gamma'
     endif
  endif
+
 end subroutine filewrite_header
 
 subroutine state_to_array(state,nwrite, array)
@@ -971,6 +930,7 @@ subroutine state_to_array(state,nwrite, array)
     array(13) = state%gamma
  endif
  if (icooling > 0) array(nwrite) = state%Q
+
 end subroutine state_to_array
 
 subroutine filewrite_state(iunit,nwrite, state)
@@ -984,7 +944,7 @@ subroutine filewrite_state(iunit,nwrite, state)
  write(fmt,*) nwrite
  write(iunit,'('// adjustl(fmt) //'(1x,es11.3E3:))') array(1:nwrite)
 !  write(iunit, '(22(1x,es11.3E3:))') array(1:nwrite)
-end subroutine filewrite_state
 
+end subroutine filewrite_state
 
 end module wind

--- a/src/setup/phantomsetup.F90
+++ b/src/setup/phantomsetup.F90
@@ -42,9 +42,6 @@ program phantomsetup
  use fileutils,       only:strip_extension
  use gravwaveutils,   only:calc_gravitwaves
  use systemutils,     only:get_command_option
-#ifdef LIGHTCURVE
- use part,            only:luminosity,maxlum,lightcurve
-#endif
 #ifdef KROME
  use krome_interface, only:write_KromeSetupFile
 #endif
@@ -119,7 +116,7 @@ program phantomsetup
     call init_domains(nprocs)
     nprocsfake = 1
  else ! non-mpi
-    nprocsfake = get_command_option('nprocsfake',default=1)
+    nprocsfake = int(get_command_option('nprocsfake',default=1))
     nprocs= nprocsfake
     print*,' nprocs = ',nprocs
     call init_domains(nprocs)

--- a/src/setup/setup_asteroidwind.f90
+++ b/src/setup/setup_asteroidwind.f90
@@ -6,9 +6,11 @@
 !--------------------------------------------------------------------------!
 module setup
 !
-! None
+! Wind from an evaporating/disintegrating asteroid, as used
+! in Trevascus et al. (2021)
 !
-! :References: None
+! :References:
+!   Trevascus et al. (2021), MNRAS 505, L21-L25
 !
 ! :Owner: David Liptai
 !
@@ -31,7 +33,7 @@ module setup
  implicit none
  public :: setpart
 
- real :: m1,m2,ecc,semia,hacc1,rasteroid,norbits,gastemp,gastemp0
+ real :: m1,m2,ecc,semia,hacc1,rasteroid,norbits,gastemp
  integer :: npart_at_end,dumpsperorbit,ipot
 
  private
@@ -42,7 +44,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use part,      only:nptmass,xyzmh_ptmass,vxyz_ptmass,ihacc,ihsoft,idust,set_particle_type,igas
  use setbinary, only:set_binary,get_a_from_period
  use spherical, only:set_sphere
- use units,     only:set_units,umass,udist,utime,unit_velocity
+ use units,     only:set_units,umass,udist,unit_velocity
  use physcon,   only:solarm,au,pi,solarr,ceresm,km,kboltz,mass_proton_cgs
  use externalforces,   only:iext_binary, iext_einsteinprec, update_externalforce, &
                             mass1,accradius1
@@ -64,7 +66,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  character(len=120) :: filename
  integer :: ierr
  logical :: iexist
- real    :: period,hacc2,temperature_coef,dtinj
+ real    :: period,hacc2,temperature_coef
  real    :: rp
 !
 !--Default runtime parameters (values for SDSS J1228+1040)
@@ -173,7 +175,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
     xyzmh_ptmass(ihsoft,1) = rasteroid    ! asteroid radius softening
  endif
 
- ! both        of these are reset in the first        call to        inject_particles
+ ! both of these are reset in the first call to inject_particles
  !massoftype(igas) = tmax*mdot/(umass/utime)/npart_at_end
  massoftype(igas) = 1.e-12
  hfact = 1.2

--- a/src/setup/setup_common.f90
+++ b/src/setup/setup_common.f90
@@ -31,8 +31,9 @@ contains
 subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,time,fileprefix)
  use part,      only:nptmass,xyzmh_ptmass,vxyz_ptmass,ihacc,ihsoft
  use setbinary, only:set_binary
- use units,     only:umass,utime,udist,set_units
+ use units,     only:umass,udist,set_units
  use physcon,   only:au,solarm,solarr
+ use kernal,    only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -50,7 +51,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
 !--general parameters
 !
  time = 0.
- hfact = 1.2
+ hfact = hfact_default
  polyk = 0.
  gamma = 1.
 !

--- a/src/setup/setup_common.f90
+++ b/src/setup/setup_common.f90
@@ -33,7 +33,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use setbinary, only:set_binary
  use units,     only:umass,udist,set_units
  use physcon,   only:au,solarm,solarr
- use kernal,    only:hfact_default
+ use kernel,    only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)

--- a/src/setup/setup_disc.f90
+++ b/src/setup/setup_disc.f90
@@ -1387,6 +1387,8 @@ subroutine planet_atmosphere(id,npart,xyzh,vxyzu,npartoftype,gamma,hfact)
     npart_disc = npart
  endif
 
+ itype = igas
+
  !--set up an atmosphere around one of the binary masses (i.e. planet)
  if (surface_force .and. npart_planet_atm > 0) then
     call set_planet_atm(id,xyzh,vxyzu,npartoftype,maxvxyzu,itype,a0,R_in(1), &
@@ -1409,7 +1411,7 @@ end subroutine planet_atmosphere
 subroutine set_planet_atm(id,xyzh,vxyzu,npartoftype,maxvxyzu,itype,a0,R_in, &
                           HoverR,Mstar,q_index,gamma,Ratm_in,Ratm_out,r_surface, &
                           npart,npart_planet_atm,npart_disc,hfact)
- use part,          only:set_particle_type
+ use part,          only:set_particle_type,igas
  use spherical,     only:set_sphere,rho_func
  integer, intent(in)    :: id
  real,    intent(inout) :: xyzh(:,:)
@@ -1431,7 +1433,6 @@ subroutine set_planet_atm(id,xyzh,vxyzu,npartoftype,maxvxyzu,itype,a0,R_in, &
  integer, intent(inout) :: npart_disc
  real,    intent(in)    :: hfact
 
- integer, parameter :: igas = 1
  integer(kind=8)    :: nptot
  integer            :: i,nx
  real               :: xyz_orig(3)
@@ -1463,10 +1464,10 @@ subroutine set_planet_atm(id,xyzh,vxyzu,npartoftype,maxvxyzu,itype,a0,R_in, &
                  np_requested=npart_planet_atm,xyz_origin=xyz_orig)
 
  npart_planet_atm = npart-npart_disc
- npartoftype(1) = npart
+ npartoftype(igas) = npart
  do i=npart_disc+1,npart
     !--set the particle type for the atmosphere particles
-    call set_particle_type(i,1)
+    call set_particle_type(i,itype)
     !--------------------------------------------------------------------------
     !  Set thermal energy
     !  utherm generally should not be stored

--- a/src/setup/setup_jadvect.f90
+++ b/src/setup/setup_jadvect.f90
@@ -33,11 +33,11 @@ contains
 !+
 !----------------------------------------------------------------
 subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,time,fileprefix)
- use dim,          only:maxp,maxvxyzu
+ use dim,          only:maxvxyzu
  use setup_params, only:rhozero,ihavesetupB
  use slab,         only:set_slab
  use boundary,     only:dxbound,dybound,dzbound
- use part,         only:Bxyz,mhd
+ use part,         only:Bxyz,mhd,igas
  use io,           only:master
  use prompting,    only:prompt
  use mpiutils,     only:bcast_mpi
@@ -74,9 +74,9 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  uuzero = przero/(gam1*rhozero)
 
  print "(/,a)",' Three dimensional current loop advection problem '
- print 10, Azero,rloop,rhozero,przero
-10 format(/,' Azero   = ',f6.3,', radius of loop = ',f6.3,/,&
-            ' density = ',f6.3,',       pressure = ',f6.3,/)
+ print "(/,' Azero   = ',f6.3,', radius of loop = ',f6.3,/,"// &
+          "' density = ',f6.3,',       pressure = ',f6.3,/)",&
+       Azero,rloop,rhozero,przero
 
  if (maxvxyzu < 4) then
     polyk = przero/rhozero**gamma
@@ -92,11 +92,11 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
 !
  call set_slab(id,master,nx,-1.,1.,-0.5,0.5,deltax,hfact,npart,xyzh)
  npartoftype(:) = 0
- npartoftype(1) = npart
+ npartoftype(igas) = npart
 
  totmass = rhozero*dxbound*dybound*dzbound
  massoftype = totmass/npart
- print*,'npart = ',npart,' particle mass = ',massoftype(1)
+ print*,'npart = ',npart,' particle mass = ',massoftype(igas)
 
  costheta = dxbound/sqrt(dxbound**2 + dybound**2)
  sintheta = dybound/sqrt(dxbound**2 + dybound**2)

--- a/src/setup/setup_nsdisc.f90
+++ b/src/setup/setup_nsdisc.f90
@@ -30,7 +30,7 @@ contains
 !----------------------------------------------------------------
 subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,time,fileprefix)
  use setdisc, only:set_disc
- use units,   only:udist, umass, utime, set_units
+ use units,   only:udist,umass,set_units
  use physcon, only:solarm,km
  use io,      only:master
  use externalforces, only:accradius1,mass1,iext_prdrag
@@ -93,7 +93,6 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  accradius1 = R_in
  mass1 = Mstar
 
- return
 end subroutine setpart
 
 end module setup

--- a/src/setup/setup_wind.F90
+++ b/src/setup/setup_wind.F90
@@ -6,9 +6,10 @@
 !--------------------------------------------------------------------------!
 module setup
 !
-! this module does setup
+! initial conditions for binary wind accretion / AGB star wind injection
 !
-! :References: None
+! :References:
+!   Siess et al.
 !
 ! :Owner: Lionel Siess
 !
@@ -47,81 +48,80 @@ module setup
 ! :Dependencies: eos, infile_utils, inject, io, part, physcon, prompting,
 !   setbinary, spherical, units
 !
-
-
-!   incl,posang_ascnode, arg_peri, omega_corotate, f, verbose not needed but may be included
-
-!
-! :Dependencies: eos, infile_utils, inject, io, part, physcon, prompting,
-!   setbinary, spherical, units
-!
-
+ use dim, only:isothermal
  implicit none
  public :: setpart
 
  private
- real, public :: wind_gamma    = 5./3.
-#ifdef ISOTHERMAL
- real, public :: T_wind        = 30000.
- real :: temp_exponent         = 0.5
- ! real :: primary_racc_au       = 0.465
- ! real :: primary_mass_msun     = 1.5
- ! real :: primary_lum_lsun      = 0.
- ! real :: primary_Reff_au       = 0.465240177008 !100 Rsun
-#else
- real, public :: T_wind = 3000.
- !real :: primary_racc_au       = 1.
- !real :: primary_mass_msun     = 1.5
- !real :: primary_lum_lsun      = 20000.
- !real :: primary_Reff_au       = 0.
-#endif
- integer :: icompanion_star = 0
- integer :: iwind
- real :: semi_major_axis       = 4.0
- real :: eccentricity          = 0.
- real :: primary_Teff          = 3000.
- real :: secondary_Teff        = 0.
- real :: semi_major_axis_au    = 4.0
- real :: default_particle_mass = 1.e-11
- real :: primary_lum_lsun      = 5315.
- real :: primary_mass_msun     = 1.5
- real :: primary_Reff_au       = 1.
- real :: primary_racc_au       = 1.
- real :: secondary_lum_lsun    = 0.
- real :: secondary_mass_msun   = 1.0
- real :: secondary_Reff_au     = 0.
- real :: secondary_racc_au     = 0.1
- real :: lum2a_lsun            = 0.
- real :: lum2b_lsun            = 0.
- real :: Teff2a                = 0.
- real :: Teff2b                = 0.
- real :: Reff2a_au             = 0.
- real :: Reff2b_au             = 0.
- real :: binary2_a_au          = 0.3
- real :: racc2a_au             = 0.1
- real :: racc2b_au             = 0.1
- real :: binary2_i             = 0.
- real :: primary_Reff
- real :: primary_lum
- real :: primary_mass
- real :: primary_racc
- real :: secondary_Reff
- real :: secondary_lum
- real :: secondary_mass
- real :: secondary_racc
- real :: Reff2a
- real :: Reff2b
- real :: racc2a
- real :: racc2b
- real :: lum2a
- real :: lum2b
- real :: q2
+ real, public :: wind_gamma
+ real, public :: T_wind
+ real :: temp_exponent
+ integer :: icompanion_star,iwind
+ real :: semi_major_axis,semi_major_axis_au,eccentricity
+ real :: default_particle_mass
+ real :: primary_lum_lsun,primary_mass_msun,primary_Reff_au,primary_racc_au
+ real :: secondary_lum_lsun,secondary_mass_msun,secondary_Reff_au,secondary_racc_au
+ real :: lum2a_lsun,lum2b_lsun,Teff2a,Teff2b,Reff2a_au,Reff2b_au
+ real :: binary2_a_au,racc2a_au,racc2b_au,binary2_i,q2
+ real :: primary_Reff,primary_Teff,primary_lum,primary_mass,primary_racc
+ real :: secondary_Reff,secondary_Teff,secondary_lum,secondary_mass,secondary_racc
+ real :: Reff2a,Reff2b
+ real :: racc2a,racc2b
+ real :: lum2a,lum2b
  real :: binary2_a
  real :: binary2_e
  integer :: subst
 
-
 contains
+!----------------------------------------------------------------
+!+
+!  default parameter choices
+!+
+!----------------------------------------------------------------
+subroutine set_default_parameters_wind()
+
+ wind_gamma    = 5./3.
+ if (isothermal) then
+    T_wind        = 30000.
+    temp_exponent         = 0.5
+    ! primary_racc_au       = 0.465
+    ! primary_mass_msun     = 1.5
+    ! primary_lum_lsun      = 0.
+    ! primary_Reff_au       = 0.465240177008 !100 Rsun
+ else
+    T_wind = 3000.
+    !primary_racc_au       = 1.
+    !primary_mass_msun     = 1.5
+    !primary_lum_lsun      = 20000.
+    !primary_Reff_au       = 0.
+ endif
+ icompanion_star = 0
+ semi_major_axis       = 4.0
+ eccentricity          = 0.
+ primary_Teff          = 3000.
+ secondary_Teff        = 0.
+ semi_major_axis_au    = 4.0
+ default_particle_mass = 1.e-11
+ primary_lum_lsun      = 5315.
+ primary_mass_msun     = 1.5
+ primary_Reff_au       = 1.
+ primary_racc_au       = 1.
+ secondary_lum_lsun    = 0.
+ secondary_mass_msun   = 1.0
+ secondary_Reff_au     = 0.
+ secondary_racc_au     = 0.1
+ lum2a_lsun            = 0.
+ lum2b_lsun            = 0.
+ Teff2a                = 0.
+ Teff2b                = 0.
+ Reff2a_au             = 0.
+ Reff2b_au             = 0.
+ binary2_a_au          = 0.3
+ racc2a_au             = 0.1
+ racc2b_au             = 0.1
+ binary2_i             = 0.
+
+end subroutine set_default_parameters_wind
 
 !----------------------------------------------------------------
 !+
@@ -151,6 +151,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  logical :: iexist
 
  call set_units(dist=au,mass=solarm,G=1.)
+ call set_default_parameters_wind()
 !
 !--general parameters
 !
@@ -269,20 +270,20 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  !
  massoftype(igas) = default_particle_mass * (solarm / umass)
 
-#ifdef ISOTHERMAL
- gamma = 1.
- if (iwind == 3) then
-    ieos = 6
-    qfacdisc = 0.5*temp_exponent
-    isink = 1
-    T_wind = primary_Teff
+ if (isothermal) then
+    gamma = 1.
+    if (iwind == 3) then
+       ieos = 6
+       qfacdisc = 0.5*temp_exponent
+       isink = 1
+       T_wind = primary_Teff
+    else
+       isink = 1
+       ieos = 1
+    endif
  else
-    isink = 1
-    ieos = 1
+    gamma = wind_gamma
  endif
-#else
- gamma = wind_gamma
-#endif
  polyk = kboltz*T_wind/(mass_proton_cgs * gmw * unit_velocity**2)
 
 end subroutine setpart
@@ -299,16 +300,16 @@ subroutine setup_interactive()
  use io,        only:fatal
  integer :: ichoice
 
-#ifdef ISOTHERMAL
- iwind = 2
-#else
- iwind = 1
- call prompt('Type of wind:  1=adia, 2=isoT, 3=T(r)',iwind,1,3)
- if (iwind == 2 .or. iwind == 3) then
-    call fatal('setup','If you choose options 2 or 3, the code must be compiled with SETUP=isowind')
+ if (isothermal) then
+    iwind = 2
+ else
+    iwind = 1
+    call prompt('Type of wind:  1=adia, 2=isoT, 3=T(r)',iwind,1,3)
+    if (iwind == 2 .or. iwind == 3) then
+       call fatal('setup','If you choose options 2 or 3, the code must be compiled with SETUP=isowind')
+    endif
+    if (iwind == 3) T_wind = primary_Teff
  endif
- if (iwind == 3) T_wind = primary_Teff
-#endif
 
  icompanion_star = 1
  call prompt('Add binary?',icompanion_star,0,2)
@@ -668,17 +669,17 @@ subroutine write_setupfile(filename)
  endif
  call write_inopt(default_particle_mass,'mass_of_particles','particle mass (Msun, overwritten if iwind_resolution <>0)',iunit)
 
-#ifdef ISOTHERMAL
- wind_gamma = 1.
- if (iwind == 3) then
-    call write_inopt(primary_Teff,'T_wind','wind temperature at injection radius (K)',iunit)
-    call write_inopt(temp_exponent,'temp_exponent','temperature profile T(r) = T_wind*(r/Reff)^(-temp_exponent)',iunit)
+ if (isothermal) then
+    wind_gamma = 1.
+    if (iwind == 3) then
+       call write_inopt(primary_Teff,'T_wind','wind temperature at injection radius (K)',iunit)
+       call write_inopt(temp_exponent,'temp_exponent','temperature profile T(r) = T_wind*(r/Reff)^(-temp_exponent)',iunit)
+    else
+       call write_inopt(T_wind,'T_wind','wind temperature (K)',iunit)
+    endif
  else
-    call write_inopt(T_wind,'T_wind','wind temperature (K)',iunit)
+    call write_inopt(wind_gamma,'wind_gamma','adiabatic index (initial if Krome chemistry used)',iunit)
  endif
-#else
- call write_inopt(wind_gamma,'wind_gamma','adiabatic index (initial if Krome chemistry used)',iunit)
-#endif
  close(iunit)
 
 end subroutine write_setupfile
@@ -770,13 +771,14 @@ subroutine read_setupfile(filename,ierr)
 
  endif
  call read_inopt(default_particle_mass,'mass_of_particles',db,min=0.,errcount=nerr)
-#ifdef ISOTHERMAL
- wind_gamma = 1.
- call read_inopt(T_wind,'T_wind',db,min=0.,errcount=nerr)
- if (iwind == 3) call read_inopt(temp_exponent,'temp_exponent',db,min=0.,max=5.,errcount=nerr)
-#else
- call read_inopt(wind_gamma,'wind_gamma',db,min=1.,max=4.,errcount=nerr)
-#endif
+
+ if (isothermal) then
+    wind_gamma = 1.
+    call read_inopt(T_wind,'T_wind',db,min=0.,errcount=nerr)
+    if (iwind == 3) call read_inopt(temp_exponent,'temp_exponent',db,min=0.,max=5.,errcount=nerr)
+ else
+    call read_inopt(wind_gamma,'wind_gamma',db,min=1.,max=4.,errcount=nerr)
+ endif
  call close_db(db)
  if (primary_Teff == 0. .and. primary_lum_lsun > 0. .and. primary_Reff > 0.) then
     ichange = ichange+1
@@ -806,4 +808,5 @@ subroutine read_setupfile(filename,ierr)
  call write_setupfile(filename)
 
 end subroutine read_setupfile
+
 end module setup

--- a/src/setup/setup_wind.F90
+++ b/src/setup/setup_wind.F90
@@ -45,8 +45,8 @@ module setup
 !   - temp_exponent     : *temperature profile T(r) = T_wind*(r/Reff)^(-temp_exponent)*
 !   - wind_gamma        : *adiabatic index (initial if Krome chemistry used)*
 !
-! :Dependencies: eos, infile_utils, inject, io, part, physcon, prompting,
-!   setbinary, spherical, units
+! :Dependencies: dim, eos, infile_utils, inject, io, part, physcon,
+!   prompting, setbinary, spherical, units
 !
  use dim, only:isothermal
  implicit none

--- a/src/tests/test_dust.F90
+++ b/src/tests/test_dust.F90
@@ -28,11 +28,7 @@ module testdust
  implicit none
  public :: test_dust
 
-#ifdef DUST
-#ifdef DUSTGROWTH
  public :: test_dustybox
-#endif
-#endif
 
  private
 
@@ -44,7 +40,6 @@ contains
 !+
 !--------------------------------------------
 subroutine test_dust(ntests,npass)
-#ifdef DUST
  use dust,        only:idrag,init_drag,get_ts
  use set_dust,    only:set_dustbinfrac
  use physcon,     only:solarm,au
@@ -54,16 +49,17 @@ subroutine test_dust(ntests,npass)
  use mpiutils,    only:barrier_mpi
  use options,     only:use_dustfrac
  use table_utils, only:logspace
-#ifdef DUSTGROWTH
  use growth,      only:init_growth
-#endif
-#endif
  integer, intent(inout) :: ntests,npass
-#ifdef DUST
  integer :: nfailed(3),ierr,iregime
  real    :: rhoi,rhogasi,rhodusti,spsoundi,tsi,grainsizei,graindensi
 
- if (id==master) write(*,"(/,a)") '--> TESTING DUST MODULE'
+ if (use_dust) then
+    if (id==master) write(*,"(/,a)") '--> TESTING DUST MODULE'
+ else
+    if (id==master) write(*,"(/,a)") '--> SKIPPING DUST TEST (REQUIRES -DDUST)'
+    return
+ endif
 
  call set_units(mass=solarm,dist=au,G=1.d0)
 
@@ -120,13 +116,9 @@ subroutine test_dust(ntests,npass)
  call barrier_mpi()
 
  if (id==master) write(*,"(/,a)") '<-- DUST TEST COMPLETE'
-#else
- if (id==master) write(*,"(/,a)") '--> SKIPPING DUST TEST (REQUIRES -DDUST)'
-#endif
 
 end subroutine test_dust
 
-#ifdef DUST
 !----------------------------------------------------
 !+
 !  Dustybox test from Laibe & Price (2011, 2012a,b)
@@ -146,28 +138,21 @@ subroutine test_dustybox(ntests,npass)
  use dust,           only:K_code,idrag
  use options,        only:alpha,alphamax
  use unifdis,        only:set_unifdis
- use dim,            only:periodic,mhd,use_dust
+ use dim,            only:periodic,mhd,use_dust,use_dustgrowth
  use timestep,       only:dtmax
  use io,             only:iverbose
  use mpiutils,       only:reduceall_mpi
  use kernel,         only:kernelname
  use mpidomain,      only:i_belong
-#ifdef DUSTGROWTH
- use part,           only:dustgasprop,dustprop
+ use part,           only:dustgasprop
  use growth,         only:ifrag
-#endif
  integer, intent(inout) :: ntests,npass
  integer(kind=8) :: npartoftypetot(maxtypes)
  integer :: nx, itype, npart_previous, i, j, nsteps
  real :: deltax, dz, hfact, totmass, rhozero
-#ifdef DUSTGROWTH
- integer         :: ncheck(6), nerr(6)
+ integer         :: ncheck(6),nerr(6)
  real            :: errmax(6)
  real, parameter :: toldv = 2.e-4
-#else
- integer :: ncheck(5), nerr(5)
- real    :: errmax(5)
-#endif
  real :: t, dt, dtext, dtnew
  real :: vg, vd, deltav, ekin_exact, fd
  real :: tol,tolvg,tolfg,tolfd
@@ -185,9 +170,7 @@ subroutine test_dustybox(ntests,npass)
     return
  endif
 
-#ifdef DUSTGROWTH
- if (id==master) write(*,"(/,a)") '--> Adding dv interpolation test'
-#endif
+ if (use_dustgrowth .and. id==master) write(*,"(/,a)") '--> Adding dv interpolation test'
 
  !
  ! setup for dustybox problem
@@ -240,9 +223,7 @@ subroutine test_dustybox(ntests,npass)
  K_code = 0.35
  ieos = 1
  idrag = 2
-#ifdef DUSTGROWTH
- ifrag = -1
-#endif
+ if (use_dustgrowth) ifrag = -1
  polyk = 1.
  gamma = 1.
  alpha = 0.
@@ -278,9 +259,9 @@ subroutine test_dustybox(ntests,npass)
        if (iamdust(iphase(j))) then
           call checkvalbuf(vxyzu(1,j),vd,tol,'vd',nerr(1),ncheck(1),errmax(1))
           call checkvalbuf(fxyzu(1,j),fd,tolfd,'fd',nerr(2),ncheck(2),errmax(2))
-#ifdef DUSTGROWTH
-          call checkvalbuf(dustgasprop(4,j),deltav,toldv,'dv',nerr(6),ncheck(6),errmax(6))
-#endif
+          if (use_dustgrowth) then
+             call checkvalbuf(dustgasprop(4,j),deltav,toldv,'dv',nerr(6),ncheck(6),errmax(6))
+          endif
        else
           call checkvalbuf(vxyzu(1,j),vg,tolvg,'vg',nerr(3),ncheck(3),errmax(3))
           call checkvalbuf(fxyzu(1,j),-fd,tolfg,'fg',nerr(4),ncheck(4),errmax(4))
@@ -296,15 +277,15 @@ subroutine test_dustybox(ntests,npass)
  call checkvalbuf_end('gas velocities match exact solution',ncheck(3),nerr(3),errmax(3),tolvg)
  call checkvalbuf_end('gas accel matches exact solution',   ncheck(4),nerr(4),errmax(4),tolfg)
  call checkvalbuf_end('kinetic energy decay matches exact',ncheck(5),nerr(5),errmax(5),tol)
-#ifdef DUSTGROWTH
- call checkvalbuf_end('interpolated dv matches exact solution',ncheck(6),nerr(6),errmax(6),toldv)
-#endif
+ if (use_dustgrowth) then
+    call checkvalbuf_end('interpolated dv matches exact solution',ncheck(6),nerr(6),errmax(6),toldv)
+ endif
 
-#ifdef DUSTGROWTH
- call update_test_scores(ntests,nerr(1:6),npass)
-#else
- call update_test_scores(ntests,nerr(1:5),npass)
-#endif
+ if (use_dustgrowth) then
+    call update_test_scores(ntests,nerr(1:6),npass)
+ else
+    call update_test_scores(ntests,nerr(1:5),npass)
+ endif
 
 end subroutine test_dustybox
 
@@ -767,7 +748,5 @@ subroutine write_file(time,xyzh,dustfrac,npart)
  close(lu)
 
 end subroutine write_file
-
-#endif
 
 end module testdust

--- a/src/tests/test_eos_stratified.f90
+++ b/src/tests/test_eos_stratified.f90
@@ -16,16 +16,16 @@ module testeos_stratified
 !
 ! :Dependencies: eos, io, physcon, testutils, units
 !
-
  use testutils,     only:checkval,update_test_scores,checkvalbuf,checkvalbuf_end
- !use units,         only:set_units,unit_density
-
  implicit none
  public :: test_eos_stratified
+ public :: map_stratified_temps ! to avoid compiler warning
 
  integer, parameter :: n = 5, nr = 700, nz = 210
+ !
  ! Parameters are found using the fits from Law et al. 2021
  ! Disc order: HD 1632996, IM Lup, GM Aur, AS 209, MWC 480
+ !
  real, parameter :: qfacdiscs(n) = (/0.09,0.01,0.005,0.09,0.115/)
  real, parameter :: qfacdisc2s(n) = (/0.305,-0.015,0.275,0.295,0.35/)
  real, parameter :: alpha_zs(n) = (/3.01,4.91,2.57,3.31,2.78/)
@@ -44,7 +44,6 @@ module testeos_stratified
  real, parameter :: q_mids(n) = (/-0.18,-0.02,-0.01,-0.18,-0.23/)
  real, parameter :: q_atms(n) = (/-0.61,0.03,-0.55,-0.59,-0.7/)
 
-
  private
 
 contains
@@ -59,12 +58,10 @@ subroutine test_eos_stratified(ntests,npass)
  use units,     only:set_units
  integer, intent(inout) :: ntests,npass
 
-
  call test_stratified_midplane(ntests,npass)
  call test_stratified_temps(ntests,npass)
  call test_stratified_temps_dartois(ntests,npass)
  !call map_stratified_temps(ntests,npass)
-
 
 end subroutine test_eos_stratified
 
@@ -74,10 +71,10 @@ end subroutine test_eos_stratified
 !+
 !----------------------------------------------------------------------------
 subroutine test_stratified_midplane(ntests, npass)
- use eos,           only:maxeos,equationofstate,eosinfo,init_eos,qfacdisc, &
-                         qfacdisc2,z0,alpha_z,beta_z,polyk,polyk2,istrat
- use units,         only:unit_density
- use io,            only:id,master,stdout
+ use eos,   only:maxeos,equationofstate,eosinfo,init_eos,qfacdisc, &
+                 qfacdisc2,z0,alpha_z,beta_z,polyk,polyk2,istrat
+ use units, only:unit_density
+ use io,    only:id,master,stdout
  integer, intent(inout) :: ntests,npass
  integer :: nfailed(2),ncheck(2)
  integer :: ierr,ieos,i,j,k
@@ -110,23 +107,19 @@ subroutine test_stratified_midplane(ntests, npass)
 
  call eosinfo(ieos,stdout)
 
-
  do i=1,5
     call get_disc_params(i,qfacdisc,qfacdisc2,alpha_z,beta_z,z0,polyk,polyk2, &
                          temp_mid0,temp_atm0,z0_original,q_mid,q_atm)
     rhoi = 1e-13/unit_density
 
     do j=1,1000,10
-       xi=j
+       xi=real(j)
        do k=1,1
-          yi = 0
-          zi = 0
+          yi = 0.
+          zi = 0.
 
           call equationofstate(ieos,ponrhoi,spsoundi,rhoi,xi,yi,zi,tempi)
-          !print*, xi, zi, tempi, spsoundi*unit_velocity, 'cm/s'
-
           call equationofstate(3,ponrhoi,spsoundi_ref,rhoi,xi,yi,zi,tempi_ref)
-          !print*, xi, zi, tempi_ref, spsoundi_ref*unit_velocity, 'cm/s'
           call checkvalbuf(spsoundi,spsoundi_ref,1e-12,'ieos=3 cs in midplane matches ieos=7 cs in midplane', &
                          nfailed(1),ncheck(1),errmax)
           call checkvalbuf(tempi,tempi_ref,1e-12,'ieos=3 temp in midplane matches ieos=7 temp in midplane', &
@@ -167,7 +160,6 @@ subroutine test_stratified_temps(ntests, npass)
  polyk2 = 0.1
  tempi = -1
 
-
  call set_units(mass=solarm,dist=au,G=1.d0)
 
  call init_eos(ieos, ierr)
@@ -179,7 +171,6 @@ subroutine test_stratified_temps(ntests, npass)
  nfailed = 0.
  ncheck  = 0.
  errmax = 0.
-
 
  do i=1,n
     call get_disc_params(i,qfacdisc,qfacdisc2,alpha_z,beta_z,z0,polyk,polyk2, &
@@ -227,8 +218,7 @@ subroutine test_stratified_temps_dartois(ntests, npass)
             temp_atm0,z0_original,q_atm,q_mid,ri,temp_atm,temp_mid,zq
  real    :: errmax
  integer, parameter :: nstep=20,nmax=1000
-
- real, parameter :: pi = 4.*atan(1.0)
+ real,    parameter :: pi = 4.*atan(1.0)
 
  ieos = 7
 
@@ -236,7 +226,6 @@ subroutine test_stratified_temps_dartois(ntests, npass)
  polyk = 0.1
  polyk2 = 0.1
  tempi = -1
-
 
  call set_units(mass=solarm,dist=au,G=1.d0)
 
@@ -269,7 +258,6 @@ subroutine test_stratified_temps_dartois(ntests, npass)
           zi = l
           istrat = 1
           call equationofstate(ieos,ponrhoi,spsoundi,rhoi,xi,yi,zi,tempi)
-          !print*, 'eos temp', tempi
           ri = sqrt(xi**2 + yi**2)
           zq = z0_original*(ri/100)**beta_z
           temp_mid = temp_mid0*(ri/100)**q_mid
@@ -279,14 +267,15 @@ subroutine test_stratified_temps_dartois(ntests, npass)
           else
              temp_ref = temp_atm
           endif
-          !print*, 'ref temp', temp_ref
+
           call checkvalbuf(tempi,temp_ref,1e-14,'ieos=7 temp matches temp from Dartois et al. 2003 equation', &
                           nfailed(1),ncheck(1),errmax)
        enddo
     enddo
  enddo
- call checkvalbuf_end('ieos=7 temp matches temp from Dartois et al. 2003 equation',ncheck(1), &
-                         nfailed(1),errmax,1e-14)
+
+ call checkvalbuf_end('ieos=7 temp matches temp from Dartois et al. 2003 equation',&
+                      ncheck(1),nfailed(1),errmax,1e-14)
  call update_test_scores(ntests,nfailed,npass)
 
 end subroutine test_stratified_temps_dartois
@@ -307,8 +296,7 @@ subroutine map_stratified_temps(ntests, npass)
             temp_atm0,z0_original,q_atm,q_mid
  real, dimension(nr) :: radius
 
-
- if (id==master) write(*,"(/,a)") '--> testing stratified disc temperatures'
+ if (id==master) write(*,"(/,a)") '--> writing stratified disc temperatures to files'
 
  ieos = 7
 
@@ -319,7 +307,6 @@ subroutine map_stratified_temps(ntests, npass)
  open(3, file='GMAur_temps.txt', status = 'replace')
  open(4, file='AS209_temps.txt', status = 'replace')
  open(5, file='MWC480_temps.txt', status = 'replace')
-
 
  do i=1,n
     call get_disc_params(i,qfacdisc,qfacdisc2,alpha_z,beta_z,z0,polyk,polyk2, &
@@ -347,10 +334,15 @@ subroutine map_stratified_temps(ntests, npass)
 
 end subroutine map_stratified_temps
 
+!----------------------------------------------------------------------------
+!+
+!  extract parameters for a particular disc from the list of presets
+!+
+!----------------------------------------------------------------------------
 subroutine get_disc_params(ndisc,qfacdisc,qfacdisc2,alpha_z,beta_z,z0,polyk, &
                             polyk2,temp_mid0,temp_atm0,z0_original,q_mid,q_atm)
  integer, intent(in) :: ndisc
- real, intent(out) :: qfacdisc,qfacdisc2,alpha_z,beta_z,z0,polyk,polyk2, &
+ real, intent(out)   :: qfacdisc,qfacdisc2,alpha_z,beta_z,z0,polyk,polyk2, &
                         temp_mid0,temp_atm0,z0_original,q_mid,q_atm
 
  qfacdisc = qfacdiscs(ndisc)

--- a/src/tests/test_nonidealmhd.F90
+++ b/src/tests/test_nonidealmhd.F90
@@ -109,7 +109,7 @@ subroutine test_wavedamp(ntests,npass)
  use eos,            only:ieos,polyk,gamma
  use options,        only:alphaB,alpha,alphamax
  use unifdis,        only:set_unifdis
- use dim,            only:periodic
+ use dim,            only:periodic,isothermal
  use timestep,       only:dtmax,tmax
  use io,             only:iverbose
  use nicil,          only:nicil_initialise,eta_constant,eta_const_type,icnstsemi, &
@@ -131,9 +131,10 @@ subroutine test_wavedamp(ntests,npass)
  logical                :: valid_dt
  logical, parameter     :: print_output = .false.
 
-#ifndef ISOTHERMAL
- if (id==master) write(*,"(/,a)") '--> skipping wave damping test (need -DISOTHERMAL)'
-#endif
+ if (.not.isothermal) then
+    if (id==master) write(*,"(/,a)") '--> skipping wave damping test (need -DISOTHERMAL)'
+    return
+ endif
  if (periodic) then
     if (id==master) write(*,"(/,a)") '--> testing wave damping test (nimhddamp)'
  else
@@ -284,7 +285,7 @@ subroutine test_standingshock(ntests,npass)
  use eos,            only:ieos,polyk,gamma
  use options,        only:alpha,alphamax,alphaB
  use unifdis,        only:set_unifdis,get_ny_nz_closepacked
- use dim,            only:periodic
+ use dim,            only:periodic,isothermal
  use timestep,       only:dtmax,tmax
  use io,             only:iverbose
  use nicil,          only:nicil_initialise,eta_constant,eta_const_type,icnstsemi, &
@@ -302,9 +303,9 @@ subroutine test_standingshock(ntests,npass)
  logical, parameter     :: print_output = .false.
  logical                :: valid_bdy_rho,valid_bdy_v
 
-#ifndef ISOTHERMAL
- if (id==master) write(*,"(/,a)") '--> skipping standing shock test (need -DISOTHERMAL)'
-#endif
+ if (.not.isothermal) then
+    if (id==master) write(*,"(/,a)") '--> skipping standing shock test (need -DISOTHERMAL)'
+ endif
  if (periodic) then
     if (id==master) write(*,"(/,a)") '--> testing standing shock & boundary particles (nimhdshock)'
  else

--- a/src/tests/test_radiation.f90
+++ b/src/tests/test_radiation.f90
@@ -254,7 +254,12 @@ subroutine test_implicit_matches_explicit(ntests,npass)
     call get_derivs_global()
     if (itry==1) then
        call get_derivs_global()  ! twice to get density on neighbours correct
-       dvdx_explicit = dvdx
+
+       !--allocate and copy dvdx (note: dvdx_explicit = dvdx works
+       !  but gives compiler warnings so we do this with source=)
+       allocate(dvdx_explicit, source=dvdx)
+
+       !--allocate and copy flux
        allocate(flux_explicit(3,npart))
        flux_explicit = radprop(ifluxx:ifluxz,1:npart)
        dvdx = 0.

--- a/src/utils/analysis_GalMerger.f90
+++ b/src/utils/analysis_GalMerger.f90
@@ -110,6 +110,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
              pmassi = massoftype(igas)
           endif
        else
+          itype = igas
           pmassi = massoftype(igas)
        endif
        rhoi = rhoh(hi,pmassi)

--- a/src/utils/analysis_MWpdf.f90
+++ b/src/utils/analysis_MWpdf.f90
@@ -25,8 +25,8 @@ module analysis
 contains
 
 subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
- use dim,              only:maxptmass, maxp
- use part,             only:massoftype,rhoh,hfact,isdead_or_accreted
+ use dim,              only:maxptmass
+ use part,             only:massoftype,rhoh,hfact,isdead_or_accreted,igas
  use readwrite_dumps,  only:read_dump
  use pdfs,             only:get_pdf,write_pdf
  character(len=*), intent(in) :: dumpfile
@@ -34,21 +34,23 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
  real,             intent(in) :: xyzh(:,:),vxyzu(:,:), particlemass, time
  character(len=3)  :: variable='rho'
  integer           :: nbins, i
- real, allocatable :: pdf_rho(:), xbin(:)
+ real, allocatable :: pdf_rho(:), xbin(:), rho(:)
  real :: totmass,rhomin,rhomax,binspacing,rhologmin,rhologmax
  real :: vx2,vy2,vz2,rhoi,rmsv
- real :: rhomean, rho(maxp), hi, pmassi
+ real :: rhomean,hi, pmassi
 
+ allocate(rho(npart))
  rho     = 0.
  rhomin  = huge(rhomin)
  rhomax  = 0.
  rhomean = 0.
  totmass = 0.
+ rmsv    = 0.
  print*,'hfact = ',hfact
  do i=1,npart
     hi = xyzh(4,i)
     if (.not.isdead_or_accreted(hi)) then
-       pmassi = massoftype(1)
+       pmassi = massoftype(igas)
        rho(i) = rhoh(hi,pmassi)
        rhoi   = rho(i)
        rhomin = min(rhomin,rhoi)
@@ -70,20 +72,18 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
 
 ! rhologmin = log10(rhomin)
 ! rhologmax = log10(rhomax)
-
  rhologmin = -10.
  rhologmax = 10.
-
 !
 !--check to see if there are densities smaller or larger than the limits of the PDF
 !
- if (log10(rhomin)<rhologmin) then
-    print*, 'ERROR: you have densities lower than the minimum value of 10^-10'
+ if (log10(rhomin) < rhologmin) then
+    print*, 'ERROR: you have densities lower than the minimum value of ',10.**rhologmin
     print*, 'Bailing out.'
     stop
  endif
- if (log10(rhomax)>rhologmax) then
-    print*, 'ERROR: you have densities higher than the maximum value of 10^10'
+ if (log10(rhomax) > rhologmax) then
+    print*, 'ERROR: you have densities higher than the maximum value of ',10.**rhologmax
     print*, 'Bailing out.'
     stop
  endif
@@ -107,7 +107,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
 
  if (allocated(xbin)) deallocate(xbin)
  if (allocated(pdf_rho)) deallocate(pdf_rho)
-!---------------------------------------------
+ if (allocated(rho)) deallocate(rho)
 
 end subroutine do_analysis
 

--- a/src/utils/analysis_cooling.f90
+++ b/src/utils/analysis_cooling.f90
@@ -6,7 +6,7 @@
 !--------------------------------------------------------------------------!
 module analysis
 !
-! analysis
+! various tests of the cooling solver module
 !
 ! :References: None
 !
@@ -35,7 +35,6 @@ module analysis
  integer :: analysis_to_perform
  real    :: Aw(nElements) = [1.0079, 4.0026, 12.011, 15.9994, 14.0067, 20.17, 28.0855, 32.06, 55.847, 47.867]
  real    :: eps(nElements) = [1.d0, 1.04d-1, 0.0,  6.d-4, 2.52d-4, 1.17d-4, 3.58d-5, 1.85d-5, 3.24d-5, 8.6d-8]
-
 
 contains
 
@@ -68,6 +67,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
  case(3)
     call test_cooling_solvers
  end select
+
 end subroutine do_analysis
 
 
@@ -201,13 +201,10 @@ subroutine test_cooling_solvers
 
 end subroutine test_cooling_solvers
 
-
 !-----------------------------------------------------------
 ! time integration of du/dt between t=0 and t=10*tcool
 !-----------------------------------------------------------
-
 subroutine integrate_cooling(file_in,ifunct,T_gas,T_floor,tcool0,tstart,ui,rho,mu,gamma)
-
  use units,   only:unit_ergg
  use physcon, only: Rg
 
@@ -300,14 +297,14 @@ subroutine get_rate
 
  call print_cooling_rates(T_gas, rho_gas, mu, nH, nH2, nHe, nCO, nH2O, nOH, kappa_gas, &
                      T_dust, v_drift, d2g, a, rho_grain, kappa_dust, JL)
-end subroutine get_rate
 
+end subroutine get_rate
 
 subroutine generate_grid
 
  real :: logtmin,logtmax,logT,dlogt,T,crate,nH_tot,rho_cgs
  real :: pC, pC2, pC2H, pC2H2, mu, gamma, T_dust, d2g, v_drift
- real :: nH, nH2, nHe, nCO, nH2O, nOH, a, rho_grain, kappa_g, n_gas, rho_gas, kappa_dust, JL
+ real :: nH, nH2, nHe, nCO, nH2O, nOH, a, rho_grain, kappa_g, n_gas, kappa_dust, JL
  integer :: i,iunit
  integer, parameter :: nt = 400, iC=3
 
@@ -342,6 +339,7 @@ subroutine generate_grid
     write(iunit,*) t,crate/nH_tot**2,crate
  enddo
  close(iunit)
+
 end subroutine generate_grid
 
 real function MPH(eps, Aw)
@@ -354,6 +352,5 @@ real function MPH(eps, Aw)
  MPH           = atomic_mass_unit*dot_product(Aw,eps)
 
 end function MPH
-
 
 end module analysis

--- a/src/utils/analysis_dustydisc.f90
+++ b/src/utils/analysis_dustydisc.f90
@@ -424,6 +424,7 @@ subroutine do_analysis(dumpfile,numfile,xyzh,vxyz,pmass,npart,time,iunit)
  dustfracisum = 0.
  dustfraci(:) = 0.
  itypei = igas
+ pgasmass = 0.
 
  do i = 1,npart
     hi = xyzh(4,i)
@@ -449,6 +450,7 @@ subroutine do_analysis(dumpfile,numfile,xyzh,vxyz,pmass,npart,time,iunit)
        elseif (iamdust(itypei)) then
           Mdust = Mdust + pmassi
           pdustmass(idusttype(itypei)) = pmassi
+          pgasmass = 0.
        endif
     else
        pgasmass = 0.
@@ -1098,17 +1100,18 @@ subroutine solve_dipierro_2018(irealvisc,vgassol,vdustsol,d2g_ratio,r,cs,vK,nu,p
     lambda0 = sum(d2g_ratio(:,i)/(1. + St_mid(:,i)**2))
     lambda1 = sum(d2g_ratio(:,i)*St_mid(:,i)/(1. + St_mid(:,i)**2))
 
-    if (irealvisc == 0) then
+    select case(irealvisc)
+    case(2)
+       v_P = -(p + q + 1.5)*cs(i)**2/vK(i)
+       v_nu = 3.*nu(i)*(p + q - 0.5)/r(i)
+    case(1)
+       v_P = -(p + q + 1.5)*cs(i)**2/vK(i)
+       v_nu = 3.*nu(i)*(p - q + 1.)/r(i)
+    case default ! irealvisc=0
        v_P = dPrdr(i)
        v_nu = -3.*nu(i)*dzetadr(i)/zeta(i+1)
        !v_nu = nu(i)*(2.*p + q + 1.5)/r(i)
-    elseif (irealvisc == 1) then
-       v_P = -(p + q + 1.5)*cs(i)**2/vK(i)
-       v_nu = 3.*nu(i)*(p - q + 1.)/r(i)
-    elseif (irealvisc == 2) then
-       v_P = -(p + q + 1.5)*cs(i)**2/vK(i)
-       v_nu = 3.*nu(i)*(p + q - 0.5)/r(i)
-    endif
+    end select
 
     denom1          = (1. + lambda0)**2 + lambda1**2
     denom2(:)       = denom1*(1. + St_mid(:,i)**2)

--- a/src/utils/ev2mdot.f90
+++ b/src/utils/ev2mdot.f90
@@ -122,6 +122,8 @@ program get_mdot
           allocate(dat_combined(ncols,nsteps))
           dat_combined = dat
        endif
+    else
+       if (.not.allocated(dat_combined)) allocate(dat_combined(0,0)) ! to avoid compiler warning
     endif
 
     nsteps_keep = 0

--- a/src/utils/phantomevcompare.f90
+++ b/src/utils/phantomevcompare.f90
@@ -97,6 +97,7 @@ program phantomevcompare
     !--List the models to compare
     !  Note: will check to ensure that 01.ev exists
     enter_filename = .true.
+    add_prefix = .false.
     write(*,'(a)') ' '
     write(*,'(a)') 'Enter the file prefixes you wish to compare; press enter when complete.'
     i = 0

--- a/src/utils/utils_gravwave.f90
+++ b/src/utils/utils_gravwave.f90
@@ -69,12 +69,12 @@ subroutine calculate_strain(hx,hp,pmass,ddq_xy,x0,v0,a0,npart,xyzh,vxyz,axyz,&
  eta = 0.
  phi = phi_gw*pi/180.
  ! define new functions instead of sin and cos
- sinphi=sin(phi)
- cosphi=cos(phi)
- sinphi2=sinphi*sinphi
- cosphi2=cosphi*cosphi
- sin2phi=sin(2*phi)
- cos2phi=cos(2*phi)
+ sinphi = sin(phi)
+ cosphi = cos(phi)
+ sinphi2 = sinphi*sinphi
+ cosphi2 = cosphi*cosphi
+ sin2phi = sin(2*phi)
+ cos2phi = cos(2*phi)
  !
  ! initialise moment of inertia and its second deriv to zero
  !
@@ -227,7 +227,7 @@ real function get_G_on_dc4() result(fac)
 
  d   = Mpc/udist                            ! 1Mpc in code units
  gc4 = (gg/c**4) / (utime**2/(umass*udist)) ! G/c^4 in code units
- fac = (gc4/d)
+ fac = real(gc4/d)
 
 end function get_G_on_dc4
 
@@ -237,11 +237,9 @@ end function get_G_on_dc4
 !+
 !--------------------------------------------------------------------------------
 subroutine get_strain_from_circular_binary(t,m1,m2,r,eta,hx,hp)
- use units,   only:get_G_code,get_c_code,udist
- use physcon, only:Mpc
- real, intent(in) :: t,m1,m2,r,eta
+ real, intent(in)  :: t,m1,m2,r,eta
  real, intent(out) :: hx,hp
- real :: mred,term,d,omega2,omega,fac
+ real :: mred,term,omega2,omega,fac
 
  mred = m1*m2/(m1 + m2)   ! reduced mass
  omega2 = (m1 + m2)/r**3  ! Keplerian speed
@@ -249,8 +247,8 @@ subroutine get_strain_from_circular_binary(t,m1,m2,r,eta,hx,hp)
 
  ! following lines are written a bit differently to the expression
  ! in calculate_strain as a better check of the code
- d   = Mpc/udist   ! 1Mpc in code units
- fac = get_G_code()/(d*get_c_code()**4)
+
+ fac = get_G_on_dc4()
  term = 4.*mred*r**2*omega2*fac
 
  ! Eqs 7-8 in Toscani et al. 2021, see e.g. Maggiore (2007)


### PR DESCRIPTION
Type of PR: 
other

Description:
Implementation of #349 this change causes the GitHub actions to fail if any compiler warnings are present when compiling with gfortran by compiling with the -Werror flag which turns warnings into errors. This change is needed
to prevent new compiler warnings being introduced on the master branch.

The first task is to see what fails, and then slowly fix everything. If this P-R ever passes, it will be possible to compile every possible SETUP of phantom with no compiler warnings!

Testing:
Can at least compile a number of setups I have tested with -Werror. The actual testing will take place in the GitHub actions workflow itself as I expect a bunch of things to fail, for which we then have to clean up all the warnings :)

UPDATE: nearly everything should now compile successfully with -Werror

Did you run the bots? yes
