### PR TITLE
Dust fixes

### DIFF
--- a/src/main/cons2prim.f90
+++ b/src/main/cons2prim.f90
@@ -247,6 +247,7 @@ subroutine cons2prim_everything(npart,xyzh,vxyzu,dvdx,rad,eos_vars,radprop,&
              dustfrac(1:ndustsmall,i) = dustevol(1:ndustsmall,i)**2/(1.+dustevol(1:ndustsmall,i)**2)
           gasfrac = (1. - sum(dustfrac(1:ndustsmall,i)))  ! rhogas/rho
           rhogas  = rhoi*gasfrac       ! rhogas = (1-eps)*rho
+          if (gasfrac < 0.) call warning('cons2prim','total dust fraction > 1: try limiting dust flux',i,'eps',1.-gasfrac)
        else
           rhogas  = rhoi
        endif

--- a/src/main/energies.F90
+++ b/src/main/energies.F90
@@ -396,7 +396,7 @@ subroutine compute_energies(t)
           if (use_dustfrac) then
              rhogasi = rhoi*gasfrac
              do j=1,ndustsmall
-                call get_ts(idrag,j,grainsize(j),graindens(j),rhogasi,rhoi*dustfraci(j),spsoundi,0.,tsi,iregime)
+                call get_ts(idrag,j,grainsize(j),graindens(j),rhogasi,rhoi*dustfracisum,spsoundi,0.,tsi,iregime)
                 call ev_data_update(ev_data_thread,iev_ts,tsi)
              enddo
           endif

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -2452,7 +2452,7 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
                           use_dustfrac,damp,icooling,implicit_radiation
  use part,           only:h2chemistry,rhoanddhdrho,iboundary,igas,maxphase,maxvxyzu,nptmass,xyzmh_ptmass, &
                           massoftype,get_partinfo,tstop,strain_from_dvdx,ithick,iradP,sinks_have_heating,luminosity, &
-                          nucleation,idK2,idmu,idkappa,idgamma,dust_temp,pxyzu
+                          nucleation,idK2,idmu,idkappa,idgamma,dust_temp,pxyzu,ndustsmall
  use cooling,        only:energ_cooling,cooling_in_step
  use ptmass_heating, only:energ_sinkheat
 #ifdef IND_TIMESTEPS
@@ -2981,8 +2981,8 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
 
     ! one fluid dust timestep
     if (use_dustfrac .and. iamgasi) then
-       if (minval(dustfraci) > 0. .and. spsoundi > 0. .and. dustfracisum > epsilon(0.)) then
-          tseff = (1.-dustfracisum)/dustfracisum*sum(dustfraci(:)*tstopi(:))
+       if (minval(dustfraci(1:ndustsmall)) > 0. .and. spsoundi > 0. .and. dustfracisum > epsilon(0.)) then
+          tseff = (1.-dustfracisum)/dustfracisum*sum(dustfraci(1:ndustsmall)*tstopi(1:ndustsmall))
           dtdustdenom = dustfracisum*tseff*spsoundi**2
           if (dtdustdenom > tiny(dtdustdenom)) then
              dtdusti = C_force*hi*hi/dtdustdenom

--- a/src/main/readwrite_dumps_fortran.F90
+++ b/src/main/readwrite_dumps_fortran.F90
@@ -1684,9 +1684,6 @@ subroutine unfill_rheader(hdr,phantomdump,ntypesinfile,nptmass,&
  call extract('time',tfile,hdr,ierr)
  if (ierr/=0)  call extract('gt',tfile,hdr,ierr)  ! this is sphNG's label for time
  call extract('dtmax',dtmaxi,hdr,ierr)
- call extract('idtmax_n',idtmax_n,hdr,ierr)
- call extract('idtmax_frac',idtmax_frac,hdr,ierr)
- call extract('idumpfile',idumpfile,hdr,ierr)
  call extract('rhozero',rhozero,hdr,ierr)
  Bextx = 0.
  Bexty = 0.
@@ -1727,6 +1724,10 @@ subroutine unfill_rheader(hdr,phantomdump,ntypesinfile,nptmass,&
        call read_headeropts_extern(iextern_in_file,hdr,nptmass,ierrs(1))
        if (ierrs(1) /= 0) ierr = 5
     endif
+
+    call extract('idtmax_n',idtmax_n,hdr,ierr,default=1)
+    call extract('idtmax_frac',idtmax_frac,hdr,ierr)
+    call extract('idumpfile',idumpfile,hdr,ierr)
  else
     massoftype(1) = 0.
     hfactfile = 0.
@@ -1800,7 +1801,6 @@ subroutine unfill_rheader(hdr,phantomdump,ntypesinfile,nptmass,&
     endif
  endif
 
- return
 end subroutine unfill_rheader
 
 

--- a/src/main/timestep.F90
+++ b/src/main/timestep.F90
@@ -22,11 +22,11 @@ module timestep
  integer :: nmax,nout
  integer :: nsteps
  real, parameter :: bignumber = 1.e29
- integer :: idtmax_n         = 1
- integer :: idtmax_n_next    = 1
- integer :: idtmax_frac      = 0
- integer :: idtmax_frac_next = 0
- real    :: dtmax_user       = -1.  ! require this initialisation for user-friendliness in phantomsetup
+ integer :: idtmax_n
+ integer :: idtmax_n_next
+ integer :: idtmax_frac
+ integer :: idtmax_frac_next
+ real    :: dtmax_user
 
  real    :: dt,dtcourant,dtforce,dtrad,dtextforce,dterr,dtdiff,time
  real    :: dtmax_dratio, dtmax_max, dtmax_min, rhomaxnow
@@ -62,6 +62,12 @@ subroutine set_defaults_timestep
  dtmax_dratio =  0.          ! dtmax will change if this ratio is exceeded in a timestep (recommend 1.258)
  dtmax_max    = -1.0         ! maximum dtmax allowed (to be reset to dtmax if = -1)
  dtmax_min    =  0.          ! minimum dtmax allowed
+
+ idtmax_n = 1
+ idtmax_n_next = 1
+ idtmax_frac = 0
+ idtmax_frac_next = 0
+ dtmax_user = -1.
 
 end subroutine set_defaults_timestep
 


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
several important bug fixes:

- P-R #352 caused a problem with restarting phantom from a dump made by an older version of the code, since idtmax_n was set to zero by default when not present in the dump header. This is now fixed.

- the timestep constraint in the one fluid dust / dust-as-mixture method was not being applied if the array size for the dustfrac was larger than ndustsmall due to a check for minval(dustfrac(:)) > 0, now changed to minval(dustfrac(1:ndustsmall))

- added a warning to cons2prim if the total dust fraction exceeds unity

Testing:
Code restarts successfully from previously generated snapshot and gives a warning if the total dust fraction exceeds unity

Did you run the bots? no

Did you update relevant documentation in the docs directory? n/a