### PR TITLE
(set_star) shifted all the work in setup_star into set_star routine

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -659,7 +659,7 @@ SRCSETUP= prompting.f90 set_dust_options.f90 \
           density_profiles.f90 set_slab.f90 set_disc.F90 \
           set_cubic_core.f90 set_fixedentropycore.f90 set_softened_core.f90 \
           set_star_kepler.f90 set_star_mesa.f90 \
-          set_star.f90 relax_star.f90 set_hierarchical.f90 \
+          set_star_utils.f90 relax_star.f90 set_star.f90 set_hierarchical.f90 \
           set_vfield.f90 set_Bfield.f90 \
           ${SETUPFILE}
 

--- a/src/setup/relax_star.f90
+++ b/src/setup/relax_star.f90
@@ -74,7 +74,7 @@ subroutine relax_star(nt,rho,pr,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,ierr)
  use physcon,         only:pi
  use options,         only:iexternalforce
  use io_summary,      only:summary_initialise
- use setstar,         only:set_star_thermalenergy,set_star_composition
+ use setstar_utils,   only:set_star_thermalenergy,set_star_composition
  integer, intent(in)    :: nt
  integer, intent(inout) :: npart
  real,    intent(in)    :: rho(nt),pr(nt),r(nt)

--- a/src/setup/set_cubic_core.f90
+++ b/src/setup/set_cubic_core.f90
@@ -19,7 +19,7 @@ module setcubiccore
 !
 ! :Dependencies: io, kernel, physcon, table_utils
 !
- use physcon, only:solarm,solarr
+ use physcon,     only:solarm,solarr
  use table_utils, only:interpolator,diff
 
  implicit none

--- a/src/setup/set_softened_core.f90
+++ b/src/setup/set_softened_core.f90
@@ -19,8 +19,6 @@ module setsoftenedcore
 !   table_utils
 !
  implicit none
- real :: rcore,mcore
-
  ! rcore: Radius / Rsun below which we replace the original profile with a
  !        softened profile.
  ! mcore: Mass / Msun of core particle
@@ -32,14 +30,16 @@ contains
 !  Main subroutine that sets a softened core profile
 !+
 !-----------------------------------------------------------------------
-subroutine set_softened_core(isoftcore,isofteningopt,r,den,pres,m,X,Y,ierr)
- use eos,         only:ieos,X_in,Z_in,init_eos,get_mean_molecular_weight
- use io,          only:fatal
- use table_utils, only:interpolator,yinterp,flip_array
- use setcubiccore,only:set_cubic_core,find_mcore_given_rcore,find_rcore_given_mcore,check_rcore_and_mcore
- use setfixedentropycore,only:set_fixedS_softened_core
- use physcon, only:solarr,solarm
+subroutine set_softened_core(isoftcore,isofteningopt,rcore,mcore,r,den,pres,m,X,Y,ierr)
+ use eos,                 only:ieos,X_in,Z_in,init_eos,get_mean_molecular_weight
+ use io,                  only:fatal
+ use table_utils,         only:interpolator,yinterp,flip_array
+ use setcubiccore,        only:set_cubic_core,find_mcore_given_rcore,&
+                               find_rcore_given_mcore,check_rcore_and_mcore
+ use setfixedentropycore, only:set_fixedS_softened_core
+ use physcon,             only:solarr,solarm
  integer, intent(in) :: isoftcore,isofteningopt
+ real, intent(inout) :: rcore,mcore
  real, intent(inout) :: r(:),den(:),m(:),pres(:),X(:),Y(:)
  integer             :: core_index,ierr
  real                :: Xcore,Zcore,rc

--- a/src/setup/set_star.f90
+++ b/src/setup/set_star.f90
@@ -6,7 +6,10 @@
 !--------------------------------------------------------------------------!
 module setstar
 !
-! Utility routines for mapping 1D stars into 3D spheres
+! General routine for setting up a 3D star from a 1D profile
+! This is the main functionality from setup_star but in a single routine
+! that can also be called from other setups. In principle this
+! could also be used to setup multiple stars
 !
 ! :References: None
 !
@@ -18,345 +21,524 @@ module setstar
 !   radiation_utils, rho_profile, setsoftenedcore, setup_params, sortutils,
 !   spherical, table_utils, unifdis, units
 !
- use extern_densprofile, only:nrhotab
- use setstar_kepler,     only:write_kepler_comp
+ use setstar_utils, only:ikepler,imesa,ibpwpoly,ipoly,iuniform,ifromfile,ievrard,&
+                         need_polyk
  implicit none
- !
- ! Index of setup options
- !
- integer, parameter, public :: nprofile_opts =  7 ! maximum number of initial configurations
- integer, parameter, public :: iuniform   = 1
- integer, parameter, public :: ipoly      = 2
- integer, parameter, public :: ifromfile  = 3
- integer, parameter, public :: ikepler    = 4
- integer, parameter, public :: imesa      = 5
- integer, parameter, public :: ibpwpoly   = 6
- integer, parameter, public :: ievrard    = 7
 
- character(len=*), parameter, public :: profile_opt(nprofile_opts) = &
-    (/'Uniform density profile     ', &
-      'Polytrope                   ', &
-      'Density vs r from ascii file', &
-      'KEPLER star from file       ', &
-      'MESA star from file         ', &
-      'Piecewise polytrope         ', &
-      'Evrard collapse             '/)
+ !
+ ! define a data type with all the options needed
+ ! to setup star (these are per-star, not per-simulation options)
+ !
+ type star_t
+  integer :: iprofile
+  integer :: isoftcore
+  logical :: isinkcore
+  integer :: isofteningopt
+  integer :: np
+  real :: Rstar
+  real :: Mstar
+  real :: ui_coef
+  real :: initialtemp
+  real :: rcore
+  real :: mcore
+  real :: hsoft
+  character(len=120) :: input_profile,dens_profile
+  character(len=120) :: outputfilename ! outputfilename is the path to the cored profile
+ end type star_t
 
- public :: read_star_profile
- public :: set_star_density
- public :: set_star_composition
- public :: set_star_thermalenergy
- public :: set_stellar_core
- public :: write_kepler_comp
+ public :: star_t
+ public :: set_defaults_star,set_star
+ public :: write_star_options,read_star_options,set_star_interactive
+ public :: ikepler,imesa,ibpwpoly,ipoly,iuniform,ifromfile,ievrard
+ public :: need_polyk
 
  private
 
- integer, parameter :: ng_max = nrhotab
-
 contains
-
-!-------------------------------------------------------------------------------
+!--------------------------------------------------------------------------
 !+
-!  read stellar profile (density, pressure, temperature, composition) from file
+!  default options for a particular star
+!  (see also set_defaults_given_profile which selects defaults
+!   based on the value of iprofile)
 !+
-!-------------------------------------------------------------------------------
-subroutine read_star_profile(iprofile,ieos,input_profile,gamma,polyk,ui_coef,r,den,pres,temp,en,mtab,&
-                             Xfrac,Yfrac,mu,npts,rmin,Rstar,Mstar,rhocentre,&
-                             isoftcore,isofteningopt,rcore,hsoft,outputfilename,&
-                             composition,comp_label,columns_compo)
- use extern_densprofile, only:read_rhotab_wrapper
- use eos_piecewise,      only:get_dPdrho_piecewise
- use eos,                only:get_mean_molecular_weight,calc_temp_and_ene,init_eos
- use rho_profile,        only:rho_uniform,rho_polytrope,rho_piecewise_polytrope,rho_evrard,func
- use setstar_mesa,       only:read_mesa,write_mesa
- use setstar_kepler,     only:read_kepler_file
- use setsoftenedcore,    only:set_softened_core
- use io,                 only:fatal
- use physcon,            only:kb_on_mh,radconst
- integer,           intent(in)    :: iprofile,ieos
- character(len=*),  intent(in)    :: input_profile,outputfilename
- real,              intent(in)    :: ui_coef
- real,              intent(inout) :: gamma,polyk,hsoft
- real, allocatable, intent(out)   :: r(:),den(:),pres(:),temp(:),en(:),mtab(:)
- real, allocatable, intent(out)   :: Xfrac(:),Yfrac(:),mu(:),composition(:,:)
- integer,           intent(out)   :: npts
- real,              intent(inout) :: rmin,Rstar,Mstar,rhocentre
- integer,           intent(in)    :: isoftcore,isofteningopt
- real,              intent(in)    :: rcore
- integer,           intent(out)   :: columns_compo
- character(len=20), allocatable, intent(out)   :: comp_label(:)
- integer :: ierr,i
- logical :: calc_polyk,iexist
- real    :: eni,tempi,guessene
- procedure(func), pointer :: get_dPdrho
- !
- ! set up tabulated density profile
- !
- calc_polyk = .true.
- allocate(r(ng_max),den(ng_max),pres(ng_max),temp(ng_max),en(ng_max),mtab(ng_max))
+!--------------------------------------------------------------------------
+subroutine set_defaults_star(star)
+ type(star_t), intent(out) :: star
 
- print "(/,a,/)",' Using '//trim(profile_opt(iprofile))
- select case(iprofile)
- case(ipoly)
-    call rho_polytrope(gamma,polyk,Mstar,r,den,npts,rhocentre,calc_polyk,Rstar)
-    rmin = r(1)
-    pres = polyk*den**gamma
- case(ifromfile)
-    call read_rhotab_wrapper(trim(input_profile),ng_max,r,den,npts,&
-                             polyk,gamma,rhocentre,Mstar,iexist,ierr)
-    if (.not.iexist) call fatal('setup','density file does not exist')
-    if (ierr > 0)    call fatal('setup','error in reading density file')
-    rmin = r(1)
-    pres = polyk*den**gamma
- case(ibpwpoly)
-    get_dPdrho => get_dPdrho_piecewise
-    call rho_piecewise_polytrope(r,den,rhocentre,Mstar,get_dPdrho,npts,ierr)
-    if (ierr == 1) call fatal('setup','ng_max is too small')
-    if (ierr == 2) call fatal('setup','failed to converge to a self-consistent density profile')
-    rmin  = r(1)
-    Rstar = r(npts)
-    pres = polyk*den**gamma
- case(imesa)
-    deallocate(r,den,pres,temp,en,mtab)
-    if (isoftcore > 0) then
-       call read_mesa(input_profile,den,r,pres,mtab,en,temp,Xfrac,Yfrac,Mstar,ierr,cgsunits=.true.)
-       allocate(mu(size(den)))
-       mu = 0.
-       if (ierr /= 0) call fatal('setup','error in reading stellar profile from'//trim(input_profile))
-       call set_softened_core(isoftcore,isofteningopt,r,den,pres,mtab,Xfrac,Yfrac,ierr) ! sets mcore, rcore
-       hsoft = 0.5 * rcore
-       ! solve for temperature and energy profile
-       do i=1,size(r)
-          mu(i) = get_mean_molecular_weight(Xfrac(i),1.-Xfrac(i)-Yfrac(i))  ! only used in u, T calculation if ieos==2,12
-          if (i==1) then
-             guessene = 1.5*pres(i)/den(i)  ! initial guess
-             tempi = min((3.*pres(i)/radconst)**0.25, pres(i)*mu(i)/(den(i)*kb_on_mh)) ! guess for temperature
-          else
-             guessene = en(i-1)
-             tempi = temp(i-1)
-          endif
-          call calc_temp_and_ene(ieos,den(i),pres(i),eni,tempi,ierr,guesseint=guessene,mu_local=mu(i))  ! for ieos==20, mu is outputted here
-          en(i) = eni
-          temp(i) = tempi
-       enddo
-       call write_mesa(outputfilename,mtab,pres,temp,r,den,en,Xfrac,Yfrac,mu=mu)
-       ! now read the softened profile instead
-       call read_mesa(outputfilename,den,r,pres,mtab,en,temp,Xfrac,Yfrac,Mstar,ierr)
+ star%iprofile    = 1
+ star%rstar       = 1.0
+ star%mstar       = 1.0
+ star%ui_coef     = 0.05
+ star%initialtemp = 1.0e7
+ star%isoftcore   = 0
+ star%isinkcore   = .false.
+ star%hsoft          = 0.
+ star%rcore          = 0.
+ star%mcore          = 0.
+ star%isofteningopt  = 1 ! By default, specify rcore
+ star%input_profile  = 'P12_Phantom_Profile.data'
+ star%outputfilename = 'mysoftenedstar.dat'
+ star%dens_profile   = 'density-profile.tab'
+
+end subroutine set_defaults_star
+
+!--------------------------------------------------------------------------
+!+
+!  Master routine to setup a star from a specified file or density profile
+!+
+!--------------------------------------------------------------------------
+subroutine set_star(id,master,star,xyzh,vxyzu,eos_vars,rad,&
+                    npart,npartoftype,massoftype,hfact,&
+                    xyzmh_ptmass,vxyz_ptmass,nptmass,ieos,polyk,gamma,X_in,Z_in,&
+                    relax,use_var_comp,write_rho_to_file,&
+                    rhozero,npart_total,mask,ierr)
+ use centreofmass,       only:reset_centreofmass
+ use dim,                only:do_radiation,gr,gravity,maxvxyzu
+ use io,                 only:fatal,error,warning
+ use eos,                only:eos_outputs_mu
+ use setstar_utils,      only:set_stellar_core,read_star_profile,set_star_density, &
+                              set_star_composition,set_star_thermalenergy,&
+                              write_kepler_comp
+ use radiation_utils,    only:set_radiation_and_gas_temperature_equal
+ use relaxstar,          only:relax_star
+ use part,               only:ihsoft,igas,imu
+ use extern_densprofile, only:write_rhotab
+ use unifdis,            only:mask_prototype
+ use physcon,            only:pi
+ use units,              only:utime,udist,umass,unit_density
+ use mpiutils,           only:reduceall_mpi
+ type(star_t), intent(inout)  :: star
+ integer,      intent(in)     :: id,master
+ integer,      intent(inout)  :: npart,npartoftype(:),nptmass
+ real,         intent(inout)  :: xyzh(:,:),vxyzu(:,:),eos_vars(:,:),rad(:,:)
+ real,         intent(inout)  :: xyzmh_ptmass(:,:),vxyz_ptmass(:,:)
+ real,         intent(out)    :: massoftype(:)
+ real,         intent(in)     :: hfact
+ logical,      intent(in)     :: relax,use_var_comp,write_rho_to_file
+ integer,      intent(in)     :: ieos
+ real,         intent(inout)  :: polyk,gamma
+ real,         intent(in)     :: X_in,Z_in
+ real,         intent(out)    :: rhozero
+ integer(kind=8), intent(out) :: npart_total
+ integer,      intent(out)    :: ierr
+ procedure(mask_prototype)    :: mask
+ integer                        :: npts,ierr_relax
+ integer                        :: ncols_compo
+ real, allocatable              :: r(:),den(:),pres(:),temp(:),en(:),mtab(:),Xfrac(:),Yfrac(:),mu(:)
+ real, allocatable              :: composition(:,:)
+ real                           :: rmin,rhocentre
+ character(len=20), allocatable :: comp_label(:)
+ character(len=30)              :: lattice  ! The lattice type if stretchmap is used
+ logical                        :: use_exactN,composition_exists
+
+ use_exactN = .true.
+ composition_exists = .false.
+ ierr_relax = 0
+ !
+ ! get the desired tables of density, pressure, temperature and composition
+ ! as a function of radius / mass fraction
+ !
+ call read_star_profile(star%iprofile,ieos,star%input_profile,gamma,polyk,&
+                        star%ui_coef,r,den,pres,temp,en,mtab,X_in,Z_in,Xfrac,Yfrac,mu,&
+                        npts,rmin,star%rstar,star%mstar,rhocentre,&
+                        star%isoftcore,star%isofteningopt,star%rcore,star%mcore,&
+                        star%hsoft,star%outputfilename,composition,&
+                        comp_label,ncols_compo)
+ !
+ ! set up particles to represent the desired stellar profile
+ !
+ lattice = 'closepacked'
+ if (relax) lattice='random'
+ call set_star_density(lattice,id,master,rmin,star%rstar,star%mstar,hfact,&
+                       npts,den,r,npart,npartoftype,massoftype,xyzh,use_exactN,&
+                       star%np,rhozero,npart_total,mask)
+ !
+ ! add sink particle stellar core
+ !
+ if (star%isinkcore) call set_stellar_core(nptmass,xyzmh_ptmass,vxyz_ptmass,ihsoft,star%mcore,star%hsoft,ierr)
+ if (ierr==1) call fatal('set_stellar_core','mcore <= 0')
+ if (ierr==2) call fatal('set_stellar_core','hsoft <= 0')
+ !
+ ! Write the desired profile to file (do this before relaxation)
+ !
+ if (write_rho_to_file) call write_rhotab(star%dens_profile,r,den,npts,polyk,gamma,rhocentre,ierr)
+ !
+ ! relax the density profile to achieve nice hydrostatic equilibrium
+ !
+ if (relax) then
+    if (reduceall_mpi('+',npart)==npart) then
+       call relax_star(npts,den,pres,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,ierr_relax)
     else
-       call read_mesa(input_profile,den,r,pres,mtab,en,temp,Xfrac,Yfrac,Mstar,ierr)
+       call error('setup_star','cannot run relaxation with MPI setup, please run setup on ONE MPI thread')
     endif
-    if (ierr==1) call fatal('set_star',trim(input_profile)//' does not exist')
-    if (ierr==2) call fatal('set_star','insufficient data points read from file')
-    if (ierr==3) call fatal('set_star','too many data points; increase ng')
-    if (ierr /= 0) call fatal('set_star','error in reading stellar profile from'//trim(input_profile))
-    npts = size(den)
-    rmin  = r(1)
-    Rstar = r(npts)
- case(ikepler)
-    call read_kepler_file(trim(input_profile),ng_max,npts,r,den,pres,temp,en,Mstar,composition,comp_label,columns_compo,ierr)
-    if (ierr==1) call fatal('set_star',trim(input_profile)//' does not exist')
-    if (ierr==2) call fatal('set_star','insufficient data points read from file')
-    if (ierr==3) call fatal('set_star','too many data points; increase ng')
-    rmin  = r(1)
-    Rstar = r(npts)
- case(ievrard)
-    call rho_evrard(ng_max,Mstar,Rstar,r,den)
-    npts = ng_max
-    polyk = ui_coef*Mstar/Rstar
-    rmin = r(1)
-    pres = polyk*den**gamma
-    print*,' Assuming polyk = ',polyk
- case default  ! set up uniform sphere by default
-    call rho_uniform(ng_max,Mstar,Rstar,r,den) ! use this array for continuity of call to set_sphere
-    npts = ng_max
-    rmin = r(1)
-    pres = polyk*den**gamma
-    print*,' Assuming polyk = ',polyk
- end select
-
-end subroutine read_star_profile
-
-!-------------------------------------------------------------------------------
-!+
-!  set up particles according to the desired density profile
-!+
-!-------------------------------------------------------------------------------
-subroutine set_star_density(lattice,id,master,rmin,Rstar,Mstar,hfact,&
-                            npts,den,r,npart,npartoftype,massoftype,xyzh,use_exactN,np,mask)
- use part,         only:set_particle_type,igas
- use spherical,    only:set_sphere
- use setup_params, only:rhozero,npart_total
- use unifdis,      only:mask_prototype
- use physcon,      only:pi
- character(len=*), intent(in)    :: lattice
- integer,          intent(in)    :: id,master,npts,np
- real,             intent(in)    :: rmin,Rstar,Mstar,hfact
- real,             intent(in)    :: den(npts),r(npts)
- integer,          intent(inout) :: npart,npartoftype(:)
- real,             intent(inout) :: xyzh(:,:),massoftype(:)
- logical,          intent(in)    :: use_exactN
- procedure(mask_prototype) :: mask
- integer :: nx,i,ntot
- real :: vol_sphere,psep
- !
- ! place particles in sphere
- !
- vol_sphere  = 4./3.*pi*Rstar**3
- nx          = int(np**(1./3.))
- psep        = vol_sphere**(1./3.)/real(nx)
- call set_sphere(lattice,id,master,rmin,Rstar,psep,hfact,npart,xyzh, &
-                 rhotab=den(1:npts),rtab=r(1:npts),nptot=npart_total, &
-                 exactN=use_exactN,np_requested=np,mask=mask)
- !
- ! get total particle number across all MPI threads
- ! and use this to set the particle mass
- !
- ntot = int(npart_total,kind=(kind(ntot)))
- massoftype(igas) = Mstar/ntot
- !
- ! set particle type as gas particles
- !
- npartoftype(igas) = npart   ! npart is number on this thread only
- do i=1,npart
-    call set_particle_type(i,igas)
- enddo
- !
- ! mean density
- !
- rhozero = Mstar/vol_sphere
-
-end subroutine set_star_density
-
-!-----------------------------------------------------------------------
-!+
-!  Add a sink particle as a stellar core
-!+
-!-----------------------------------------------------------------------
-subroutine set_stellar_core(nptmass,xyzmh_ptmass,vxyz_ptmass,ihsoft,mcore,hsoft,ierr)
- integer, intent(out) :: nptmass,ierr
- real, intent(out)    :: xyzmh_ptmass(:,:),vxyz_ptmass(:,:)
- real, intent(in)     :: mcore,hsoft
- integer              :: n,ihsoft
-
- ierr = 0
- ! Check for sensible values
- if (mcore < tiny(mcore)) then
-    ierr = 1
-    return
  endif
- if (hsoft < tiny(hsoft)) then
-    ierr = 2
-    return
+ !
+ ! set composition (X,Z,mu, if using variable composition) of each particle by interpolating from table
+ !
+ if (use_var_comp .or. eos_outputs_mu(ieos)) then
+    call set_star_composition(use_var_comp,eos_outputs_mu(ieos),npart,&
+                              xyzh,Xfrac,Yfrac,mu,mtab,star%mstar,eos_vars)
  endif
-
- nptmass                = 1
- n                      = nptmass
- xyzmh_ptmass(:,n)      = 0. ! zero all quantities by default
- xyzmh_ptmass(4,n)      = mcore
- xyzmh_ptmass(ihsoft,n) = hsoft
- vxyz_ptmass(:,n)       = 0.
-
-end subroutine set_stellar_core
-
-!-----------------------------------------------------------------------
-!+
-!  Set the composition, if variable composition is used
-!+
-!-----------------------------------------------------------------------
-subroutine set_star_composition(use_var_comp,use_mu,npart,xyzh,Xfrac,Yfrac,mu,mtab,Mstar,eos_vars)
- use part,        only:iorder=>ll,iX,iZ,imu  ! borrow the unused linklist array for the sort
- use sortutils,   only:find_rank,r2func
- use table_utils, only:yinterp
- logical, intent(in)  :: use_var_comp,use_mu
- integer, intent(in)  :: npart
- real,    intent(in)  :: xyzh(:,:)
- real,    intent(in)  :: Xfrac(:),Yfrac(:),mu(:),mtab(:),Mstar
- real,    intent(out) :: eos_vars(:,:)
- real :: ri,massri
- integer :: i
-
- ! this does NOT work with MPI
- call find_rank(npart,r2func,xyzh(1:3,:),iorder)
- do i = 1,npart
-    ri  = sqrt(dot_product(xyzh(1:3,i),xyzh(1:3,i)))
-    massri = Mstar * real(iorder(i)-1) / real(npart) ! mass coordinate of particle i
-    if (use_var_comp) then
-       eos_vars(iX,i) = yinterp(Xfrac,mtab,massri)
-       eos_vars(iZ,i) = 1. - eos_vars(iX,i) - yinterp(Yfrac,mtab,massri)
-    endif
-    if (use_mu) eos_vars(imu,i) = yinterp(mu,mtab,massri)
- enddo
-
-end subroutine set_star_composition
-
-!-----------------------------------------------------------------------
-!+
-!  Set the thermal energy profile
-!+
-!-----------------------------------------------------------------------
-subroutine set_star_thermalenergy(ieos,den,pres,r,npts,npart,xyzh,vxyzu,rad,eos_vars,relaxed,use_var_comp,initialtemp)
- use part,            only:do_radiation,rhoh,massoftype,igas,itemp,igasP,iX,iZ,imu,iradxi
- use eos,             only:equationofstate,calc_temp_and_ene,gamma,gmw
- use radiation_utils, only:ugas_from_Tgas,radE_from_Trad
- use table_utils,     only:yinterp
- use units,           only:unit_density,unit_ergg,unit_pressure
- integer, intent(in)    :: ieos,npart,npts
- real,    intent(in)    :: den(:), pres(:), r(:)  ! density and pressure tables
- real,    intent(in)    :: xyzh(:,:)
- real,    intent(inout) :: vxyzu(:,:),eos_vars(:,:),rad(:,:)
- logical, intent(in)    :: relaxed,use_var_comp
- real,    intent(in)    :: initialtemp
- integer :: eos_type,i,ierr
- real    :: xi,yi,zi,hi,presi,densi,tempi,eni,ri,p_on_rhogas,spsoundi
- real    :: rho_cgs,p_cgs
+ !
+ ! Write composition file called kepler.comp contaning composition of each particle after interpolation
+ !
+ if (star%iprofile==iKepler) call write_kepler_comp(composition,comp_label,ncols_compo,r,&
+                                                    xyzh,npart,npts,composition_exists)
+ !
+ ! set the internal energy and temperature
+ !
+ if (maxvxyzu==4) call set_star_thermalenergy(ieos,den,pres,r,npts,npart,xyzh,vxyzu,rad,&
+                                              eos_vars,relax,use_var_comp,star%initialtemp)
 
  if (do_radiation) then
-    eos_type=12  ! Calculate temperature from both gas and radiation pressure
- else
-    eos_type=ieos
- endif
- do i = 1,npart
-    if (relaxed) then
-       hi = xyzh(4,i)
-       densi = rhoh(hi,massoftype(igas))
-       presi = eos_vars(igasP,i)  ! retrieve pressure from relax_star calculated with the fake (ieos=2) internal energy
+    if (eos_outputs_mu(ieos)) then
+       call set_radiation_and_gas_temperature_equal(npart,xyzh,vxyzu,massoftype,rad,eos_vars(imu,:))
     else
-       !  Interpolate density and pressure from table
-       ri    = sqrt(dot_product(xyzh(1:3,i),xyzh(1:3,i)))
-       densi = yinterp(den(1:npts),r(1:npts),ri)
-       presi = yinterp(pres(1:npts),r(1:npts),ri)
+       call set_radiation_and_gas_temperature_equal(npart,xyzh,vxyzu,massoftype,rad)
     endif
+ endif
+ !
+ ! Reset centre of mass (again)
+ !
+ call reset_centreofmass(npart,xyzh,vxyzu,nptmass,xyzmh_ptmass,vxyz_ptmass)
 
-    select case(ieos)
-    case(16) ! Shen EoS
-       vxyzu(4,i) = initialtemp
-    case(15) ! Helmholtz EoS
-       xi    = xyzh(1,i)
-       yi    = xyzh(2,i)
-       zi    = xyzh(3,i)
-       tempi = initialtemp
-       call equationofstate(ieos,p_on_rhogas,spsoundi,densi,xi,yi,zi,tempi,eni)
-       vxyzu(4,i) = eni
-       eos_vars(itemp,i) = initialtemp
-    case default ! Recalculate eint and temp for each particle according to EoS
-       rho_cgs = densi*unit_density
-       p_cgs = presi*unit_pressure
-       if (use_var_comp) then
-          call calc_temp_and_ene(eos_type,rho_cgs,p_cgs,eni,tempi,ierr,&
-                                 mu_local=eos_vars(imu,i),X_local=eos_vars(iX,i),Z_local=eos_vars(iZ,i))
-       else
-          call calc_temp_and_ene(eos_type,rho_cgs,p_cgs,eni,tempi,ierr)
+ if (gr) then
+    xyzh(1,:)=xyzh(1,:)+10.
+    xyzh(2,:)=xyzh(2,:)+10.
+ endif
+ !
+ ! Print summary to screen
+ !
+ if (id==master) then
+    write(*,"(70('='))")
+    if (ieos /= 9) then
+       write(*,'(1x,a,f12.5)')       'gamma               = ', gamma
+    endif
+    if (maxvxyzu <= 4) then
+       write(*,'(1x,a,f12.5)')       'polyk               = ', polyk
+       write(*,'(1x,a,f12.6,a)')     'specific int. energ = ', polyk*star%rstar/star%mstar,' GM/R'
+    endif
+    call write_mass('particle mass       = ',massoftype(igas),umass)
+    call write_dist('Radius              = ',star%rstar,udist)
+    call write_mass('Mass                = ',star%mstar,umass)
+    if (star%iprofile==ipoly) then
+       write(*,'(1x,a,es12.5,a)') 'rho_central         = ', rhocentre*unit_density,' g/cm^3'
+    endif
+    write(*,'(1x,a,i12)')         'N                   = ', npart_total
+    write(*,'(1x,a,2(es12.5,a))') 'rho_mean            = ', rhozero*unit_density,  ' g/cm^3 = '&
+                                                          , rhozero,               ' code units'
+    write(*,'(1x,a,es12.5,a)')    'free fall time      = ', sqrt(3.*pi/(32.*rhozero))*utime,' s'
+
+    if (composition_exists) then
+       write(*,'(a)') 'Composition written to kepler.comp file.'
+    endif
+    write(*,"(70('='))")
+ endif
+
+ if ( (star%iprofile==iuniform .and. .not.gravity) .or. star%iprofile==ifromfile) then
+    call warning('setup_star','This setup may not be stable')
+ endif
+
+ if (ierr_relax /= 0) call warning('setup_star','ERRORS DURING RELAXATION, SEE ABOVE!!')
+
+end subroutine set_star
+
+!-----------------------------------------------------------------------
+!+
+!  print a distance in both code units and physical units
+!+
+!-----------------------------------------------------------------------
+subroutine write_dist(item_in,dist_in,udist)
+ use physcon, only:solarr,km
+ real,             intent(in) :: dist_in
+ real(kind=8),     intent(in) :: udist
+ character(len=*), intent(in) :: item_in
+
+ if ( abs(1.0-solarr/udist) < 1.0d-4) then
+    write(*,'(1x,2(a,es12.5),a)') item_in, dist_in*udist,' cm     = ',dist_in,' R_sun'
+ elseif ( abs(1.0-km/udist) < 1.0d-4) then
+    write(*,'(1x,2(a,es12.5),a)') item_in, dist_in*udist,' cm     = ',dist_in,' km'
+ else
+    write(*,'(1x,a,es12.5,a)')    item_in, dist_in*udist,' cm'
+ endif
+
+end subroutine write_dist
+!-----------------------------------------------------------------------
+!+
+!  print a mass in both code units and physical units
+!+
+!-----------------------------------------------------------------------
+subroutine write_mass(item_in,mass_in,umass)
+ use physcon, only:solarm
+ real,             intent(in) :: mass_in
+ real(kind=8),     intent(in) :: umass
+ character(len=*), intent(in) :: item_in
+
+ if ( abs(1.0-solarm/umass) < 1.0d-4) then
+    write(*,'(1x,2(a,es12.5),a)') item_in, mass_in*umass,' g      = ',mass_in,' M_sun'
+ else
+    write(*,'(1x,a,es12.5,a)')    item_in, mass_in*umass,' g'
+ endif
+
+end subroutine write_mass
+
+!-----------------------------------------------------------------------
+!+
+!  Set default options associated with a particular choice of iprofile
+!  This routine should not do ANY prompting
+!+
+!-----------------------------------------------------------------------
+subroutine set_defaults_given_profile(iprofile,filename,need_iso,ieos,mstar,polyk)
+ integer, intent(in)  :: iprofile
+ character(len=120), intent(out) :: filename
+ integer, intent(out) :: need_iso
+ integer, intent(inout) :: ieos
+ real,    intent(inout) :: mstar,polyk
+
+ select case(iprofile)
+ case(ifromfile)
+    ! Read the density profile from file (e.g. for neutron star)
+    !  Original Author: Mark Bennett
+    filename = 'ns-rdensity.tab'
+ case(imesa)
+    ! sets up a star from a 1D MESA code output
+    !  Original Author: Roberto Iaconi
+    filename = 'P12_Phantom_Profile.data'
+ case(ikepler)
+    ! sets up a star from a 1D KEPLER code output
+    !  Original Author: Nicole Rodrigues and Megha Sharma
+    filename = 'kepler_MS.data'
+ case(ibpwpoly)
+    !  piecewise polytrope
+    !  Original Author: Madeline Marshall & Bernard Field
+    !  Supervisors: James Wurster & Paul Lasky
+    ieos         = 9
+    !dist_unit    = 'km'
+    Mstar        = 1.35
+    polyk        = 144.
+ case(ievrard)
+    need_iso    = -1
+ end select
+
+end subroutine set_defaults_given_profile
+
+!-----------------------------------------------------------------------
+!+
+!  write setupfile options needed for a star
+!+
+!-----------------------------------------------------------------------
+subroutine write_star_options(star,iunit)
+ use infile_utils,  only:write_inopt,get_optstring
+ use setstar_utils, only:nprofile_opts,profile_opt,need_inputprofile,need_rstar
+ type(star_t), intent(in) :: star
+ integer,      intent(in) :: iunit
+ character(len=120) :: string
+
+ write(iunit,"(/,a)") '# options for star'
+ call get_optstring(nprofile_opts,profile_opt,string,4)
+ call write_inopt(star%iprofile,'iprofile',trim(string),iunit)
+
+ write(iunit,"(/,a)") '# resolution'
+ call write_inopt(star%np,'np','number of particles',iunit)
+ !call write_inopt(use_exactN,'use_exactN','find closest particle number to np',iunit)
+
+ if (star%isoftcore <= 0) then
+    write(iunit,"(/,a)") '# star properties'
+    if (need_inputprofile(star%iprofile)) then
+       call write_inopt(star%input_profile,'input_profile','Path to input profile',iunit)
+    else
+       call write_inopt(star%Mstar,'Mstar','mass of star',iunit)
+       if (need_rstar(star%iprofile)) call write_inopt(star%Rstar,'Rstar','radius of star',iunit)
+    endif
+ endif
+
+ if (star%iprofile==imesa) then
+    write(iunit,"(/,a)") '# core softening and sink stellar core options'
+    call write_inopt(star%isoftcore,'isoftcore','0=no core softening, 1=cubic core, 2=constant entropy core',iunit)
+    if (star%isoftcore > 0) then
+       call write_inopt(star%input_profile,'input_profile','Path to input profile',iunit)
+       call write_inopt(star%outputfilename,'outputfilename','Output path for softened MESA profile',iunit)
+       if (star%isoftcore == 1) then
+          call write_inopt(star%isofteningopt,'isofteningopt','1=supply rcore, 2=supply mcore, 3=supply both',iunit)
+          if ((star%isofteningopt == 1) .or. (star%isofteningopt == 3)) then
+             call write_inopt(star%rcore,'rcore','Radius of core softening',iunit)
+          endif
+          if ((star%isofteningopt == 2) .or. (star%isofteningopt == 3)) then
+             call write_inopt(star%mcore,'mcore','Mass of sink particle stellar core',iunit)
+          endif
+       elseif (star%isoftcore == 2) then
+          call write_inopt(star%rcore,'rcore','Radius of core softening',iunit)
+          call write_inopt(star%mcore,'mcore','Initial guess for mass of sink particle stellar core',iunit)
        endif
-       if (do_radiation) then
-          vxyzu(4,i) = ugas_from_Tgas(tempi,gamma,gmw)
-          rad(iradxi,i) = radE_from_Trad(tempi)/densi
-       else
-          vxyzu(4,i) = eni / unit_ergg
+    else
+       call write_inopt(star%isinkcore,'isinkcore','Add a sink particle stellar core',iunit)
+       if (star%isinkcore) then
+          call write_inopt(star%mcore,'mcore','Mass of sink particle stellar core',iunit)
+          call write_inopt(star%hsoft,'hsoft','Softening length of sink particle stellar core',iunit)
        endif
-       eos_vars(itemp,i) = tempi
-    end select
+    endif
+ endif
+
+ if (star%iprofile==ievrard) then
+    call write_inopt(star%ui_coef,'ui_coef','specific internal energy (units of GM/R)',iunit)
+ endif
+
+end subroutine write_star_options
+
+!-----------------------------------------------------------------------
+!+
+!  interactive prompting for setting up a star
+!+
+!-----------------------------------------------------------------------
+subroutine set_star_interactive(id,master,star,need_iso,use_var_comp,ieos,polyk)
+ use prompting,     only:prompt
+ use setstar_utils, only:nprofile_opts,profile_opt,need_inputprofile,need_rstar
+ type(star_t), intent(out)   :: star
+ integer,      intent(in)    :: id,master
+ logical,      intent(out)   :: use_var_comp
+ integer,      intent(out)   :: need_iso
+ integer,      intent(inout) :: ieos
+ real,         intent(inout) :: polyk
+ integer :: i
+
+ ! Select sphere & set default values
+ do i = 1, nprofile_opts
+    write(*,"(i2,')',1x,a)") i, profile_opt(i)
  enddo
 
-end subroutine set_star_thermalenergy
+ call prompt('Enter which density profile to use',star%iprofile,1,nprofile_opts)
+ !
+ ! set default file output parameters
+ !
+ if (id==master) write(*,"('Setting up ',a)") trim(profile_opt(star%iprofile))
+ call set_defaults_given_profile(star%iprofile,star%input_profile,&
+                                 need_iso,ieos,star%mstar,polyk)
+
+ ! resolution
+ star%np = 100000 ! default number of particles
+ call prompt('Enter the approximate number of particles in the sphere ',star%np,0)
+
+ ! star properties
+ if (need_inputprofile(star%iprofile)) then
+    call prompt('Enter file name containing input profile',star%input_profile)
+ else
+    call prompt('Enter the mass of the star (code units)',star%mstar,0.)
+    if (need_rstar(star%iprofile)) call prompt('Enter the radius of the star (code units)',star%rstar,0.)
+ endif
+
+ if (star%iprofile==imesa) then
+    call prompt('Use variable composition?',use_var_comp)
+
+    print*,'Soften the core density profile and add a sink particle core?'
+    print "(3(/,a))",'0: Do not soften profile', &
+                     '1: Use cubic softened density profile', &
+                     '2: Use constant entropy softened profile'
+    call prompt('Select option above : ',star%isoftcore,0,2)
+
+    select case(star%isoftcore)
+    case(0)
+       call prompt('Add a sink particle stellar core?',star%isinkcore)
+       if (star%isinkcore) then
+          call prompt('Enter mass of the created sink particle core',star%mcore,0.)
+          call prompt('Enter softening length of the sink particle core',star%hsoft,0.)
+       endif
+    case(1)
+       star%isinkcore = .true. ! Create sink particle core automatically
+       print*,'Options for core softening:'
+       print "(5(/,a))",'1. Specify radius of density softening', &
+                        '2. Specify mass of sink particle core (not recommended)', &
+                        '3. Specify both radius of density softening length and mass', &
+                        '   of sink particle core (if you do not know what you are', &
+                        '   doing, you will obtain a poorly softened profile)'
+       call prompt('Select option above : ',star%isofteningopt,1,3)
+
+       select case(star%isofteningopt)
+       case(1)
+          call prompt('Enter core radius',star%rcore,0.)
+       case(2)
+          call prompt('Enter mass of the created sink particle core',star%mcore,0.)
+       case(3)
+          call prompt('Enter mass of the created sink particle core',star%mcore,0.)
+          call prompt('Enter core radius',star%rcore,0.)
+       end select
+
+       call prompt('Enter output file name of cored stellar profile:',star%outputfilename)
+
+    case(2)
+       star%isinkcore = .true. ! Create sink particle core automatically
+       print*,'Specify core radius and initial guess for mass of sink particle core'
+       call prompt('Enter core radius in Rsun : ',star%rcore,0.)
+       call prompt('Enter guess for core mass in Msun : ',star%mcore,0.)
+       call prompt('Enter output file name of cored stellar profile:',star%outputfilename)
+    end select
+
+ endif
+
+ if (star%iprofile==ievrard) then
+    call prompt('Enter the specific internal energy (units of GM/R) ',star%ui_coef,0.)
+ endif
+
+end subroutine set_star_interactive
+
+!-----------------------------------------------------------------------
+!+
+!  read setupfile options needed for a star
+!+
+!-----------------------------------------------------------------------
+subroutine read_star_options(star,need_iso,ieos,polyk,db,nerr)
+ use infile_utils,  only:inopts,read_inopt
+ use setstar_utils, only:need_inputprofile,need_rstar
+ type(star_t),              intent(out)   :: star
+ type(inopts), allocatable, intent(inout) :: db(:)
+ integer,                   intent(out)   :: need_iso
+ integer,                   intent(inout) :: ieos
+ real,                      intent(inout) :: polyk
+ integer,                   intent(inout) :: nerr
+
+ call read_inopt(star%iprofile,'iprofile',db,errcount=nerr)
+ call set_defaults_given_profile(star%iprofile,star%input_profile,&
+                                 need_iso,ieos,star%mstar,polyk)
+
+ if (need_inputprofile(star%iprofile)) then
+    call read_inopt(star%input_profile,'input_profile',db,errcount=nerr)
+ endif
+
+ ! resolution
+ call read_inopt(star%np,'np',db,errcount=nerr)
+ !call read_inopt(use_exactN,'use_exactN',db,errcount=nerr)
+
+ ! core softening options
+ if (star%iprofile==imesa) then
+    call read_inopt(star%isoftcore,'isoftcore',db,errcount=nerr)
+    if (star%isoftcore==2) star%isofteningopt=3
+
+    if (star%isoftcore <= 0) then ! sink particle core without softening
+       call read_inopt(star%isinkcore,'isinkcore',db,errcount=nerr)
+       if (star%isinkcore) then
+          call read_inopt(star%mcore,'mcore',db,errcount=nerr)
+          call read_inopt(star%hsoft,'hsoft',db,errcount=nerr)
+       endif
+    else
+       star%isinkcore = .true.
+       call read_inopt(star%input_profile,'input_profile',db,errcount=nerr)
+       call read_inopt(star%outputfilename,'outputfilename',db,errcount=nerr)
+       if (star%isoftcore==1) call read_inopt(star%isofteningopt,'isofteningopt',db,errcount=nerr)
+       if ((star%isofteningopt==1) .or. (star%isofteningopt==3)) call read_inopt(star%rcore,'rcore',db,errcount=nerr)
+       if ((star%isofteningopt==2) .or. (star%isofteningopt==3) &
+          .or. (star%isoftcore==2)) call read_inopt(star%mcore,'mcore',db,errcount=nerr)
+    endif
+ endif
+
+ ! star properties
+ if (star%isoftcore <= 0) then
+    if (need_inputprofile(star%iprofile)) then
+       call read_inopt(star%input_profile,'input_profile',db,errcount=nerr)
+    else
+       call read_inopt(star%mstar,'Mstar',db,errcount=nerr)
+       if (need_rstar(star%iprofile)) call read_inopt(star%rstar,'Rstar',db,errcount=nerr)
+    endif
+ endif
+
+end subroutine read_star_options
 
 end module setstar

--- a/src/setup/set_star_mesa.f90
+++ b/src/setup/set_star_mesa.f90
@@ -14,7 +14,7 @@ module setstar_mesa
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: datafiles, eos, fileutils, physcon, units
+! :Dependencies: datafiles, fileutils, physcon, units
 !
  implicit none
 
@@ -29,9 +29,8 @@ contains
 !  the P12 star (phantom/data/star_data_files/P12_Phantom_Profile.data)
 !+
 !-----------------------------------------------------------------------
-subroutine read_mesa(filepath,rho,r,pres,m,ene,temp,Xfrac,Yfrac,Mstar,ierr,cgsunits)
+subroutine read_mesa(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,Mstar,ierr,cgsunits)
  use physcon,   only:solarm,solarr
- use eos,       only:X_in,Z_in
  use fileutils, only:get_nlines,get_ncolumns,string_delete,lcase
  use datafiles, only:find_phantom_datafile
  use units,     only:udist,umass,unit_density,unit_pressure,unit_ergg
@@ -44,6 +43,7 @@ subroutine read_mesa(filepath,rho,r,pres,m,ene,temp,Xfrac,Yfrac,Mstar,ierr,cgsun
  character(len=24),allocatable              :: header(:),dum(:)
  logical                                    :: iexist,usecgs,ismesafile,got_column
  real,allocatable,dimension(:,:)            :: dat
+ real, intent(in)                           :: X_in,Z_in
  real,allocatable,dimension(:),intent(out)  :: rho,r,pres,m,ene,temp,Xfrac,Yfrac
  real, intent(out)                          :: Mstar
 
@@ -107,7 +107,7 @@ subroutine read_mesa(filepath,rho,r,pres,m,ene,temp,Xfrac,Yfrac,Mstar,ierr,cgsun
              temp(lines),Xfrac(lines),Yfrac(lines))
 
  close(iu)
- ! Set mass fractions to default in eos module if not in file
+ ! Set mass fractions to fixed inputs if not in file
  Xfrac = X_in
  Yfrac = 1. - X_in - Z_in
  do i = 1,rows

--- a/src/setup/set_star_utils.f90
+++ b/src/setup/set_star_utils.f90
@@ -1,0 +1,420 @@
+!--------------------------------------------------------------------------!
+! The Phantom Smoothed Particle Hydrodynamics code, by Daniel Price et al. !
+! Copyright (c) 2007-2023 The Authors (see AUTHORS)                        !
+! See LICENCE file for usage and distribution conditions                   !
+! http://phantomsph.bitbucket.io/                                          !
+!--------------------------------------------------------------------------!
+module setstar_utils
+!
+! Utility routines for mapping 1D stars into 3D spheres
+!
+! :References: None
+!
+! :Owner: Daniel Price
+!
+! :Runtime parameters: None
+!
+! :Dependencies: eos, eos_piecewise, extern_densprofile, io, part, physcon,
+!   radiation_utils, rho_profile, setsoftenedcore, setup_params, sortutils,
+!   spherical, table_utils, unifdis, units
+!
+ use extern_densprofile, only:nrhotab
+ use setstar_kepler,     only:write_kepler_comp
+ implicit none
+ !
+ ! Index of setup options
+ !
+ integer, parameter, public :: nprofile_opts =  7 ! maximum number of initial configurations
+ integer, parameter, public :: iuniform   = 1
+ integer, parameter, public :: ipoly      = 2
+ integer, parameter, public :: ifromfile  = 3
+ integer, parameter, public :: ikepler    = 4
+ integer, parameter, public :: imesa      = 5
+ integer, parameter, public :: ibpwpoly   = 6
+ integer, parameter, public :: ievrard    = 7
+
+ character(len=*), parameter, public :: profile_opt(nprofile_opts) = &
+    (/'Uniform density profile     ', &
+      'Polytrope                   ', &
+      'Density vs r from ascii file', &
+      'KEPLER star from file       ', &
+      'MESA star from file         ', &
+      'Piecewise polytrope         ', &
+      'Evrard collapse             '/)
+
+ public :: read_star_profile
+ public :: set_star_density
+ public :: set_star_composition
+ public :: set_star_thermalenergy
+ public :: set_stellar_core
+ public :: write_kepler_comp
+ public :: need_inputprofile,need_polyk,need_rstar
+
+ private
+
+ integer, parameter :: ng_max = nrhotab
+
+contains
+
+!-------------------------------------------------------------------------------
+!+
+!  read stellar profile (density, pressure, temperature, composition) from file
+!+
+!-------------------------------------------------------------------------------
+subroutine read_star_profile(iprofile,ieos,input_profile,gamma,polyk,ui_coef,r,den,pres,temp,en,mtab,&
+                             X_in,Z_in,Xfrac,Yfrac,mu,npts,rmin,Rstar,Mstar,rhocentre,&
+                             isoftcore,isofteningopt,rcore,mcore,hsoft,outputfilename,&
+                             composition,comp_label,columns_compo)
+ use extern_densprofile, only:read_rhotab_wrapper
+ use eos_piecewise,      only:get_dPdrho_piecewise
+ use eos,                only:get_mean_molecular_weight,calc_temp_and_ene,init_eos
+ use rho_profile,        only:rho_uniform,rho_polytrope,rho_piecewise_polytrope,rho_evrard,func
+ use setstar_mesa,       only:read_mesa,write_mesa
+ use setstar_kepler,     only:read_kepler_file
+ use setsoftenedcore,    only:set_softened_core
+ use io,                 only:fatal
+ use physcon,            only:kb_on_mh,radconst
+ integer,           intent(in)    :: iprofile,ieos
+ character(len=*),  intent(in)    :: input_profile,outputfilename
+ real,              intent(in)    :: ui_coef
+ real,              intent(inout) :: gamma,polyk,hsoft
+ real,              intent(in)    :: X_in,Z_in
+ real, allocatable, intent(out)   :: r(:),den(:),pres(:),temp(:),en(:),mtab(:)
+ real, allocatable, intent(out)   :: Xfrac(:),Yfrac(:),mu(:),composition(:,:)
+ integer,           intent(out)   :: npts
+ real,              intent(inout) :: rmin,Rstar,Mstar,rhocentre
+ integer,           intent(in)    :: isoftcore,isofteningopt
+ real,              intent(inout) :: rcore,mcore
+ integer,           intent(out)   :: columns_compo
+ character(len=20), allocatable, intent(out) :: comp_label(:)
+ integer :: ierr,i
+ logical :: calc_polyk,iexist
+ real    :: eni,tempi,guessene
+ procedure(func), pointer :: get_dPdrho
+ !
+ ! set up tabulated density profile
+ !
+ calc_polyk = .true.
+ allocate(r(ng_max),den(ng_max),pres(ng_max),temp(ng_max),en(ng_max),mtab(ng_max))
+
+ print "(/,a,/)",' Using '//trim(profile_opt(iprofile))
+ select case(iprofile)
+ case(ipoly)
+    call rho_polytrope(gamma,polyk,Mstar,r,den,npts,rhocentre,calc_polyk,Rstar)
+    rmin = r(1)
+    pres = polyk*den**gamma
+ case(ifromfile)
+    call read_rhotab_wrapper(trim(input_profile),ng_max,r,den,npts,&
+                             polyk,gamma,rhocentre,Mstar,iexist,ierr)
+    if (.not.iexist) call fatal('setup','density file does not exist')
+    if (ierr > 0)    call fatal('setup','error in reading density file')
+    rmin = r(1)
+    pres = polyk*den**gamma
+ case(ibpwpoly)
+    get_dPdrho => get_dPdrho_piecewise
+    call rho_piecewise_polytrope(r,den,rhocentre,Mstar,get_dPdrho,npts,ierr)
+    if (ierr == 1) call fatal('setup','ng_max is too small')
+    if (ierr == 2) call fatal('setup','failed to converge to a self-consistent density profile')
+    rmin  = r(1)
+    Rstar = r(npts)
+    pres = polyk*den**gamma
+ case(imesa)
+    deallocate(r,den,pres,temp,en,mtab)
+    if (isoftcore > 0) then
+       call read_mesa(input_profile,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,Mstar,ierr,cgsunits=.true.)
+       allocate(mu(size(den)))
+       mu = 0.
+       if (ierr /= 0) call fatal('setup','error in reading stellar profile from'//trim(input_profile))
+       call set_softened_core(isoftcore,isofteningopt,rcore,mcore,r,den,pres,mtab,Xfrac,Yfrac,ierr) ! sets mcore, rcore
+       hsoft = 0.5 * rcore
+       ! solve for temperature and energy profile
+       do i=1,size(r)
+          mu(i) = get_mean_molecular_weight(Xfrac(i),1.-Xfrac(i)-Yfrac(i))  ! only used in u, T calculation if ieos==2,12
+          if (i==1) then
+             guessene = 1.5*pres(i)/den(i)  ! initial guess
+             tempi = min((3.*pres(i)/radconst)**0.25, pres(i)*mu(i)/(den(i)*kb_on_mh)) ! guess for temperature
+          else
+             guessene = en(i-1)
+             tempi = temp(i-1)
+          endif
+          call calc_temp_and_ene(ieos,den(i),pres(i),eni,tempi,ierr,guesseint=guessene,mu_local=mu(i))  ! for ieos==20, mu is outputted here
+          en(i) = eni
+          temp(i) = tempi
+       enddo
+       call write_mesa(outputfilename,mtab,pres,temp,r,den,en,Xfrac,Yfrac,mu=mu)
+       ! now read the softened profile instead
+       call read_mesa(outputfilename,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,Mstar,ierr)
+    else
+       call read_mesa(input_profile,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,Mstar,ierr)
+    endif
+    if (ierr==1) call fatal('set_star',trim(input_profile)//' does not exist')
+    if (ierr==2) call fatal('set_star','insufficient data points read from file')
+    if (ierr==3) call fatal('set_star','too many data points; increase ng')
+    if (ierr /= 0) call fatal('set_star','error in reading stellar profile from'//trim(input_profile))
+    npts = size(den)
+    rmin  = r(1)
+    Rstar = r(npts)
+ case(ikepler)
+    call read_kepler_file(trim(input_profile),ng_max,npts,r,den,pres,temp,en,&
+                          Mstar,composition,comp_label,columns_compo,ierr)
+    if (ierr==1) call fatal('set_star',trim(input_profile)//' does not exist')
+    if (ierr==2) call fatal('set_star','insufficient data points read from file')
+    if (ierr==3) call fatal('set_star','too many data points; increase ng')
+    rmin  = r(1)
+    Rstar = r(npts)
+ case(ievrard)
+    call rho_evrard(ng_max,Mstar,Rstar,r,den)
+    npts = ng_max
+    polyk = ui_coef*Mstar/Rstar
+    rmin = r(1)
+    pres = polyk*den**gamma
+    print*,' Assuming polyk = ',polyk
+ case default  ! set up uniform sphere by default
+    call rho_uniform(ng_max,Mstar,Rstar,r,den) ! use this array for continuity of call to set_sphere
+    npts = ng_max
+    rmin = r(1)
+    pres = polyk*den**gamma
+    print*,' Assuming polyk = ',polyk
+ end select
+
+end subroutine read_star_profile
+
+!-------------------------------------------------------------------------------
+!+
+!  query function for whether a particular profile needs to read an input file
+!+
+!-------------------------------------------------------------------------------
+logical function need_inputprofile(iprofile)
+ integer, intent(in) :: iprofile
+
+ select case(iprofile)
+ case(imesa,ikepler,ifromfile)
+    need_inputprofile = .true.
+ case default
+    need_inputprofile = .false.
+ end select
+
+end function need_inputprofile
+
+!-------------------------------------------------------------------------------
+!+
+!  query function for whether a particular profile needs to read the
+!  polytropic constant
+!+
+!-------------------------------------------------------------------------------
+logical function need_polyk(iprofile)
+ integer, intent(in) :: iprofile
+
+ select case(iprofile)
+ case(iuniform,ibpwpoly)
+    need_polyk = .true.
+ case default
+    need_polyk = .false.
+ end select
+
+end function need_polyk
+
+!-------------------------------------------------------------------------------
+!+
+!  query function for whether a particular profile needs to read the
+!  stellar radius
+!+
+!-------------------------------------------------------------------------------
+logical function need_rstar(iprofile)
+ integer, intent(in) :: iprofile
+
+ select case(iprofile)
+ case(ibpwpoly)
+    need_rstar = .false.
+ case default
+    need_rstar = .true.
+ end select
+
+end function need_rstar
+
+!-------------------------------------------------------------------------------
+!+
+!  set up particles according to the desired density profile
+!+
+!-------------------------------------------------------------------------------
+subroutine set_star_density(lattice,id,master,rmin,Rstar,Mstar,hfact,&
+                            npts,den,r,npart,npartoftype,massoftype,xyzh,&
+                            use_exactN,np,rhozero,npart_total,mask)
+ use part,         only:set_particle_type,igas
+ use spherical,    only:set_sphere
+ use unifdis,      only:mask_prototype
+ use physcon,      only:pi
+ character(len=*), intent(in)    :: lattice
+ integer,          intent(in)    :: id,master,npts,np
+ integer(kind=8),  intent(out)   :: npart_total
+ real,             intent(in)    :: rmin,Rstar,Mstar,hfact
+ real,             intent(in)    :: den(npts),r(npts)
+ real,             intent(out)   :: rhozero
+ integer,          intent(inout) :: npart,npartoftype(:)
+ real,             intent(inout) :: xyzh(:,:),massoftype(:)
+ logical,          intent(in)    :: use_exactN
+ procedure(mask_prototype) :: mask
+ integer :: nx,i,ntot
+ real :: vol_sphere,psep
+ !
+ ! place particles in sphere
+ !
+ vol_sphere  = 4./3.*pi*Rstar**3
+ nx          = int(np**(1./3.))
+ psep        = vol_sphere**(1./3.)/real(nx)
+ call set_sphere(lattice,id,master,rmin,Rstar,psep,hfact,npart,xyzh, &
+                 rhotab=den(1:npts),rtab=r(1:npts),nptot=npart_total, &
+                 exactN=use_exactN,np_requested=np,mask=mask)
+ !
+ ! get total particle number across all MPI threads
+ ! and use this to set the particle mass
+ !
+ ntot = int(npart_total,kind=(kind(ntot)))
+ massoftype(igas) = Mstar/ntot
+ !
+ ! set particle type as gas particles
+ !
+ npartoftype(igas) = npart   ! npart is number on this thread only
+ do i=1,npart
+    call set_particle_type(i,igas)
+ enddo
+ !
+ ! mean density
+ !
+ rhozero = Mstar/vol_sphere
+
+end subroutine set_star_density
+
+!-----------------------------------------------------------------------
+!+
+!  Add a sink particle as a stellar core
+!+
+!-----------------------------------------------------------------------
+subroutine set_stellar_core(nptmass,xyzmh_ptmass,vxyz_ptmass,ihsoft,mcore,hsoft,ierr)
+ integer, intent(out) :: nptmass,ierr
+ real, intent(out)    :: xyzmh_ptmass(:,:),vxyz_ptmass(:,:)
+ real, intent(in)     :: mcore,hsoft
+ integer              :: n,ihsoft
+
+ ierr = 0
+ ! Check for sensible values
+ if (mcore < tiny(mcore)) then
+    ierr = 1
+    return
+ endif
+ if (hsoft < tiny(hsoft)) then
+    ierr = 2
+    return
+ endif
+
+ nptmass                = 1
+ n                      = nptmass
+ xyzmh_ptmass(:,n)      = 0. ! zero all quantities by default
+ xyzmh_ptmass(4,n)      = mcore
+ xyzmh_ptmass(ihsoft,n) = hsoft
+ vxyz_ptmass(:,n)       = 0.
+
+end subroutine set_stellar_core
+
+!-----------------------------------------------------------------------
+!+
+!  Set the composition, if variable composition is used
+!+
+!-----------------------------------------------------------------------
+subroutine set_star_composition(use_var_comp,use_mu,npart,xyzh,Xfrac,Yfrac,mu,mtab,Mstar,eos_vars)
+ use part,        only:iorder=>ll,iX,iZ,imu  ! borrow the unused linklist array for the sort
+ use sortutils,   only:find_rank,r2func
+ use table_utils, only:yinterp
+ logical, intent(in)  :: use_var_comp,use_mu
+ integer, intent(in)  :: npart
+ real,    intent(in)  :: xyzh(:,:)
+ real,    intent(in)  :: Xfrac(:),Yfrac(:),mu(:),mtab(:),Mstar
+ real,    intent(out) :: eos_vars(:,:)
+ real :: ri,massri
+ integer :: i
+
+ ! this does NOT work with MPI
+ call find_rank(npart,r2func,xyzh(1:3,:),iorder)
+ do i = 1,npart
+    ri  = sqrt(dot_product(xyzh(1:3,i),xyzh(1:3,i)))
+    massri = Mstar * real(iorder(i)-1) / real(npart) ! mass coordinate of particle i
+    if (use_var_comp) then
+       eos_vars(iX,i) = yinterp(Xfrac,mtab,massri)
+       eos_vars(iZ,i) = 1. - eos_vars(iX,i) - yinterp(Yfrac,mtab,massri)
+    endif
+    if (use_mu) eos_vars(imu,i) = yinterp(mu,mtab,massri)
+ enddo
+
+end subroutine set_star_composition
+
+!-----------------------------------------------------------------------
+!+
+!  Set the thermal energy profile
+!+
+!-----------------------------------------------------------------------
+subroutine set_star_thermalenergy(ieos,den,pres,r,npts,npart,xyzh,vxyzu,rad,eos_vars,relaxed,use_var_comp,initialtemp)
+ use part,            only:do_radiation,rhoh,massoftype,igas,itemp,igasP,iX,iZ,imu,iradxi
+ use eos,             only:equationofstate,calc_temp_and_ene,gamma,gmw
+ use radiation_utils, only:ugas_from_Tgas,radE_from_Trad
+ use table_utils,     only:yinterp
+ use units,           only:unit_density,unit_ergg,unit_pressure
+ integer, intent(in)    :: ieos,npart,npts
+ real,    intent(in)    :: den(:), pres(:), r(:)  ! density and pressure tables
+ real,    intent(in)    :: xyzh(:,:)
+ real,    intent(inout) :: vxyzu(:,:),eos_vars(:,:),rad(:,:)
+ logical, intent(in)    :: relaxed,use_var_comp
+ real,    intent(in)    :: initialtemp
+ integer :: eos_type,i,ierr
+ real    :: xi,yi,zi,hi,presi,densi,tempi,eni,ri,p_on_rhogas,spsoundi
+ real    :: rho_cgs,p_cgs
+
+ if (do_radiation) then
+    eos_type=12  ! Calculate temperature from both gas and radiation pressure
+ else
+    eos_type=ieos
+ endif
+ do i = 1,npart
+    if (relaxed) then
+       hi = xyzh(4,i)
+       densi = rhoh(hi,massoftype(igas))
+       presi = eos_vars(igasP,i)  ! retrieve pressure from relax_star calculated with the fake (ieos=2) internal energy
+    else
+       !  Interpolate density and pressure from table
+       ri    = sqrt(dot_product(xyzh(1:3,i),xyzh(1:3,i)))
+       densi = yinterp(den(1:npts),r(1:npts),ri)
+       presi = yinterp(pres(1:npts),r(1:npts),ri)
+    endif
+
+    select case(ieos)
+    case(16) ! Shen EoS
+       vxyzu(4,i) = initialtemp
+    case(15) ! Helmholtz EoS
+       xi    = xyzh(1,i)
+       yi    = xyzh(2,i)
+       zi    = xyzh(3,i)
+       tempi = initialtemp
+       call equationofstate(ieos,p_on_rhogas,spsoundi,densi,xi,yi,zi,tempi,eni)
+       vxyzu(4,i) = eni
+       eos_vars(itemp,i) = initialtemp
+    case default ! Recalculate eint and temp for each particle according to EoS
+       rho_cgs = densi*unit_density
+       p_cgs = presi*unit_pressure
+       if (use_var_comp) then
+          call calc_temp_and_ene(eos_type,rho_cgs,p_cgs,eni,tempi,ierr,&
+                                 mu_local=eos_vars(imu,i),X_local=eos_vars(iX,i),Z_local=eos_vars(iZ,i))
+       else
+          call calc_temp_and_ene(eos_type,rho_cgs,p_cgs,eni,tempi,ierr)
+       endif
+       if (do_radiation) then
+          vxyzu(4,i) = ugas_from_Tgas(tempi,gamma,gmw)
+          rad(iradxi,i) = radE_from_Trad(tempi)/densi
+       else
+          vxyzu(4,i) = eni / unit_ergg
+       endif
+       eos_vars(itemp,i) = tempi
+    end select
+ enddo
+
+end subroutine set_star_thermalenergy
+
+end module setstar_utils

--- a/src/utils/moddump_binary.f90
+++ b/src/utils/moddump_binary.f90
@@ -44,6 +44,7 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  use io,                only:fatal,idisk1,iprint
  use timestep,          only:tmax,dtmax
  use readwrite_dumps,   only:read_dump
+ use eos,               only:X_in,Z_in
 
  integer, intent(inout)    :: npart
  integer, intent(inout)    :: npartoftype(:)
@@ -330,7 +331,7 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
        call prompt('Enter mass of the created point mass core', mcut)
        call prompt('Enter softening length of the point mass', hsoft_default)
 
-       call read_mesa(densityfile,den,r,pres,m,enitab,temp,Xfrac,Yfrac,Mstar,ierr,cgsunits=.false.)
+       call read_mesa(densityfile,den,r,pres,m,enitab,temp,X_in,Z_in,Xfrac,Yfrac,Mstar,ierr,cgsunits=.false.)
        rcut = yinterp(r,m,mcut)
 
        irhomax = 1


### PR DESCRIPTION
Type of PR: 
cleanup / structural changes to set_star

Description:

The aim of this change is to be able to perform all the functionality of setup_star from any setup routine in phantom. This is with the intention of making several "two-step" setup-and-moddump procedures into a single, streamlined procedure. For example, the TDE setup could add a star, relax the star and place it into orbit without needing the moddump procedure. Similarly, this change allows implementation a binary, triple or hierarchical star setup with multiple stars read from MESA tables.

The changes to the code at the moment are purely structural, there is no change in functionality:

- added new set_star routine/module that does all the steps in setup_star
- set_star provides routines to read/write/ask for all the options needed to setup and relax a single stellar model
- teased apart the options that would be per-star from the equation of state options that are per-setup

Testing:
Testing on AGB stellar model with sink particle core, ensuring setup procedure proceeds as previously

Did you run the bots? no

Did you update relevant documentation in the docs directory? no