### PR TITLE
GitHub actions workflow to check phantom+mcfost

### DIFF
--- a/.github/workflows/mcfost.yml
+++ b/.github/workflows/mcfost.yml
@@ -23,21 +23,22 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+    - name: install gfortran
+      run: brew install gfortran
+
+    - name: soft link gfortran and check version
+      run: |
+        ln -s `ls $PREFIX/bin/gfortran-* | tail -1` $PREFIX/bin/gfortran
+        gfortran -v
+
     - name: tap the homebrew repo
       run: brew tap danieljprice/all
 
     - name: install mcfost with homebrew
-      env:
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: brew install mcfost
 
     - name: "Clone phantom"
       uses: actions/checkout@v3
-
-    - name: install gfortran
-      env:
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: brew install gfortran
 
     - name: "Compile phantom and link with mcfost"
       run: make SETUP=disc MCFOST=yes PREFIX=${PREFIX} LIBCXX=-lc++

--- a/.github/workflows/mcfost.yml
+++ b/.github/workflows/mcfost.yml
@@ -9,9 +9,10 @@ on:
       - 'README.md'
 
 env:
-  PREFIX: /opt/homebrew
+  PREFIX: /usr/local/
   MCFOST_GIT: 1
   SYSTEM: gfortran
+  HOMEBREW_NO_INSTALL_CLEANUP: 1
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -32,6 +33,11 @@ jobs:
 
     - name: "Clone phantom"
       uses: actions/checkout@v3
+
+    - name: install gfortran
+      env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: brew install gcc
 
     - name: "Compile phantom and link with mcfost"
       run: make SETUP=disc MCFOST=yes PREFIX=${PREFIX} LIBCXX=-lc++

--- a/.github/workflows/mcfost.yml
+++ b/.github/workflows/mcfost.yml
@@ -37,7 +37,7 @@ jobs:
     - name: install gfortran
       env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: brew install gcc
+      run: brew install gfortran
 
     - name: "Compile phantom and link with mcfost"
       run: make SETUP=disc MCFOST=yes PREFIX=${PREFIX} LIBCXX=-lc++

--- a/.github/workflows/mcfost.yml
+++ b/.github/workflows/mcfost.yml
@@ -1,0 +1,46 @@
+name: mcfost
+
+# Trigger on pull request, but only for the master branch
+on:
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+
+env:
+  PREFIX: /opt/homebrew
+  MCFOST_GIT: 1
+  SYSTEM: gfortran
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  mcfost:
+
+    # The type of runner that the job will run on
+    runs-on: macos-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - name: tap the homebrew repo
+      run: brew tap danieljprice/all
+
+    - name: install mcfost with homebrew
+      env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: brew install mcfost
+
+    - name: "Clone phantom"
+      uses: actions/checkout@v3
+
+    - name: "Compile phantom and link with mcfost"
+      run: make SETUP=disc MCFOST=yes PREFIX=${PREFIX} LIBCXX=-lc++
+
+    - name: "Compile phantomsetup and link with mcfost"
+      run: make SETUP=disc MCFOST=yes PREFIX=${PREFIX} LIBCXX=-lc++ setup
+
+    - name: "Compile phantomanalysis and link with mcfost"
+      run: make SETUP=disc MCFOST=yes PREFIX=${PREFIX} LIBCXX=-lc++ analysis
+
+    - name: "Compile phantommoddump and link with mcfost"
+      run: make SETUP=disc MCFOST=yes PREFIX=${PREFIX} LIBCXX=-lc++ moddump


### PR DESCRIPTION
Type of PR: 
continuous integration testing, closes #379 

Description:
this is a GitHub action to compile phantom and link it against MCFOST, as needed for live phantom+mcfost simulations
the idea is to check if the API gets broken for whatever reason (could either be at the phantom or on the mcfost end).

Testing:
Will be tested in the actions workflow

Did you run the bots? no

Did you update relevant documentation in the docs directory? yes, the action follows recommended installation procedure for homebrew installation of mcfost in the mcfost help page