### PR TITLE
(setup_star): unclutter warnings; warn if relaxation not converged

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -637,9 +637,9 @@ OBJDUMP= $(OBJDUMP1:.F90=.o)
 LIBSETUP=$(BINDIR)/libphantomsetup.a
 SRCLIBSETUP=physcon.f90 geometry.f90 random.f90 utils_tables.f90 utils_vectors.f90 stretchmap.f90 \
             utils_binary.f90 set_binary.f90 set_flyby.f90 \
-            set_hierarchical_utils.f90 set_hierarchical.f90 \
+            set_hierarchical_utils.f90 \
             set_unifdis.f90 set_sphere.f90 set_shock.f90 \
-            set_dust.f90 libsetup.f90 
+            set_dust.f90 libsetup.f90
 OBJLIBSETUP=${SRCLIBSETUP:.f90=.o}
 
 libsetup: $(OBJLIBSETUP)
@@ -659,7 +659,7 @@ SRCSETUP= utils_summary.F90 utils_gravwave.f90 \
           utils_indtimesteps.F90 partinject.F90 \
           ${SRCTURB} ${SRCNIMHD} ${SRCCHEM} \
           ptmass.F90 energies.F90 density_profiles.f90 set_slab.f90 set_disc.F90 \
-          set_cubic_core.f90 set_fixedentropycore.f90 set_softened_core.f90 set_star.f90 relax_star.f90 \
+          set_cubic_core.f90 set_fixedentropycore.f90 set_softened_core.f90 set_star.f90 relax_star.f90 set_hierarchical.f90 \
           set_vfield.f90 ptmass_radiation.F90 ${SRCINJECT} \
           ${SETUPFILE} checksetup.F90 \
           set_Bfield.f90 readwrite_infile.f90 ${SRCKROME}

--- a/build/Makefile
+++ b/build/Makefile
@@ -659,7 +659,9 @@ SRCSETUP= utils_summary.F90 utils_gravwave.f90 \
           utils_indtimesteps.F90 partinject.F90 \
           ${SRCTURB} ${SRCNIMHD} ${SRCCHEM} \
           ptmass.F90 energies.F90 density_profiles.f90 set_slab.f90 set_disc.F90 \
-          set_cubic_core.f90 set_fixedentropycore.f90 set_softened_core.f90 set_star.f90 relax_star.f90 set_hierarchical.f90 \
+          set_cubic_core.f90 set_fixedentropycore.f90 set_softened_core.f90 \
+          set_star_kepler.f90 set_star_mesa.f90 \
+          set_star.f90 relax_star.f90 set_hierarchical.f90 \
           set_vfield.f90 ptmass_radiation.F90 ${SRCINJECT} \
           ${SETUPFILE} checksetup.F90 \
           set_Bfield.f90 readwrite_infile.f90 ${SRCKROME}

--- a/build/Makefile
+++ b/build/Makefile
@@ -650,27 +650,21 @@ libsetup: $(OBJLIBSETUP)
 
 #----------------------------------------------------
 # these are the sources for phantom setup utility
+# (just the list of extra files not included in libphantom)
 #
 .PHONY: phantomsetup
 phantomsetup: setup
 
-SRCSETUP= utils_summary.F90 utils_gravwave.f90 \
-          set_dust_options.f90 \
-          utils_indtimesteps.F90 partinject.F90 \
-          ${SRCTURB} ${SRCNIMHD} ${SRCCHEM} \
-          ptmass.F90 energies.F90 density_profiles.f90 set_slab.f90 set_disc.F90 \
+SRCSETUP= prompting.f90 set_dust_options.f90 \
+          density_profiles.f90 set_slab.f90 set_disc.F90 \
           set_cubic_core.f90 set_fixedentropycore.f90 set_softened_core.f90 \
           set_star_kepler.f90 set_star_mesa.f90 \
           set_star.f90 relax_star.f90 set_hierarchical.f90 \
-          set_vfield.f90 ptmass_radiation.F90 ${SRCINJECT} \
-          ${SETUPFILE} checksetup.F90 \
-          set_Bfield.f90 readwrite_infile.f90 ${SRCKROME}
+          set_vfield.f90 set_Bfield.f90 \
+          ${SETUPFILE}
 
 OBJSETUP1= $(SRCSETUP:.f90=.o)
-ifeq ($(KROME), krome)
-    OBJSETUP1 += $(KROME_OBJS)
-endif
-OBJSETUP= $(OBJDUMP) $(OBJSETUP1:.F90=.o) phantomsetup.o
+OBJSETUP= $(OBJSETUP1:.F90=.o) phantomsetup.o
 
 setup: checksystem checkparams libsetup libphantom $(OBJSETUP)
 	$(FC) $(FFLAGS) -o $(BINDIR)/phantomsetup  $(OBJSETUP) $(LIBSETUP) $(LIBPHANTOM) $(LDFLAGS) $(LIBS)

--- a/build/Makefile
+++ b/build/Makefile
@@ -796,7 +796,7 @@ interpolate3D_amr.o: adaptivemesh.o
 ifndef MODDUMPBIN
 MODDUMPBIN=phantommoddump
 endif
-OBJMOD1 = prompting.o set_Bfield.o density_profiles.o ${MODFILE:.f90=.o} phantom_moddump.o
+OBJMOD1 = prompting.o set_Bfield.o density_profiles.o set_star_mesa.o ${MODFILE:.f90=.o} phantom_moddump.o
 OBJMOD = ${OBJMOD1:.F90=.o}
 
 phantom_moddump: checksystem checkparams libphantom libsetup $(OBJMOD)

--- a/src/main/checksetup.F90
+++ b/src/main/checksetup.F90
@@ -421,6 +421,10 @@ subroutine check_setup(nerror,nwarn,restart)
 !--check point mass setup
 !
  call check_setup_ptmass(nerror,nwarn,hmin)
+!
+!--check centre of mass
+!
+ call get_centreofmass(xcom,vcom,npart,xyzh,vxyzu,nptmass,xyzmh_ptmass,vxyz_ptmass)
 
  if (.not.h2chemistry .and. maxvxyzu >= 4 .and. icooling == 3 .and. iexternalforce/=iext_corotate) then
     if (dot_product(xcom,xcom) >  1.e-2) then
@@ -435,7 +439,6 @@ subroutine check_setup(nerror,nwarn,restart)
 !--print centre of mass (must be done AFTER types have been checked)
 !  ALSO, only print this if there are no warnings or errors to avoid obscuring warnings
 !
-    call get_centreofmass(xcom,vcom,npart,xyzh,vxyzu,nptmass,xyzmh_ptmass,vxyz_ptmass)
     if (id==master) then
        write(*,"(a,2(es10.3,', '),es10.3,a)") ' Centre of mass is at (x,y,z) = (',xcom,')'
        write(*,"(1x,a)") 'Particle setup OK'

--- a/src/main/checksetup.F90
+++ b/src/main/checksetup.F90
@@ -73,15 +73,15 @@ subroutine check_setup(nerror,nwarn,restart)
  endif
 
  if (npart > maxp) then
-    print*,'Error in setup: npart (',npart,') > maxp (',maxp,')'
+    print*,'ERROR: npart (',npart,') > maxp (',maxp,')'
     nerror = nerror + 1
  endif
  if (any(npartoftype < 0)) then
-    print*,'Error in setup: npartoftype -ve: ',npartoftype(:)
+    print*,'ERROR: npartoftype -ve: ',npartoftype(:)
     nerror = nerror + 1
  endif
  if (sum(npartoftype) > maxp) then
-    print*,'Error in setup: sum(npartoftype) > maxp ',sum(npartoftype(:))
+    print*,'ERROR: sum(npartoftype) > maxp ',sum(npartoftype(:))
     nerror = nerror + 1
  endif
  if (sum(npartoftype) /= npart) then
@@ -90,16 +90,16 @@ subroutine check_setup(nerror,nwarn,restart)
  endif
 #ifndef KROME
  if (gamma <= 0.) then
-    print*,'WARNING! Error in setup: gamma not set (should be set > 0 even if not used)'
+    print*,'WARNING! gamma not set (should be set > 0 even if not used)'
     nwarn = nwarn + 1
  endif
 #endif
  if (hfact < 1. .or. hfact /= hfact) then
-    print*,'Error in setup: hfact = ',hfact,', should be >= 1'
+    print*,'ERROR: hfact = ',hfact,', should be >= 1'
     nerror = nerror + 1
  endif
  if (polyk < 0. .or. polyk /= polyk) then
-    print*,'Error in setup: polyk = ',polyk,', should be >= 0'
+    print*,'ERROR: polyk = ',polyk,', should be >= 0'
     nerror = nerror + 1
  endif
 #ifdef KROME
@@ -114,7 +114,7 @@ subroutine check_setup(nerror,nwarn,restart)
  endif
 #endif
  if (npart < 0) then
-    print*,'Error in setup: npart = ',npart,', should be >= 0'
+    print*,'ERROR: npart = ',npart,', should be >= 0'
     nerror = nerror + 1
  elseif (npart==0 .and. nptmass==0) then
     print*,'WARNING! setup: npart = 0 (and no sink particles either)'
@@ -130,12 +130,12 @@ subroutine check_setup(nerror,nwarn,restart)
 !
     if (all(iphase(1:npart)==0)) then
        if (any(npartoftype(2:) > 0)) then
-          print*,'Error in setup: npartoftype > 0 for non-gas particles, but types have not been assigned'
+          print*,'ERROR: npartoftype > 0 for non-gas particles, but types have not been assigned'
           nerror = nerror + 1
        endif
        iphase(1:npart) = isetphase(igas,iactive=.true.)
     elseif (any(iphase(1:npart)==0)) then
-       print*,'Error in setup: types need to be assigned to all particles (or none)'
+       print*,'ERROR: types need to be assigned to all particles (or none)'
        nerror = nerror + 1
     endif
 !
@@ -232,7 +232,7 @@ subroutine check_setup(nerror,nwarn,restart)
     hmax = max(hi,hmax)
  enddo
  if (nbad > 0) then
-    print*,'Error in setup: negative, zero or ridiculous h on ',nbad,' of ',npart,' particles'
+    print*,'ERROR: negative, zero or ridiculous h on ',nbad,' of ',npart,' particles'
     print*,' hmin = ',hmin,' hmax = ',hmax
     nerror = nerror + 1
  endif
@@ -249,12 +249,12 @@ subroutine check_setup(nerror,nwarn,restart)
        endif
     enddo
     if (nbad > 0) then
-       print*,'Error in setup: negative thermal energy on ',nbad,' of ',npart,' particles'
+       print*,'ERROR: negative thermal energy on ',nbad,' of ',npart,' particles'
        nerror = nerror + 1
     endif
  else
     if (abs(gamma-1.) > tiny(gamma) .and. (ieos /= 2 .and. ieos /=9)) then
-       print*,'*** Error in setup: using isothermal EOS, but gamma = ',gamma
+       print*,'*** ERROR: using isothermal EOS, but gamma = ',gamma
        gamma = 1.
        print*,'*** Resetting gamma to 1, gamma = ',gamma
        nwarn = nwarn + 1
@@ -269,7 +269,7 @@ subroutine check_setup(nerror,nwarn,restart)
        nwarn = nwarn + 1
     endif
     if (npartoftype(itype) > 0 .and. .not.(in_range(massoftype(itype),0.))) then
-       print*,'Error in setup: massoftype = ',massoftype(itype),' for '//trim(labeltype(itype))// &
+       print*,'ERROR: massoftype = ',massoftype(itype),' for '//trim(labeltype(itype))// &
               ' particles (n'//trim(labeltype(itype))//' = ',npartoftype(itype),')'
        nerror = nerror + 1
     endif
@@ -279,7 +279,7 @@ subroutine check_setup(nerror,nwarn,restart)
  !
  call check_for_identical_positions(npart,xyzh,nbad)
  if (nbad > 0) then
-    print*,'Error in setup: ',nbad,' of ',npart,' particles have identical or near-identical positions'
+    print*,'ERROR: ',nbad,' of ',npart,' particles have identical or near-identical positions'
     nwarn = nwarn + 1
  endif
 !
@@ -296,7 +296,7 @@ subroutine check_setup(nerror,nwarn,restart)
        endif
     enddo
     if (nbad > 0) then
-       print*,'Error in setup: ',nbad,' of ',npart,' particles setup OUTSIDE the periodic box'
+       print*,'ERROR: ',nbad,' of ',npart,' particles setup OUTSIDE the periodic box'
        nerror = nerror + 1
     endif
  endif
@@ -317,7 +317,7 @@ subroutine check_setup(nerror,nwarn,restart)
        if (accreted) nbad = nbad + 1
     enddo
     if (nbad > 0) then
-       print*,'Warning: ',nbad,' of ',npart,' particles setup within the accretion boundary'
+       print*,'WARNING: ',nbad,' of ',npart,' particles setup within the accretion boundary'
        nwarn = nwarn + 1
     endif
     !--check if we are using a central accretor
@@ -325,7 +325,7 @@ subroutine check_setup(nerror,nwarn,restart)
     call accrete_particles(iexternalforce,0.,0.,0.,hi,massoftype(1),time,accreted)
     !--if so, check for unresolved accretion radius
     if (accreted .and. accradius1 < 0.5*hmin) then
-       print*,'Warning: accretion radius is unresolved by a factor of hmin/racc = ',hmin/accradius1
+       print*,'WARNING: accretion radius is unresolved by a factor of hmin/racc = ',hmin/accradius1
        print*,'(this will cause the code to run needlessly slow)'
        nwarn = nwarn + 1
     endif
@@ -336,9 +336,9 @@ subroutine check_setup(nerror,nwarn,restart)
  if (gravity .or. nptmass > 0) then
     if (.not.G_is_unity()) then
        if (gravity) then
-          print*,'Error in setup: self-gravity ON but G /= 1 in code units, got G=',get_G_code()
+          print*,'ERROR: self-gravity ON but G /= 1 in code units, got G=',get_G_code()
        elseif (nptmass > 0) then
-          print*,'Error in setup: sink particles used but G /= 1 in code units, got G=',get_G_code()
+          print*,'ERROR: sink particles used but G /= 1 in code units, got G=',get_G_code()
        endif
        nerror = nerror + 1
     endif
@@ -357,7 +357,7 @@ subroutine check_setup(nerror,nwarn,restart)
     endif
     if (mhd_nonideal) then
        if (n_nden /= n_nden_phantom) then
-          print*,'Error in setup: n_nden in nicil.f90 needs to match n_nden_phantom in config.F90; n_nden = ',n_nden
+          print*,'ERROR: n_nden in nicil.f90 needs to match n_nden_phantom in config.F90; n_nden = ',n_nden
           nerror = nerror + 1
        endif
     endif
@@ -367,7 +367,7 @@ subroutine check_setup(nerror,nwarn,restart)
 !
  if (npartoftype(idust) > 0) then
     if (.not. use_dust) then
-       if (id==master) print*,'Error in setup: dust particles present but -DDUST is not set'
+       if (id==master) print*,'ERROR: dust particles present but -DDUST is not set'
        nerror = nerror + 1
     endif
     if (use_dustfrac) then
@@ -421,23 +421,25 @@ subroutine check_setup(nerror,nwarn,restart)
 !--check point mass setup
 !
  call check_setup_ptmass(nerror,nwarn,hmin)
-!
-!--print centre of mass (must be done AFTER types have been checked)
-!
- call get_centreofmass(xcom,vcom,npart,xyzh,vxyzu,nptmass,xyzmh_ptmass,vxyz_ptmass)
- if (id==master) &
-    write(*,"(a,2(es10.3,', '),es10.3,a)") ' Centre of mass is at (x,y,z) = (',xcom,')'
 
  if (.not.h2chemistry .and. maxvxyzu >= 4 .and. icooling == 3 .and. iexternalforce/=iext_corotate) then
     if (dot_product(xcom,xcom) >  1.e-2) then
-       print*,'Error in setup: Gammie (2001) cooling (icooling=3) assumes Omega = 1./r^1.5'
+       print*,'ERROR: Gammie (2001) cooling (icooling=3) assumes Omega = 1./r^1.5'
        print*,'                but the centre of mass is not at the origin!'
        nerror = nerror + 1
     endif
  endif
 
  if (nerror==0 .and. nwarn==0) then
-    if (id==master) write(*,"(1x,a)") 'Particle setup OK'
+!
+!--print centre of mass (must be done AFTER types have been checked)
+!  ALSO, only print this if there are no warnings or errors to avoid obscuring warnings
+!
+    call get_centreofmass(xcom,vcom,npart,xyzh,vxyzu,nptmass,xyzmh_ptmass,vxyz_ptmass)
+    if (id==master) then
+       write(*,"(a,2(es10.3,', '),es10.3,a)") ' Centre of mass is at (x,y,z) = (',xcom,')'
+       write(*,"(1x,a)") 'Particle setup OK'
+    endif
  endif
 
 end subroutine check_setup
@@ -486,17 +488,17 @@ subroutine check_setup_ptmass(nerror,nwarn,hmin)
  real :: r,hsink
 
  if (gr .and. nptmass > 0) then
-    print*,' Warning! Error in setup: nptmass = ',nptmass, ' should be = 0 for GR'
+    print*,' ERROR: nptmass = ',nptmass, ' should be = 0 for GR'
     nwarn = nwarn + 1
     return
  endif
 
  if (nptmass < 0) then
-    print*,' Error in setup: nptmass = ',nptmass, ' should be >= 0 '
+    print*,' ERROR: nptmass = ',nptmass, ' should be >= 0 '
     nerror = nerror + 1
  endif
  if (nptmass > maxptmass) then
-    print*,' Error in setup: nptmass = ',nptmass,' exceeds ptmass array dimensions of ',maxptmass
+    print*,' ERROR: nptmass = ',nptmass,' exceeds ptmass array dimensions of ',maxptmass
     nerror = nerror + 1
     return
  endif
@@ -512,10 +514,10 @@ subroutine check_setup_ptmass(nerror,nwarn,hmin)
        dx = xyzmh_ptmass(1:3,j) - xyzmh_ptmass(1:3,i)
        r  = sqrt(dot_product(dx,dx))
        if (r <= tiny(r)) then
-          print*,'Error in setup: sink ',j,' on top of sink ',i,' at ',xyzmh_ptmass(1:3,i)
+          print*,'ERROR: sink ',j,' on top of sink ',i,' at ',xyzmh_ptmass(1:3,i)
           nerror = nerror + 1
        elseif (r <= max(xyzmh_ptmass(ihacc,i),xyzmh_ptmass(ihacc,j))) then
-          print*,'Warning: sinks ',i,' and ',j,' within each others accretion radii: sep =',&
+          print*,'WARNING: sinks ',i,' and ',j,' within each others accretion radii: sep =',&
                   r,' h = ',xyzmh_ptmass(ihacc,i),xyzmh_ptmass(ihacc,j)
           nwarn = nwarn + 1
        endif
@@ -529,7 +531,7 @@ subroutine check_setup_ptmass(nerror,nwarn,hmin)
  do i=1,nptmass
     if (.not.in_range(xyzmh_ptmass(4,i))) then
        nerror = nerror + 1
-       print*,' Error in setup: sink ',i,' mass = ',xyzmh_ptmass(4,i)
+       print*,' ERROR: sink ',i,' mass = ',xyzmh_ptmass(4,i)
     elseif (xyzmh_ptmass(4,i) < 0.) then
        print*,' Sink ',i,' has previously merged with another sink'
        n = n + 1
@@ -544,11 +546,11 @@ subroutine check_setup_ptmass(nerror,nwarn,hmin)
     hsink = max(xyzmh_ptmass(ihacc,i),xyzmh_ptmass(ihsoft,i))
     if (hsink <= 0.) then
        nerror = nerror + 1
-       print*,'Error in setup: sink ',i,' has accretion radius ',xyzmh_ptmass(ihacc,i),&
+       print*,'ERROR: sink ',i,' has accretion radius ',xyzmh_ptmass(ihacc,i),&
               ' and softening radius ',xyzmh_ptmass(ihsoft,i)
     elseif (hsink <= 0.5*hmin .and. hmin > 0.) then
        nwarn = nwarn + 1
-       print*,'Warning: sink ',i,' has unresolved accretion radius: hmin/racc = ',hmin/hsink
+       print*,'WARNING: sink ',i,' has unresolved accretion radius: hmin/racc = ',hmin/hsink
        print*,'         (this makes the code run pointlessly slow)'
     endif
  enddo

--- a/src/main/io.F90
+++ b/src/main/io.F90
@@ -218,7 +218,6 @@ subroutine formatreal(val,string,ierror,precision)
 ! endif
  string = trim(adjustl(string))
 
- return
 end subroutine formatreal
 
 !--------------------------------------------------------------------
@@ -406,12 +405,12 @@ subroutine warn(wherefrom,string,severity)
     if (buffer_warnings) then
        call buffer_warning(trim(wherefrom),trim(string),ncount)
        if (ncount < maxcount) then
-          write(iprint,"(' WARNING! ',a,': ',a)") trim(wherefrom),trim(string)
+          write(iprint,"(/' WARNING! ',a,': ',a,/)") trim(wherefrom),trim(string)
        elseif (ncount==maxcount) then
           write(iprint,"(' (buffering remaining warnings... ',a,') ')") trim(string)
        endif
     else
-       write(iprint,"(' WARNING! ',a,': ',a)") trim(wherefrom),trim(string)
+       write(iprint,"(/' WARNING! ',a,': ',a,/)") trim(wherefrom),trim(string)
     endif
  case(3)
     ncount = 0_8
@@ -434,7 +433,6 @@ subroutine warn(wherefrom,string,severity)
     write(iprint,"(/' WARNING(unknown severity)! ',a,': ',a)") trim(wherefrom),trim(string)
  end select
 
- return
 end subroutine warn
 
 !--------------------------------------------------------------------
@@ -565,6 +563,7 @@ subroutine die
 #endif
 
  call exit(1)
+
 end subroutine die
 
 end module io

--- a/src/setup/density_profiles.f90
+++ b/src/setup/density_profiles.f90
@@ -6,16 +6,15 @@
 !--------------------------------------------------------------------------!
 module rho_profile
 !
-! This contains several density profiles, including
+! This computes several radial density profiles useful for stars
+! and gravitational collapse calculations, including
 !               1) uniform
 !               2) polytrope
 !               3) piecewise polytrope
 !               4) Evrard
-!               5) Read data from MESA file
-!               6) Read data from KEPLER file
-!               7) Bonnor-Ebert sphere
+!               5) Bonnor-Ebert sphere
 !
-! :References: None
+! :References: Evrard (1988), MNRAS 235, 911-934
 !
 ! :Owner: Daniel Price
 !
@@ -27,9 +26,8 @@ module rho_profile
  implicit none
 
  public  :: rho_uniform,rho_polytrope,rho_piecewise_polytrope, &
-            rho_evrard,read_mesa,read_kepler_file, &
-            rho_bonnorebert,prompt_BEparameters
- public  :: write_profile,calc_mass_enc
+            rho_evrard,rho_bonnorebert,prompt_BEparameters
+ public  :: calc_mass_enc
  private :: integrate_rho_profile
 
  abstract interface
@@ -42,7 +40,6 @@ contains
 
 !-----------------------------------------------------------------------
 !+
-!  Option 1:
 !  Uniform density sphere
 !+
 !-----------------------------------------------------------------------
@@ -64,7 +61,6 @@ end subroutine rho_uniform
 
 !-----------------------------------------------------------------------
 !+
-!  Option 2:
 !  Density profile for a polytrope (assumes G==1)
 !+
 !-----------------------------------------------------------------------
@@ -142,7 +138,6 @@ end subroutine rho_polytrope
 
 !-----------------------------------------------------------------------
 !+
-!  Option 3:
 !  Calculate the density profile for a piecewise polytrope
 !  Original Authors: Madeline Marshall & Bernard Field
 !  Supervisors: James Wurster & Paul Lasky
@@ -287,7 +282,6 @@ end subroutine calc_mass_enc
 
 !-----------------------------------------------------------------------
 !+
-!  Option 4:
 !  Calculate the density profile for the Evrard Collapse
 !+
 !-----------------------------------------------------------------------
@@ -308,372 +302,6 @@ end subroutine rho_evrard
 
 !-----------------------------------------------------------------------
 !+
-!  Read quantities from MESA profile or from profile in the format of
-!  the P12 star (phantom/data/star_data_files/P12_Phantom_Profile.data)
-!+
-!-----------------------------------------------------------------------
-subroutine read_mesa(filepath,rho,r,pres,m,ene,temp,Xfrac,Yfrac,Mstar,ierr,cgsunits)
- use physcon,   only:solarm,solarr
- use eos,       only:X_in,Z_in
- use fileutils, only:get_nlines,get_ncolumns,string_delete,lcase
- use datafiles, only:find_phantom_datafile
- use units,     only:udist,umass,unit_density,unit_pressure,unit_ergg
- integer                                    :: lines,rows,i,ncols,nheaderlines,iu
- character(len=*), intent(in)               :: filepath
- logical, intent(in), optional              :: cgsunits
- integer, intent(out)                       :: ierr
- character(len=10000)                       :: dumc
- character(len=120)                         :: fullfilepath
- character(len=24),allocatable              :: header(:),dum(:)
- logical                                    :: iexist,usecgs,ismesafile,got_column
- real,allocatable,dimension(:,:)            :: dat
- real,allocatable,dimension(:),intent(out)  :: rho,r,pres,m,ene,temp,Xfrac,Yfrac
- real, intent(out)                          :: Mstar
-
- rows = 0
- usecgs = .false.
- if (present(cgsunits)) usecgs = cgsunits
- !
- !--Get path name
- !
- ierr = 0
- fullfilepath = find_phantom_datafile(filepath,'star_data_files')
- inquire(file=trim(fullfilepath),exist=iexist)
- if (.not.iexist) then
-    ierr = 1
-    return
- endif
- lines = get_nlines(fullfilepath) ! total number of lines in file
-
- print "(1x,a)",trim(fullfilepath)
- open(newunit=iu,file=fullfilepath,status='old')
- call get_ncolumns(iu,ncols,nheaderlines)
- if (nheaderlines == 6) then ! Assume file is a MESA profile, and so it has 6 header lines, and (row=3, col=2) = number of zones
-    read(iu,'()')
-    read(iu,'()')
-    read(iu,*) lines,lines
-    read(iu,'()')
-    read(iu,'()')
-    ismesafile = .true.
- else
-    ismesafile = .false.
-    lines = lines - nheaderlines
-    do i = 1,nheaderlines-1
-       read(iu,'()')
-    enddo
- endif
- if (lines <= 0) then ! file not found
-    ierr = 1
-    return
- endif
-
- read(iu,'(a)') dumc! counting rows
- call string_delete(dumc,'[')
- call string_delete(dumc,']')
- allocate(dum(500)) ; dum = 'aaa'
- read(dumc,*,end=101) dum
-101 continue
- do i = 1,500
-    if (dum(i)=='aaa') then
-       rows = i-1
-       exit
-    endif
- enddo
- allocate(header(rows),dat(lines,rows))
- header(1:rows) = dum(1:rows)
- deallocate(dum)
- do i = 1,lines
-    read(iu,*) dat(lines-i+1,1:rows)
- enddo
-
- allocate(m(lines),r(lines),pres(lines),rho(lines),ene(lines), &
-             temp(lines),Xfrac(lines),Yfrac(lines))
-
- close(iu)
- ! Set mass fractions to default in eos module if not in file
- Xfrac = X_in
- Yfrac = 1. - X_in - Z_in
- do i = 1,rows
-    if (header(i)(1:1) == '#' .and. .not. trim(lcase(header(i)))=='#mass') then
-       print '("Detected wrong header entry : ",A," in file ",A)',trim(lcase(header(i))),trim(fullfilepath)
-       ierr = 2
-       return
-    endif
-    got_column = .true.
-    select case(trim(lcase(header(i))))
-    case('mass_grams')
-       m = dat(1:lines,i)
-    case('mass','#mass')
-       m = dat(1:lines,i)
-       if (ismesafile) m = m * solarm  ! If reading MESA profile, 'mass' is in units of Msun
-    case('rho','density')
-       rho = dat(1:lines,i)
-    case('logrho')
-       rho = 10**(dat(1:lines,i))
-    case('energy','e_int','e_internal')
-       ene = dat(1:lines,i)
-    case('radius_cm')
-       r = dat(1:lines,i)
-    case('radius')
-       r = dat(1:lines,i)
-       if (ismesafile) r = r * solarr
-    case('logr')
-       r = (10**dat(1:lines,i)) * solarr
-    case('pressure')
-       pres = dat(1:lines,i)
-    case('temperature')
-       temp = dat(1:lines,i)
-    case('x_mass_fraction_h','xfrac')
-       Xfrac = dat(1:lines,i)
-    case('y_mass_fraction_he','yfrac')
-       Yfrac = dat(1:lines,i)
-    case default
-       got_column = .false.
-    end select
-    if (got_column) print "(1x,i0,': ',a)",i,trim(header(i))
- enddo
- print "(a)"
-
- if (.not. usecgs) then
-    m = m / umass
-    r = r / udist
-    pres = pres / unit_pressure
-    rho = rho / unit_density
-    ene = ene / unit_ergg
- endif
-
- Mstar = m(lines)
-
-end subroutine read_mesa
-
-!----------------------------------------------------------------
-!+
-!  Write stellar profile in format readable by read_mesa;
-!  used in star setup to write softened stellar profile.
-!+
-!----------------------------------------------------------------
-subroutine write_profile(outputpath,m,pres,temp,r,rho,ene,Xfrac,Yfrac,csound,mu)
- real, intent(in)                :: m(:),rho(:),pres(:),r(:),ene(:),temp(:)
- real, intent(in), optional      :: Xfrac(:),Yfrac(:),csound(:),mu(:)
- character(len=120), intent(in)  :: outputpath
- character(len=200)              :: headers
- integer                         :: i,noptionalcols,j,iu
- real, allocatable               :: optionalcols(:,:)
-
- headers = '[    Mass   ]  [  Pressure ]  [Temperature]  [   Radius  ]  [  Density  ]  [   E_int   ]'
-
- ! Add optional columns
- allocate(optionalcols(size(r),10))
- noptionalcols = 0
- if (present(Xfrac)) then
-    noptionalcols = noptionalcols + 1
-    headers = trim(headers) // '  [   Xfrac   ]'
-    optionalcols(:,noptionalcols) = Xfrac
- endif
- if (present(Yfrac)) then
-    noptionalcols = noptionalcols + 1
-    headers = trim(headers) // '  [   Yfrac   ]'
-    optionalcols(:,noptionalcols) = Yfrac
- endif
- if (present(mu)) then
-    noptionalcols = noptionalcols + 1
-    headers = trim(headers) // '  [    mu     ]'
-    optionalcols(:,noptionalcols) = mu
- endif
- if (present(csound)) then
-    noptionalcols = noptionalcols + 1
-    headers = trim(headers) // '  [Sound speed]'
-    optionalcols(:,noptionalcols) = csound
- endif
-
- open(newunit=iu, file = outputpath, status = 'replace')
- write(iu,'(a)') headers
-101 format (es13.6,2x,es13.6,2x,es13.6,2x,es13.6,2x,es13.6,2x,es13.6)
- do i=1,size(r)
-    if (noptionalcols <= 0) then
-       write(iu,101) m(i),pres(i),temp(i),r(i),rho(i),ene(i)
-    else
-       write(iu,101,advance="no") m(i),pres(i),temp(i),r(i),rho(i),ene(i)
-       do j=1,noptionalcols
-          if (j==noptionalcols) then
-             write(iu,'(2x,es13.6)') optionalcols(i,j)
-          else
-             write(iu,'(2x,es13.6)',advance="no") optionalcols(i,j)
-          endif
-       enddo
-    endif
- enddo
- close(iu)
-
-end subroutine write_profile
-
-!-----------------------------------------------------------------------
-!+
-!  Option 6:
-!  Read in datafile from the KEPLER stellar evolution code
-!+
-!-----------------------------------------------------------------------
-subroutine read_kepler_file(filepath,ng_max,n_rows,rtab,rhotab,ptab,temperature,&
-                               enitab,totmass,composition,comp_label,columns_compo,ierr,mcut,rcut  )
- use units,     only                      : udist,umass,unit_density,unit_pressure,unit_ergg
- use datafiles, only                      : find_phantom_datafile
- use fileutils, only                      : get_ncolumns,get_nlines,skip_header,get_column_labels
-
- integer,intent(in)                       :: ng_max
- integer,intent(out)                      :: ierr,n_rows
- real,allocatable,intent(out)             :: rtab(:),rhotab(:),ptab(:),temperature(:),enitab(:)
- real,intent(out),allocatable             :: composition(:,:)
- real,intent(out)                         :: totmass
- real,intent(out),optional                :: rcut
- real,intent(in),optional                 :: mcut
- character(len=20),allocatable,intent(out):: comp_label(:)
- character(len=20),allocatable            :: all_label(:) !This contains all labels read from KEPLER file.
- character(len=*),intent(in)              :: filepath
- integer,intent(out)                      :: columns_compo
-
- character(len=120)                       :: fullfilepath
- character(len=10000)                     :: line
-
- integer                                  :: k,aloc,i,column_no,n_cols,n_labels
- integer                                  :: nheaderlines,skip_no
- real,allocatable                         :: stardata(:,:)
- logical                                  :: iexist,n_too_big,composition_available
-
- !
- !--Get path name
- !
- ierr = 0
- fullfilepath = find_phantom_datafile(filepath,'star_data_files')
- inquire(file=trim(fullfilepath),exist=iexist)
- if (.not.iexist) then
-    ierr = 1
-    return
- endif
- !
- !--Read data from file
- !
- k = 1
- n_rows = 0
- n_cols = 0
- n_too_big = .false.
- composition_available = .false.
- skip_no = 0
- !
- !--Calculate the number of rows, columns and comments in kepler file.
- !
- n_rows = get_nlines(trim(fullfilepath),skip_comments=.true.,n_columns=n_cols,n_headerlines=nheaderlines)
- !
- !--Check if the number of rows is 0 or greater than ng_max.
- !
- if (n_rows < 1 .or. n_cols < 1) then
-    ierr = 2
-    return
- endif
-
- if (n_rows >= ng_max) n_too_big = .true.
-
- if (n_too_big) then
-    ierr = 3
-    return
- endif
-
- print "(a,i5)",' number of data rows = ', n_rows
- !
- !--If there is 'nt1' in the column headings, we know the file contains composition.
- !--This is used as a test for saving composition.
- !
- ierr = 0
- OPEN(UNIT=11, file=trim(fullfilepath))
- !The row with the information about column headings is at nheaderlines-1.
- !we skip the first nheaderlines-2 rows and then read the nheaderlines-1 to find the substrings
- call skip_header(11,nheaderlines-2,ierr)
- read(11, '(a)', iostat=ierr) line
-
- !read the column labels and store them in an array.
- allocate(all_label(n_cols))
- call get_column_labels(line,n_labels,all_label)
- close(11)
-
- !check which label gives nt1.
- do i = 1,len(all_label)
-    if (all_label(i) == 'nt1') then
-       skip_no = i - 1
-       composition_available = .true.
-    endif
- enddo
-
- !Allocate memory for saving data
- allocate(stardata(n_rows, n_cols))
- allocate(rtab(n_rows),rhotab(n_rows),ptab(n_rows),temperature(n_rows),enitab(n_rows))
- !
- !--Read the file again and save the data in stardata tensor.
- !
- open(UNIT=11, file=trim(fullfilepath))
- call skip_header(11,nheaderlines,ierr)
- do k=1,n_rows
-    read(11,*,iostat=ierr) stardata(k,:)
- enddo
- close(11)
- !
- !--Save the relevant information we require into arrays that can be used later.
- !--convert relevant data from CGS to code units
- !
- !radius
- stardata(1:n_rows,4)  = stardata(1:n_rows,4)/udist
- rtab(1:n_rows)        = stardata(1:n_rows,4)
-
- !density
- stardata(1:n_rows,6)  = stardata(1:n_rows,6)/unit_density
- rhotab(1:n_rows)      = stardata(1:n_rows,6)
- !mass
- stardata(1:n_rows,3)  = stardata(1:n_rows,3)/umass
- totmass               = stardata(n_rows,3)
- !pressure
- stardata(1:n_rows,8)  = stardata(1:n_rows,8)/unit_pressure
- ptab(1:n_rows)        = stardata(1:n_rows,8)
-
- !temperature
- temperature(1:n_rows) = stardata(1:n_rows,7)
-
- !specific internal energy
- stardata(1:n_rows,9)  = stardata(1:n_rows,9)/unit_ergg
- enitab(1:n_rows)      = stardata(1:n_rows,9)
-
- print*, totmass*umass, "Total Mass",rtab(n_rows)*udist,"max radius"
-
- !if elements were found in the file read, save the composition by allocating an array
- !else set it to 0
- if (composition_available) then
-    !saving composition. In a composition file of KEPLER, we have first 13 columns that do not contain composition
-    !We skip them and store the rest into a composition tensor.
-    print*, 'Kepler file has composition.'
-    columns_compo = 0
-    allocate(composition(n_rows,n_cols-skip_no))
-    allocate(comp_label(n_cols-skip_no))
-    comp_label(:) = all_label(skip_no+1:n_cols)
-    column_no = skip_no + 1
-    do i = 1, n_cols-skip_no
-       composition(:,i) = stardata(:,column_no)
-       column_no        = column_no + 1
-    enddo
-    columns_compo = n_cols-skip_no
- else
-    allocate(composition(0,0))
-    allocate(comp_label(0))
- endif
- print*, shape(composition),'shape of composition array'
- if (present(rcut) .and. present(mcut)) then
-    aloc = minloc(abs(stardata(1:n_rows,1) - mcut),1)
-    rcut = rtab(aloc)
-    print*, 'rcut = ', rcut
- endif
- print*, 'Finished reading KEPLER file'
- print*, '------------------------------------------------------------'
-
-end subroutine read_kepler_file
-!-----------------------------------------------------------------------
-!+
-!  Option 7:
 !  Calculates a Bonnor-Ebert sphere
 !
 !  Examples:

--- a/src/setup/phantomsetup.F90
+++ b/src/setup/phantomsetup.F90
@@ -118,7 +118,7 @@ program phantomsetup
  else ! non-mpi
     nprocsfake = int(get_command_option('nprocsfake',default=1))
     nprocs= nprocsfake
-    print*,' nprocs = ',nprocs
+    if (nprocs > 1) print*,' nprocs = ',nprocs
     call init_domains(nprocs)
     id = 0
  endif

--- a/src/setup/relax_star.f90
+++ b/src/setup/relax_star.f90
@@ -35,7 +35,8 @@ module relaxstar
 
  integer, public :: ierr_setup_errors = 1, &
                     ierr_no_pressure  = 2, &
-                    ierr_unbound = 3
+                    ierr_unbound = 3, &
+                    ierr_notconverged = 4
 
  private
 
@@ -166,7 +167,7 @@ subroutine relax_star(nt,rho,pr,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,ierr)
     call init_step(npart,t,dtmax)
  endif
  nits = 0
- do while (.not. converged)
+ do while (.not. converged .and. nits < maxits)
     nits = nits + 1
     !
     ! shift particles by one "timestep"
@@ -186,8 +187,7 @@ subroutine relax_star(nt,rho,pr,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,ierr)
     ! compute energies and check for convergence
     !
     call compute_energies(t)
-    converged = ((ekin > 0. .and. ekin/abs(epot) < tol_ekin .and. &
-                 rmserr < 0.01*tol_dens) .or. nits >= maxits)
+    converged = (ekin > 0. .and. ekin/abs(epot) < tol_ekin .and. rmserr < 0.01*tol_dens)
     !
     ! print information to screen
     !
@@ -209,9 +209,12 @@ subroutine relax_star(nt,rho,pr,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,ierr)
        !
        ! write dump files
        !
-       if (mod(nits,10)==0) then
+       if (mod(nits,100)==0) then
           filename = getnextfilename(filename)
-          ! give the real thermal energy profile so the file is useable as a starting file for the main calculation
+          !
+          ! before writing a file, set the real thermal energy profile
+          ! so the file is useable as a starting file for the main calculation
+          !
           if (use_var_comp) call set_star_composition(use_var_comp,eos_outputs_mu(ieos_prev),&
                                                       npart,xyzh,Xfrac,Yfrac,mu,mr,mstar,eos_vars)
           if (maxvxyzu==4) call set_star_thermalenergy(ieos_prev,rho,pr,r,nt,npart,xyzh,vxyzu,rad,&
@@ -224,6 +227,13 @@ subroutine relax_star(nt,rho,pr,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,ierr)
     endif
  enddo
  if (write_files) close(iunit)
+ !
+ ! warn if relaxation finished due to hitting nits=nitsmax
+ !
+ if (.not.converged) then
+    call warning('relax_star','relaxation did not converge, just reached max iterations')
+    ierr = ierr_notconverged
+ endif
  !
  ! unfake some things
  !
@@ -352,8 +362,6 @@ subroutine set_options_for_relaxation(tdyn)
  !
  ! turn on settings appropriate to relaxation
  !
- !gamma = 2.
- !hfact = 0.8 !0.7
  if (maxvxyzu >= 4) ieos = 2
  if (tdyn > 0.) then
     idamp = 2

--- a/src/setup/set_fixedentropycore.f90
+++ b/src/setup/set_fixedentropycore.f90
@@ -131,13 +131,11 @@ subroutine calc_rho_and_pres(r,mcore,mh,rho,pres,Xcore,Ycore)
        msoft = mh - mcore
     endif
     if (mold * mass < 0.) fac = fac * 0.5
-    if (mold == mass) then
-       write(*,'(a,f12.5)') 'Warning: Setting fixed entropy for m(r=0)/msoft = ',mass/msoft
+    if (abs(mold-mass) < tiny(0.)) then
+       write(*,'(/,1x,a,f12.5)') 'WARNING: Setting fixed entropy for m(r=0)/msoft = ',mass/msoft
        exit
     endif
  enddo
-
- return
 
 end subroutine calc_rho_and_pres
 
@@ -179,8 +177,6 @@ subroutine one_shot(Sc,r,mcore,msoft,mu,rho,pres,mass)
     mass = mass - 0.5*(rho(i)+rho(i-1)) * dvol(i)
     if (mass < 0.) return ! m(r) < 0 encountered, exit and decrease mcore
  enddo
-
- return
 
 end subroutine one_shot
 

--- a/src/setup/set_star_kepler.f90
+++ b/src/setup/set_star_kepler.f90
@@ -1,0 +1,251 @@
+!--------------------------------------------------------------------------!
+! The Phantom Smoothed Particle Hydrodynamics code, by Daniel Price et al. !
+! Copyright (c) 2007-2023 The Authors (see AUTHORS)                        !
+! See LICENCE file for usage and distribution conditions                   !
+! http://phantomsph.bitbucket.io/                                          !
+!--------------------------------------------------------------------------!
+module setstar_kepler
+!
+! Utilities for reading in/out stellar profiles from the Kepler stellar
+! evolution code
+!
+! :References: None
+!
+! :Owner: Megha Sharma
+!
+! :Runtime parameters: None
+!
+! :Dependencies: datafiles, fileutils, table_utils, units
+!
+ implicit none
+
+ public :: read_kepler_file,write_kepler_comp
+
+ private
+
+contains
+
+!-----------------------------------------------------------------------
+!+
+!  Read in datafile from the KEPLER stellar evolution code
+!+
+!-----------------------------------------------------------------------
+subroutine read_kepler_file(filepath,ng_max,n_rows,rtab,rhotab,ptab,temperature,&
+                            enitab,totmass,composition,comp_label,columns_compo,ierr,mcut,rcut)
+ use units,     only:udist,umass,unit_density,unit_pressure,unit_ergg
+ use datafiles, only:find_phantom_datafile
+ use fileutils, only:get_ncolumns,get_nlines,skip_header,get_column_labels
+
+ integer,intent(in)                       :: ng_max
+ integer,intent(out)                      :: ierr,n_rows
+ real,allocatable,intent(out)             :: rtab(:),rhotab(:),ptab(:),temperature(:),enitab(:)
+ real,intent(out),allocatable             :: composition(:,:)
+ real,intent(out)                         :: totmass
+ real,intent(out),optional                :: rcut
+ real,intent(in),optional                 :: mcut
+ character(len=20),allocatable,intent(out):: comp_label(:)
+ character(len=20),allocatable            :: all_label(:) !This contains all labels read from KEPLER file.
+ character(len=*),intent(in)              :: filepath
+ integer,intent(out)                      :: columns_compo
+
+ character(len=120)                       :: fullfilepath
+ character(len=10000)                     :: line
+
+ integer                                  :: k,aloc,i,column_no,n_cols,n_labels,iu
+ integer                                  :: nheaderlines,skip_no
+ real,allocatable                         :: stardata(:,:)
+ logical                                  :: iexist,n_too_big,composition_available
+
+ !
+ !--Get path name
+ !
+ ierr = 0
+ fullfilepath = find_phantom_datafile(filepath,'star_data_files')
+ inquire(file=trim(fullfilepath),exist=iexist)
+ if (.not.iexist) then
+    ierr = 1
+    return
+ endif
+ !
+ !--Read data from file
+ !
+ k = 1
+ n_rows = 0
+ n_cols = 0
+ n_too_big = .false.
+ composition_available = .false.
+ skip_no = 0
+ !
+ !--Calculate the number of rows, columns and comments in kepler file.
+ !
+ n_rows = get_nlines(trim(fullfilepath),skip_comments=.true.,n_columns=n_cols,n_headerlines=nheaderlines)
+ !
+ !--Check if the number of rows is 0 or greater than ng_max.
+ !
+ if (n_rows < 1 .or. n_cols < 1) then
+    ierr = 2
+    return
+ endif
+
+ if (n_rows >= ng_max) n_too_big = .true.
+
+ if (n_too_big) then
+    ierr = 3
+    return
+ endif
+
+ print "(a,i5)",' number of data rows = ', n_rows
+ !
+ !--If there is 'nt1' in the column headings, we know the file contains composition.
+ !--This is used as a test for saving composition.
+ !
+ ierr = 0
+ open(newunit=iu, file=trim(fullfilepath))
+ !The row with the information about column headings is at nheaderlines-1.
+ !we skip the first nheaderlines-2 rows and then read the nheaderlines-1 to find the substrings
+ call skip_header(iu,nheaderlines-2,ierr)
+ read(iu, '(a)', iostat=ierr) line
+
+ !read the column labels and store them in an array.
+ allocate(all_label(n_cols))
+ call get_column_labels(line,n_labels,all_label)
+ close(iu)
+
+ !check which label gives nt1.
+ do i = 1,len(all_label)
+    if (all_label(i) == 'nt1') then
+       skip_no = i - 1
+       composition_available = .true.
+    endif
+ enddo
+
+ !Allocate memory for saving data
+ allocate(stardata(n_rows, n_cols))
+ allocate(rtab(n_rows),rhotab(n_rows),ptab(n_rows),temperature(n_rows),enitab(n_rows))
+ !
+ !--Read the file again and save the data in stardata tensor.
+ !
+ open(newunit=iu, file=trim(fullfilepath))
+ call skip_header(iu,nheaderlines,ierr)
+ do k=1,n_rows
+    read(iu,*,iostat=ierr) stardata(k,:)
+ enddo
+ close(iu)
+ !
+ !--Save the relevant information we require into arrays that can be used later.
+ !--convert relevant data from CGS to code units
+ !
+ !radius
+ stardata(1:n_rows,4)  = stardata(1:n_rows,4)/udist
+ rtab(1:n_rows)        = stardata(1:n_rows,4)
+
+ !density
+ stardata(1:n_rows,6)  = stardata(1:n_rows,6)/unit_density
+ rhotab(1:n_rows)      = stardata(1:n_rows,6)
+ !mass
+ stardata(1:n_rows,3)  = stardata(1:n_rows,3)/umass
+ totmass               = stardata(n_rows,3)
+ !pressure
+ stardata(1:n_rows,8)  = stardata(1:n_rows,8)/unit_pressure
+ ptab(1:n_rows)        = stardata(1:n_rows,8)
+
+ !temperature
+ temperature(1:n_rows) = stardata(1:n_rows,7)
+
+ !specific internal energy
+ stardata(1:n_rows,9)  = stardata(1:n_rows,9)/unit_ergg
+ enitab(1:n_rows)      = stardata(1:n_rows,9)
+
+ print*, totmass*umass, "Total Mass",rtab(n_rows)*udist,"max radius"
+
+ !if elements were found in the file read, save the composition by allocating an array
+ !else set it to 0
+ if (composition_available) then
+    !saving composition. In a composition file of KEPLER, we have first 13 columns that do not contain composition
+    !We skip them and store the rest into a composition tensor.
+    print*, 'Kepler file has composition.'
+    columns_compo = 0
+    allocate(composition(n_rows,n_cols-skip_no))
+    allocate(comp_label(n_cols-skip_no))
+    comp_label(:) = all_label(skip_no+1:n_cols)
+    column_no = skip_no + 1
+    do i = 1, n_cols-skip_no
+       composition(:,i) = stardata(:,column_no)
+       column_no        = column_no + 1
+    enddo
+    columns_compo = n_cols-skip_no
+ else
+    allocate(composition(0,0))
+    allocate(comp_label(0))
+ endif
+ print*, shape(composition),'shape of composition array'
+ if (present(rcut) .and. present(mcut)) then
+    aloc = minloc(abs(stardata(1:n_rows,1) - mcut),1)
+    rcut = rtab(aloc)
+    print*, 'rcut = ', rcut
+ endif
+ print*, 'Finished reading KEPLER file'
+ print*, '------------------------------------------------------------'
+
+end subroutine read_kepler_file
+
+!-----------------------------------------------------------------------
+!+
+!  Write kepler.comp which is file that contains interpolated composition
+!  for each particle. This works for ikepler only.
+!  Interpolating composition for each particle in the star.
+!  For now I write a file with the interpolate data
+!  This is used in analysis kepler file to bin composition.
+!
+!+
+!-----------------------------------------------------------------------
+subroutine write_kepler_comp(composition,comp_label,columns_compo,r,&
+                             xyzh,npart,npts,composition_exists)
+
+ use table_utils, only:yinterp
+ integer, intent(in)                        :: columns_compo,npart,npts
+ real,    intent(in)                        :: xyzh(:,:)
+ real, allocatable,intent(in)               :: r(:)
+ real, allocatable, intent(in)              :: composition(:,:)
+ character(len=20), allocatable,intent(in)  :: comp_label(:)
+ real , allocatable                         :: compositioni(:,:)
+ logical, intent(out)                       :: composition_exists
+ real, allocatable                          :: comp(:)
+ integer                                    :: i,j,iu
+ real                                       :: ri
+
+ composition_exists = .false.
+
+ ! !Check if composition exists. If composition array is non-zero, we use it to interpolate composition for each particle
+ ! !in the star.
+ if (columns_compo /= 0) then
+    composition_exists = .true.
+ endif
+
+ if (composition_exists) then
+    print*, 'Writing the stellar composition for each particle into ','kepler.comp'
+
+    open(newunit=iu,file='kepler.comp')
+    write(iu,"('#',50(1x,'[',1x,a7,']',2x))") &
+            comp_label
+    !Now setting the composition of star if the case used was ikepler
+    allocate(compositioni(columns_compo,1))
+    allocate(comp(1:npts))
+    do i = 1,npart
+       !Interpolate compositions
+       ri = sqrt(dot_product(xyzh(1:3,i),xyzh(1:3,i)))
+
+       do j = 1,columns_compo
+          comp(1:npts)      = composition(1:npts,j)
+          compositioni(j,1) = yinterp(comp(1:npts),r(1:npts),ri)
+       enddo
+       write(iu,'(50(es18.10,1X))') &
+            (compositioni(j,1),j=1,columns_compo)
+    enddo
+    close(iu)
+    print*, '>>>>>> done'
+ endif
+
+end subroutine write_kepler_comp
+
+end module setstar_kepler

--- a/src/setup/set_star_mesa.f90
+++ b/src/setup/set_star_mesa.f90
@@ -1,0 +1,228 @@
+!--------------------------------------------------------------------------!
+! The Phantom Smoothed Particle Hydrodynamics code, by Daniel Price et al. !
+! Copyright (c) 2007-2023 The Authors (see AUTHORS)                        !
+! See LICENCE file for usage and distribution conditions                   !
+! http://phantomsph.bitbucket.io/                                          !
+!--------------------------------------------------------------------------!
+module setstar_mesa
+!
+! Utility routines for reading stellar profiles from the MESA code
+!
+! :References: Paxton et al. (2011), ApJS 192, 3
+!
+! :Owner: Daniel Price
+!
+! :Runtime parameters: None
+!
+! :Dependencies: datafiles, eos, fileutils, physcon, units
+!
+ implicit none
+
+ public :: read_mesa,write_mesa
+
+ private
+
+contains
+!-----------------------------------------------------------------------
+!+
+!  Read quantities from MESA profile or from profile in the format of
+!  the P12 star (phantom/data/star_data_files/P12_Phantom_Profile.data)
+!+
+!-----------------------------------------------------------------------
+subroutine read_mesa(filepath,rho,r,pres,m,ene,temp,Xfrac,Yfrac,Mstar,ierr,cgsunits)
+ use physcon,   only:solarm,solarr
+ use eos,       only:X_in,Z_in
+ use fileutils, only:get_nlines,get_ncolumns,string_delete,lcase
+ use datafiles, only:find_phantom_datafile
+ use units,     only:udist,umass,unit_density,unit_pressure,unit_ergg
+ integer                                    :: lines,rows,i,ncols,nheaderlines,iu
+ character(len=*), intent(in)               :: filepath
+ logical, intent(in), optional              :: cgsunits
+ integer, intent(out)                       :: ierr
+ character(len=10000)                       :: dumc
+ character(len=120)                         :: fullfilepath
+ character(len=24),allocatable              :: header(:),dum(:)
+ logical                                    :: iexist,usecgs,ismesafile,got_column
+ real,allocatable,dimension(:,:)            :: dat
+ real,allocatable,dimension(:),intent(out)  :: rho,r,pres,m,ene,temp,Xfrac,Yfrac
+ real, intent(out)                          :: Mstar
+
+ rows = 0
+ usecgs = .false.
+ if (present(cgsunits)) usecgs = cgsunits
+ !
+ !--Get path name
+ !
+ ierr = 0
+ fullfilepath = find_phantom_datafile(filepath,'star_data_files')
+ inquire(file=trim(fullfilepath),exist=iexist)
+ if (.not.iexist) then
+    ierr = 1
+    return
+ endif
+ lines = get_nlines(fullfilepath) ! total number of lines in file
+
+ print "(1x,a)",trim(fullfilepath)
+ open(newunit=iu,file=fullfilepath,status='old')
+ call get_ncolumns(iu,ncols,nheaderlines)
+ if (nheaderlines == 6) then ! Assume file is a MESA profile, and so it has 6 header lines, and (row=3, col=2) = number of zones
+    read(iu,'()')
+    read(iu,'()')
+    read(iu,*) lines,lines
+    read(iu,'()')
+    read(iu,'()')
+    ismesafile = .true.
+ else
+    ismesafile = .false.
+    lines = lines - nheaderlines
+    do i = 1,nheaderlines-1
+       read(iu,'()')
+    enddo
+ endif
+ if (lines <= 0) then ! file not found
+    ierr = 1
+    return
+ endif
+
+ read(iu,'(a)') dumc! counting rows
+ call string_delete(dumc,'[')
+ call string_delete(dumc,']')
+ allocate(dum(500)) ; dum = 'aaa'
+ read(dumc,*,end=101) dum
+101 continue
+ do i = 1,500
+    if (dum(i)=='aaa') then
+       rows = i-1
+       exit
+    endif
+ enddo
+ allocate(header(rows),dat(lines,rows))
+ header(1:rows) = dum(1:rows)
+ deallocate(dum)
+ do i = 1,lines
+    read(iu,*) dat(lines-i+1,1:rows)
+ enddo
+
+ allocate(m(lines),r(lines),pres(lines),rho(lines),ene(lines), &
+             temp(lines),Xfrac(lines),Yfrac(lines))
+
+ close(iu)
+ ! Set mass fractions to default in eos module if not in file
+ Xfrac = X_in
+ Yfrac = 1. - X_in - Z_in
+ do i = 1,rows
+    if (header(i)(1:1) == '#' .and. .not. trim(lcase(header(i)))=='#mass') then
+       print '("Detected wrong header entry : ",A," in file ",A)',trim(lcase(header(i))),trim(fullfilepath)
+       ierr = 2
+       return
+    endif
+    got_column = .true.
+    select case(trim(lcase(header(i))))
+    case('mass_grams')
+       m = dat(1:lines,i)
+    case('mass','#mass')
+       m = dat(1:lines,i)
+       if (ismesafile) m = m * solarm  ! If reading MESA profile, 'mass' is in units of Msun
+    case('rho','density')
+       rho = dat(1:lines,i)
+    case('logrho')
+       rho = 10**(dat(1:lines,i))
+    case('energy','e_int','e_internal')
+       ene = dat(1:lines,i)
+    case('radius_cm')
+       r = dat(1:lines,i)
+    case('radius')
+       r = dat(1:lines,i)
+       if (ismesafile) r = r * solarr
+    case('logr')
+       r = (10**dat(1:lines,i)) * solarr
+    case('pressure')
+       pres = dat(1:lines,i)
+    case('temperature')
+       temp = dat(1:lines,i)
+    case('x_mass_fraction_h','xfrac')
+       Xfrac = dat(1:lines,i)
+    case('y_mass_fraction_he','yfrac')
+       Yfrac = dat(1:lines,i)
+    case default
+       got_column = .false.
+    end select
+    if (got_column) print "(1x,i0,': ',a)",i,trim(header(i))
+ enddo
+ print "(a)"
+
+ if (.not. usecgs) then
+    m = m / umass
+    r = r / udist
+    pres = pres / unit_pressure
+    rho = rho / unit_density
+    ene = ene / unit_ergg
+ endif
+
+ Mstar = m(lines)
+
+end subroutine read_mesa
+
+!----------------------------------------------------------------
+!+
+!  Write stellar profile in format readable by read_mesa;
+!  used in star setup to write softened stellar profile.
+!+
+!----------------------------------------------------------------
+subroutine write_mesa(outputpath,m,pres,temp,r,rho,ene,Xfrac,Yfrac,csound,mu)
+ real, intent(in)                :: m(:),rho(:),pres(:),r(:),ene(:),temp(:)
+ real, intent(in), optional      :: Xfrac(:),Yfrac(:),csound(:),mu(:)
+ character(len=120), intent(in)  :: outputpath
+ character(len=200)              :: headers
+ integer                         :: i,noptionalcols,j,iu
+ real, allocatable               :: optionalcols(:,:)
+ character(len=*), parameter     :: fmtstring = "(5(es13.6,2x),es13.6)"
+
+ headers = '[    Mass   ]  [  Pressure ]  [Temperature]  [   Radius  ]  [  Density  ]  [   E_int   ]'
+
+ ! Add optional columns
+ allocate(optionalcols(size(r),10))
+ noptionalcols = 0
+ if (present(Xfrac)) then
+    noptionalcols = noptionalcols + 1
+    headers = trim(headers) // '  [   Xfrac   ]'
+    optionalcols(:,noptionalcols) = Xfrac
+ endif
+ if (present(Yfrac)) then
+    noptionalcols = noptionalcols + 1
+    headers = trim(headers) // '  [   Yfrac   ]'
+    optionalcols(:,noptionalcols) = Yfrac
+ endif
+ if (present(mu)) then
+    noptionalcols = noptionalcols + 1
+    headers = trim(headers) // '  [    mu     ]'
+    optionalcols(:,noptionalcols) = mu
+ endif
+ if (present(csound)) then
+    noptionalcols = noptionalcols + 1
+    headers = trim(headers) // '  [Sound speed]'
+    optionalcols(:,noptionalcols) = csound
+ endif
+
+ open(newunit=iu, file = outputpath, status = 'replace')
+ write(iu,'(a)') headers
+
+ do i=1,size(r)
+    if (noptionalcols <= 0) then
+       write(iu,fmtstring) m(i),pres(i),temp(i),r(i),rho(i),ene(i)
+    else
+       write(iu,fmtstring,advance="no") m(i),pres(i),temp(i),r(i),rho(i),ene(i)
+       do j=1,noptionalcols
+          if (j==noptionalcols) then
+             write(iu,'(2x,es13.6)') optionalcols(i,j)
+          else
+             write(iu,'(2x,es13.6)',advance="no") optionalcols(i,j)
+          endif
+       enddo
+    endif
+ enddo
+ close(iu)
+
+end subroutine write_mesa
+
+end module setstar_mesa

--- a/src/setup/setup_grtde.f90
+++ b/src/setup/setup_grtde.f90
@@ -6,7 +6,7 @@
 !--------------------------------------------------------------------------!
 module setup
 !
-! Setup GR TDE
+! Setup for general relativistic tidal disruption event
 !
 ! :References: None
 !
@@ -57,7 +57,8 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use kernel,    only:hfact_default
  use extern_densprofile, only:nrhotab
  use externalforces,only:accradius1,accradius1_hard
- use rho_profile,   only:rho_polytrope,read_kepler_file
+ use rho_profile,   only:rho_polytrope
+ use setstar_kepler,only:read_kepler_file
  use vectorutils,   only:rotatevec
  use gravwaveutils, only:theta_gw,calc_gravitwaves
  integer,           intent(in)    :: id

--- a/src/utils/moddump_binary.f90
+++ b/src/utils/moddump_binary.f90
@@ -39,7 +39,7 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
                              primarycore_mass,primarycore_hsoft,hsoft
  use infile_utils,      only:open_db_from_file,inopts,read_inopt,close_db
  use table_utils,       only:yinterp
- use rho_profile,       only:read_mesa
+ use setstar_mesa,      only:read_mesa
  use dim,               only:maxptmass,maxp,nsinkproperties
  use io,                only:fatal,idisk1,iprint
  use timestep,          only:tmax,dtmax


### PR DESCRIPTION
Type of PR: 
Bug fix / cleanup

Description:
This is a cleanup of the setup_star procedure, containing the following changes:

major:
- moved read_mesa and read_kepler_profile into separate modules containing
  functionality for read/write of mesa and Kepler files

minor:
- uncluttered warnings, in particular added line spaces before and after ALL warnings in phantom
- added warning if the relaxation procedure in setup_star did not converge
- setup_star now dies if it fails to read the MESA EOS tables, instead of seg faulting
- fix build failure in phantomsetup due to set_hierarchical (if make setup typed before make)
- make all warnings in checksetup emit "ERROR: " or "WARNING: " to make them more obvious
- only print the centre of mass from checksetup if there are no warnings or errors, to avoid clutter around important warnings
- a few other minor cleanups (use id==master for MPI; remove commented code and unnecessary printouts)
- simplified Makefile for phantomsetup

Testing:
Tested on .setup file setting up a MESA AGB star, supplied by Chunliang Mu

Did you run the bots? no

Did you update relevant documentation in the docs directory? no