### PR TITLE
setup for tidal disruption event in GR

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,8 +20,8 @@ Rebecca Nealon <rebecca.nealon@warwick.ac.uk>
 Ward Homan <ward.homan@kuleuven.be>
 Christophe Pinte <christophe.pinte@univ-grenoble-alpes.fr>
 Elisabeth Borchert <elisabeth.borchert@monash.edu>
-Fangyi (Fitz) Hu <fhuu0005@student.monash.edu>
 Megha Sharma <msha0023@student.monash.edu>
+Fangyi (Fitz) Hu <fhuu0005@student.monash.edu>
 Terrence Tricco <ttricco@cita.utoronto.ca>
 Mats Esseldeurs <matsesseldeurs@yahoo.com>
 Simone Ceppi <simone.ceppi@unimi.it>

--- a/build/Makefile
+++ b/build/Makefile
@@ -204,9 +204,6 @@ endif
 
 ifeq ($(GR), yes)
     FPPFLAGS += -DGR
-ifeq ($(METRIC), kerr)
-    FPPFLAGS += -DKERR
-endif
 ifeq ($(ISENTROPIC), yes)
     FPPFLAGS += -DISENTROPIC
     FPPFLAGS += -DLIGHTCURVE

--- a/build/Makefile_setups
+++ b/build/Makefile_setups
@@ -264,7 +264,6 @@ endif
 
 ifeq ($(SETUP), prtest)
 #   simple test of prdrag
-    FPPFLAGS=
     SETUPFILE= setup_prtest.f90
     KNOWN_SETUP=yes
 endif
@@ -318,7 +317,6 @@ endif
 
 ifeq ($(SETUP), torus)
 #   MRI torus
-    FPPFLAGS=
     SETUPFILE= setup_torus.f90
     ANALYSIS= analysis_torus.f90
     KNOWN_SETUP=yes
@@ -326,7 +324,6 @@ endif
 
 ifeq ($(SETUP), galcen)
 #   galactic centre
-    FPPFLAGS=
     SETUPFILE= setup_galcen_stars.f90
     SRCINJECT= inject_galcen_winds.f90
     KNOWN_SETUP=yes
@@ -689,7 +686,6 @@ endif
 
 ifeq ($(SETUP), cluster)
 #   star cluster formation
-    FPPFLAGS=
     SETUPFILE= velfield_fromcubes.f90 setup_cluster.f90
     MODFILE= moddump_default.f90
     ANALYSIS= phantom_pdfs.o analysis_MWpdf.f90 #analysis_sinkmass.f90
@@ -703,7 +699,6 @@ endif
 
 ifeq ($(SETUP), binary)
 #   binary stars
-    FPPFLAGS=
     #SRCINJECT= utils_binary.f90 set_binary.f90 inject_rochelobe.f90
     SETUPFILE= setup_binary.f90
     #SETUPFILE= setup_chinchen.f90
@@ -713,7 +708,6 @@ endif
 
 ifeq ($(SETUP), hierarchical)
 #   hierarchical system setup
-    FPPFLAGS= -DCONST_AV
     #SRCINJECT= set_hierarchical.f90 set_binary.f90 inject_rochelobe.f90 utils_binary.f90
     SETUPFILE= setup_hierarchical.f90
     KNOWN_SETUP=yes
@@ -722,14 +716,12 @@ endif
 
 ifeq ($(SETUP), common)
 #   binary setup
-    FPPFLAGS=
     SETUPFILE= setup_common.f90
     KNOWN_SETUP=yes
 endif
 
 ifeq ($(SETUP), star)
 #   import stellar model from 1D stellar evolution code
-    FPPFLAGS=
     SETUPFILE= setup_star.f90
     MODFILE= utils_binary.f90 set_binary.f90 moddump_binary.f90
     ANALYSIS= ${SRCNIMHD} utils_summary.o utils_omp.o ptmass.o energies.o analysis_common_envelope.F90
@@ -742,7 +734,6 @@ ifeq ($(SETUP), grstar)
 #   star in GR using Minkowski metric
     GR=yes
     METRIC=minkowski
-    FPPFLAGS=
     IND_TIMESTEPS=yes
     SETUPFILE= setup_star.f90
     MODFILE= moddump_tidal.f90
@@ -1003,7 +994,6 @@ endif
 ifeq ($(SETUP), testgr)
 #   unit tests of general relativistic code
     GR=yes
-    FPPFLAGS= -DGR
     KNOWN_SETUP=yes
     METRIC=kerr
     SETUPFILE= setup_grdisc.f90

--- a/src/main/checksetup.F90
+++ b/src/main/checksetup.F90
@@ -804,10 +804,6 @@ subroutine check_gr(npart,nerror,xyzh,vxyzu)
        call pack_metric(xyzh(1:3,i),metrici)
        call unpack_metric(metrici,gcov=gcov)
        call get_u0(gcov,vxyzu(1:3,i),U0,ierr)
-       if (ierr /= 0) then
-          print*,vxyzu(1:3,i),gcov,U0
-          read*
-       endif
        if (ierr/=0) nbad = nbad + 1
     endif
  enddo

--- a/src/main/externalforces_gr.F90
+++ b/src/main/externalforces_gr.F90
@@ -16,7 +16,8 @@ module externalforces
 !   - accradius1      : *soft accretion radius of black hole*
 !   - accradius1_hard : *hard accretion radius of black hole*
 !
-! :Dependencies: dump_utils, infile_utils, io, metric_tools, part, units
+! :Dependencies: dump_utils, infile_utils, io, metric, metric_tools, part,
+!   units
 !
  use metric, only:mass1
  implicit none

--- a/src/main/externalforces_gr.F90
+++ b/src/main/externalforces_gr.F90
@@ -18,9 +18,8 @@ module externalforces
 !
 ! :Dependencies: dump_utils, infile_utils, io, metric_tools, part, units
 !
+ use metric, only:mass1
  implicit none
- character(len=80), parameter, public :: &  ! module version
-    modid="$Id$"
 
  private
  public :: externalforce,externalforce_vdependent
@@ -36,7 +35,7 @@ module externalforces
  !
  integer, parameter, public :: iext_gr = 1
 
- real, public :: mass1 = 1.0
+ public :: mass1  ! exported from metric module
  real, public :: accradius1 = 0.
  real, public :: accradius1_hard = 0.
 

--- a/src/main/metric_schwarzschild.f90
+++ b/src/main/metric_schwarzschild.f90
@@ -22,6 +22,7 @@ module metric
  integer,          parameter :: imetric     = 2
 
  real, public :: mass1 = 1.       ! mass of central object
+ real, public :: a     = 0.       ! spin of central object
 
 contains
 

--- a/src/main/options.f90
+++ b/src/main/options.f90
@@ -127,7 +127,7 @@ subroutine set_default_options
  ! artificial thermal conductivity
  alphau = 1.
  if (gr) alphau = 0.1
- ireconav = 1
+ ireconav = -1
 
  ! artificial resistivity (MHD only)
  alphaB            = 1.0

--- a/src/setup/relax_star.f90
+++ b/src/setup/relax_star.f90
@@ -30,7 +30,7 @@ module relaxstar
  real,    private :: tol_dens = 1.   ! allow 1% RMS error in density
  integer, private :: maxits = 1000
 
- real,    private :: gammaprev,hfactprev
+ real,    private :: gammaprev,hfactprev,mass1prev
  integer, private :: ieos_prev
 
  integer, public :: ierr_setup_errors = 1, &
@@ -113,7 +113,7 @@ subroutine relax_star(nt,rho,pr,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,ierr,np
  !
  ! check particle setup is sensible
  !
- call check_setup(nwarn,nerr,restart=.true.) ! restart=T allows accreted/masked particles
+ call check_setup(nerr,nwarn,restart=.true.) ! restart=T allows accreted/masked particles
  if (nerr > 0) then
     call error('relax_star','cannot relax star because particle setup contains errors')
     call restore_original_options(i1,npart)
@@ -372,15 +372,17 @@ end subroutine reset_u_and_get_errors
 !----------------------------------------------------------------
 subroutine set_options_for_relaxation(tdyn)
  use eos,  only:ieos,gamma
- use part, only:hfact,maxvxyzu
+ use part, only:hfact,maxvxyzu,gr
  use damping, only:damp,tdyn_s
  use options, only:idamp
- use units,   only:utime
+ use units,          only:utime
+ use externalforces, only:mass1
  real, intent(in) :: tdyn
 
  gammaprev = gamma
  hfactprev = hfact
  ieos_prev = ieos
+ mass1prev = mass1
  !
  ! turn on settings appropriate to relaxation
  !
@@ -392,6 +394,7 @@ subroutine set_options_for_relaxation(tdyn)
     idamp = 1
     damp = 0.05
  endif
+ if (gr) mass1 = 0. ! use Minkowski metric during relaxation
 
 end subroutine set_options_for_relaxation
 
@@ -422,7 +425,8 @@ subroutine restore_original_options(i1,npart)
  use eos,     only:ieos,gamma
  use damping, only:damp
  use options, only:idamp
- use part,    only:hfact,vxyzu
+ use part,    only:hfact,vxyzu,gr
+ use externalforces, only:mass1
  integer, intent(in) :: i1,npart
 
  gamma = gammaprev
@@ -431,6 +435,7 @@ subroutine restore_original_options(i1,npart)
  idamp = 0
  damp = 0.
  vxyzu(1:3,i1+1:npart) = 0.
+ if (gr) mass1 = mass1prev
 
 end subroutine restore_original_options
 

--- a/src/setup/relax_star.f90
+++ b/src/setup/relax_star.f90
@@ -18,10 +18,10 @@ module relaxstar
 !   - tol_dens : *% error in density to stop relaxation*
 !   - tol_ekin : *tolerance on ekin/epot to stop relaxation*
 !
-! :Dependencies: checksetup, damping, deriv, dim, energies, eos, fileutils,
-!   infile_utils, initial, io, io_summary, memory, options, part, physcon,
-!   ptmass, readwrite_dumps, setstar_utils, sortutils, step_lf_global,
-!   table_utils, units
+! :Dependencies: checksetup, damping, deriv, dim, energies, eos,
+!   externalforces, fileutils, infile_utils, initial, io, io_summary,
+!   memory, options, part, physcon, ptmass, readwrite_dumps, setstar_utils,
+!   sortutils, step_lf_global, table_utils, units
 !
  implicit none
  public :: relax_star,write_options_relax,read_options_relax

--- a/src/setup/set_binary.f90
+++ b/src/setup/set_binary.f90
@@ -91,7 +91,7 @@ subroutine set_binary(m1,m2,semimajoraxis,eccentricity, &
 
  if (do_verbose) then
     print "(/,2x,a)",'---------- binary parameters ----------- '
-    print "(8(2x,a,g14.6,/),2x,a,g14.6)", &
+    print "(8(2x,a,1pg14.6,/),2x,a,1pg14.6)", &
         'primary mass     :',m1, &
         'secondary mass   :',m2, &
         'mass ratio m2/m1 :',m2/m1, &
@@ -167,7 +167,7 @@ subroutine set_binary(m1,m2,semimajoraxis,eccentricity, &
     E_dot = sqrt((m1 + m2)/(a**3))/(1.-eccentricity*cos(E))
 
     if (do_verbose) then
-       print "(4(2x,a,g12.4,/),2x,a,g12.4)", &
+       print "(4(2x,a,1pg14.6,/),2x,a,1pg14.6)", &
              'Eccentric anomaly:',E, &
              'E_dot            :',E_dot, &
              'inclination     (i, deg):',incl, &
@@ -202,7 +202,7 @@ subroutine set_binary(m1,m2,semimajoraxis,eccentricity, &
 
  ! print info about positions and velocities
  if (do_verbose) then
-    print "(7(2x,a,g12.4,/),2x,a,g12.4)", &
+    print "(7(2x,a,1pg14.6,/),2x,a,1pg14.6)", &
         'angular momentum :',angmbin, &
         'mean ang. speed  :',omega0, &
         'Omega_0 (prim)   :',v1(2)/x1(1), &
@@ -218,7 +218,7 @@ subroutine set_binary(m1,m2,semimajoraxis,eccentricity, &
     omega_corotate = omega0
     v1(2) = v1(2) - omega0*x1(1)
     v2(2) = v2(2) - omega0*x2(1)
-    if (do_verbose) print "(2(2x,a,g12.4,/))", &
+    if (do_verbose) print "(2(2x,a,1pg14.6,/))", &
      'Omega_0 (primary)     :',v1(2)/x1(1), &
      'Omega_0 (secondary)   :',v2(2)/x2(1)
  endif

--- a/src/setup/setup_grtde.f90
+++ b/src/setup/setup_grtde.f90
@@ -148,16 +148,20 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  !
  !--place star into orbit
  !
- print*, 'mstar', star%mstar
- print*, 'rstar', star%rstar
- print*, 'umass', umass
- print*, 'udist', udist
  rtidal          = star%rstar*(mass1/star%mstar)**(1./3.)
  rp              = rtidal/beta
  accradius1_hard = 5.*mass1
  accradius1      = accradius1_hard
  a               = 0.
  theta           = theta*pi/180.
+
+ print*, 'mstar', star%mstar
+ print*, 'rstar', star%rstar
+ print*, 'umass', umass
+ print*, 'udist', udist
+ print*, 'mass1', mass1
+ print*, 'tidal radius', rtidal
+ print*, 'beta', beta
 
  xyzstar  = 0.
  vxyzstar = 0.
@@ -170,9 +174,6 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
     semia    = rp/(1.-ecc)
     period   = 2.*pi*sqrt(semia**3/mass1)
     print*, 'period', period
-    print*, 'mass1', mass1
-    print*, 'tidal radius', rtidal
-    print*, 'beta', beta
     hacc1    = star%rstar/1.e8    ! Something small so that set_binary doesnt warn about Roche lobe
     hacc2    = hacc1
     ! apocentre = rp*(1.+ecc)/(1.-ecc)

--- a/src/setup/setup_grtde.f90
+++ b/src/setup/setup_grtde.f90
@@ -13,21 +13,16 @@ module setup
 ! :Owner: David Liptai
 !
 ! :Runtime parameters:
-!   - beta            : *penetration factor*
-!   - dumpsperorbit   : *number of dumps per orbit*
-!   - ecc             : *eccentricity (1 for parabolic)*
-!   - mhole           : *mass of black hole (solar mass)*
-!   - mstar           : *mass of star       (solar mass)*
-!   - norbits         : *number of orbits*
-!   - nr              : *particles per star radius (i.e. resolution)*
-!   - rstar           : *radius of star     (solar radii)*
-!   - stardensprofile : *star density profile (1=adiabatic, 2=kepler)*
-!   - theta           : *inclination of orbit (degrees)*
+!   - beta          : *penetration factor*
+!   - dumpsperorbit : *number of dumps per orbit*
+!   - ecc           : *eccentricity (1 for parabolic)*
+!   - mhole         : *mass of black hole (solar mass)*
+!   - norbits       : *number of orbits*
+!   - theta         : *inclination of orbit (degrees)*
 !
-! :Dependencies: eos, extern_densprofile, externalforces, gravwaveutils,
-!   infile_utils, io, kernel, metric, part, physcon, rho_profile,
-!   setbinary, setstar_kepler, spherical, table_utils, timestep, units,
-!   vectorutils
+! :Dependencies: eos, externalforces, gravwaveutils, infile_utils, io,
+!   kernel, metric, mpidomain, part, physcon, setbinary, setstar,
+!   setup_params, timestep, units, vectorutils
 !
  use setstar, only:star_t
  implicit none

--- a/src/setup/setup_grtde.f90
+++ b/src/setup/setup_grtde.f90
@@ -30,6 +30,7 @@ module setup
 
  real    :: mhole,beta,ecc,norbits,theta
  integer :: dumpsperorbit
+ logical :: relax
  type(star_t) :: star
 
  private
@@ -69,7 +70,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  real,              intent(out)   :: vxyzu(:,:)
  character(len=120) :: filename
  integer :: ierr
- logical :: iexist,write_profile,use_var_comp,relax
+ logical :: iexist,write_profile,use_var_comp
  real    :: rtidal,rp,semia,period,hacc1,hacc2
  real    :: vxyzstar(3),xyzstar(3)
  real    :: r0,vel,lorentz
@@ -106,7 +107,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  theta           = 0.
  write_profile   = .false.
  use_var_comp    = .false.
- relax           = .true.
+ relax           = .false.
 !
 !-- Read runtime parameters from setup file
 !
@@ -242,6 +243,7 @@ end subroutine setpart
 subroutine write_setupfile(filename)
  use infile_utils, only:write_inopt
  use setstar,      only:write_options_star
+ use relaxstar,    only:write_options_relax
  character(len=*), intent(in) :: filename
  integer, parameter :: iunit = 20
 
@@ -250,6 +252,8 @@ subroutine write_setupfile(filename)
  write(iunit,"(a)") '# input file for tidal disruption setup'
 
  call write_options_star(star,iunit)
+ call write_inopt(relax,'relax','relax star into hydrostatic equilibrium',iunit)
+ if (relax) call write_options_relax(iunit)
 
  write(iunit,"(/,a)") '# options for black hole and orbit'
 
@@ -267,6 +271,7 @@ subroutine read_setupfile(filename,ieos,polyk,ierr)
  use infile_utils, only:open_db_from_file,inopts,read_inopt,close_db
  use io,           only:error
  use setstar,      only:read_options_star
+ use relaxstar,    only:read_options_relax
  character(len=*), intent(in)    :: filename
  integer,          intent(inout) :: ieos
  real,             intent(inout) :: polyk
@@ -280,6 +285,8 @@ subroutine read_setupfile(filename,ieos,polyk,ierr)
  ierr = 0
  call open_db_from_file(db,filename,iunit,ierr)
  call read_options_star(star,need_iso,ieos,polyk,db,nerr)
+ call read_inopt(relax,'relax',db,errcount=nerr)
+ if (relax) call read_options_relax(db,nerr)
 
  call read_inopt(mhole,          'mhole',          db,min=0.,errcount=nerr)
  call read_inopt(beta,           'beta',           db,min=0.,errcount=nerr)

--- a/src/setup/setup_grtde.f90
+++ b/src/setup/setup_grtde.f90
@@ -29,11 +29,13 @@ module setup
 !   setbinary, setstar_kepler, spherical, table_utils, timestep, units,
 !   vectorutils
 !
+ use setstar, only:star_t
  implicit none
  public :: setpart
 
- real    :: mhole,mstar,rstar,beta,ecc,norbits,theta
- integer :: dumpsperorbit,nr,stardensprofile
+ real    :: mhole,beta,ecc,norbits,theta
+ integer :: dumpsperorbit
+ type(star_t) :: star
 
  private
 
@@ -45,23 +47,22 @@ contains
 !+
 !----------------------------------------------------------------
 subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,time,fileprefix)
- use part,      only:nptmass,xyzmh_ptmass,vxyz_ptmass,ihacc,ihsoft,igas,set_particle_type,rhoh,gravity,eos_vars,itemp
+ use part,      only:nptmass,xyzmh_ptmass,vxyz_ptmass,ihacc,ihsoft,igas,&
+                     gravity,eos_vars,rad
  use setbinary, only:set_binary
- use spherical, only:set_sphere
- use units,     only:set_units,umass,udist,unit_density,unit_pressure,unit_ergg
+ use setstar,   only:set_star,shift_star
+ use units,     only:set_units,umass,udist
  use physcon,   only:solarm,pi,solarr
- use table_utils,only:yinterp
  use io,        only:master,fatal,warning
  use timestep,  only:tmax,dtmax
  use metric,    only:mass1,a
- use eos,       only:ieos,calc_temp_and_ene
+ use eos,       only:ieos,X_in,Z_in
  use kernel,    only:hfact_default
- use extern_densprofile, only:nrhotab
- use readwrite_kepler,   only:read_kepler_file
- use externalforces,     only:accradius1,accradius1_hard
- use rho_profile,        only:rho_polytrope
- use vectorutils,        only:rotatevec
- use gravwaveutils,      only:theta_gw,calc_gravitwaves
+ use mpidomain, only:i_belong
+ use externalforces, only:accradius1,accradius1_hard
+ use vectorutils,    only:rotatevec
+ use gravwaveutils,  only:theta_gw,calc_gravitwaves
+ use setup_params,   only:rhozero,npart_total
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -72,17 +73,12 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  character(len=20), intent(in)    :: fileprefix
  real,              intent(out)   :: vxyzu(:,:)
  character(len=120) :: filename
- integer, parameter :: ntab=5000
- integer, parameter :: ng_max = nrhotab
- integer :: ierr,i,npts,columns_compo
- logical :: iexist
- real    :: rtidal,rp,semia,psep,period,hacc1,hacc2
+ integer :: ierr
+ logical :: iexist,write_profile,use_var_comp,relax
+ real    :: rtidal,rp,semia,period,hacc1,hacc2
  real    :: vxyzstar(3),xyzstar(3)
- real    :: densi,r0,vel,lorentz,eni,tempi,presi,ri
+ real    :: r0,vel,lorentz
  real    :: vhat(3),x0,y0
- real,allocatable :: rtab(:),rhotab(:)
- real,allocatable :: pres(:), temp(:), en(:),composition(:,:)
- character(len=20), allocatable :: comp_label(:)
 !
 !-- general parameters
 !
@@ -92,7 +88,6 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  gamma = 5./3.
  ieos  = 2
  if (.not.gravity) call fatal('setup','recompile with GRAVITY=yes')
-
 !
 !-- space available for injected gas particles
 !
@@ -101,28 +96,29 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  xyzh(:,:)      = 0.
  vxyzu(:,:)     = 0.
  nptmass        = 0
-
 !
 !-- Default runtime parameters
 !
-!
  mhole           = 1.e6  ! (solar masses)
- mstar           = 1.    ! (solar masses)
- rstar           = 1.    ! (solar radii)
+ star%mstar      = 1.    ! (solar masses)
+ star%rstar      = 1.    ! (solar radii)
+ star%np         = 1e6
+ star%iprofile   = 2
  beta            = 5.
  ecc             = 0.8
  norbits         = 5.
  dumpsperorbit   = 100
- nr              = 50
  theta           = 0.
- stardensprofile = 1
+ write_profile   = .false.
+ use_var_comp    = .false.
+ relax           = .true.
 !
 !-- Read runtime parameters from setup file
 !
  if (id==master) print "(/,65('-'),1(/,a),/,65('-'),/)",' Tidal disruption in GR'
  filename = trim(fileprefix)//'.setup'
  inquire(file=filename,exist=iexist)
- if (iexist) call read_setupfile(filename,ierr)
+ if (iexist) call read_setupfile(filename,ieos,polyk,ierr)
  if (.not. iexist .or. ierr /= 0) then
     if (id==master) then
        call write_setupfile(filename)
@@ -136,19 +132,31 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
 !
  mhole = mhole*solarm
  call set_units(mass=mhole,c=1.d0,G=1.d0) !--Set central mass to M=1 in code units
- mstar         = mstar*solarm/umass
- rstar         = rstar*solarr/udist
- print*, 'mstar', mstar
- print*, 'rstar', rstar
+ star%mstar = star%mstar*solarm/umass
+ star%rstar = star%rstar*solarr/udist
+
+ !
+ !--set up and relax a star
+ !
+ call set_star(id,master,star,xyzh,vxyzu,eos_vars,rad,npart,npartoftype,&
+               massoftype,hfact,xyzmh_ptmass,vxyz_ptmass,nptmass,ieos,polyk,gamma,&
+               X_in,Z_in,relax,use_var_comp,write_profile,&
+               rhozero,npart_total,i_belong,ierr)
+
+ if (ierr /= 0) call fatal('setup','errors in set_star')
+
+ !
+ !--place star into orbit
+ !
+ print*, 'mstar', star%mstar
+ print*, 'rstar', star%rstar
  print*, 'umass', umass
  print*, 'udist', udist
- rtidal          = rstar*(mass1/mstar)**(1./3.)
+ rtidal          = star%rstar*(mass1/star%mstar)**(1./3.)
  rp              = rtidal/beta
- psep            = rstar/nr
  accradius1_hard = 5.*mass1
  accradius1      = accradius1_hard
  a               = 0.
-
  theta           = theta*pi/180.
 
  xyzstar  = 0.
@@ -165,11 +173,11 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
     print*, 'mass1', mass1
     print*, 'tidal radius', rtidal
     print*, 'beta', beta
-    hacc1    = rstar/1.e8    ! Something small so that set_binary doesnt warn about Roche lobe
+    hacc1    = star%rstar/1.e8    ! Something small so that set_binary doesnt warn about Roche lobe
     hacc2    = hacc1
     ! apocentre = rp*(1.+ecc)/(1.-ecc)
     ! trueanom = acos((rp*(1.+ecc)/r0 - 1.)/ecc)*180./pi
-    call set_binary(mass1,mstar,semia,ecc,hacc1,hacc2,xyzmh_ptmass,vxyz_ptmass,nptmass,ierr,&
+    call set_binary(mass1,star%mstar,semia,ecc,hacc1,hacc2,xyzmh_ptmass,vxyz_ptmass,nptmass,ierr,&
                     posang_ascnode=0.,arg_peri=90.,incl=0.,f=-180.)
     vxyzstar = vxyz_ptmass(1:3,2)
     xyzstar  = xyzmh_ptmass(1:3,2)
@@ -178,10 +186,10 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
     call rotatevec(xyzstar,(/0.,1.,0./),-theta)
     call rotatevec(vxyzstar,(/0.,1.,0./),-theta)
 
+ elseif (abs(ecc-1.) < tiny(0.)) then
     !
     !-- Setup a parabolic orbit
     !
- elseif (abs(ecc-1.) < tiny(0.)) then
     r0       = 10.*rtidal              ! A default starting distance from the black hole.
     period   = 2.*pi*sqrt(r0**3/mass1) !period not defined for parabolic orbit, so just need some number
     y0       = -2.*rp + r0
@@ -196,7 +204,6 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
 
  else
     call fatal('setup','please choose a valid eccentricity (0<ecc<=1)',var='ecc',val=ecc)
-
  endif
 
  lorentz = 1./sqrt(1.-dot_product(vxyzstar,vxyzstar))
@@ -204,33 +211,6 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
 
  tmax      = norbits*period
  dtmax     = period/dumpsperorbit
- select case (stardensprofile)
- case (2)
-    allocate(pres(ng_max), temp(ng_max), en(ng_max), rtab(ng_max), rhotab(ng_max))
-    call read_kepler_file(trim('star1@hign'),ng_max,npts,rtab,rhotab,pres,temp,en,mstar,composition,comp_label,columns_compo,ierr)
- case default
-    allocate(rtab(ntab),rhotab(ntab))
-    call rho_polytrope(gamma,polyk,mstar,rtab,rhotab,npts,set_polyk=.true.,Rstar=rstar)
- end select
- call set_sphere('cubic',id,master,0.,rstar,psep,hfact,npart,xyzh,xyz_origin=xyzstar,rhotab=rhotab(1:npts),rtab=rtab(1:npts))
-
- npartoftype(igas) = npart
- massoftype(igas)  = mstar/npart
- do i=1,npart
-    call set_particle_type(i,igas)
-    densi        = rhoh(xyzh(4,i),massoftype(igas))
-    select case (stardensprofile)
-    case (2)
-       ri        = sqrt(dot_product(xyzh(1:3,i)-xyzstar,xyzh(1:3,i)-xyzstar))
-       presi     = yinterp(pres(1:npts),rtab(1:npts),ri)
-       call calc_temp_and_ene(ieos,densi*unit_density,presi*unit_pressure,eni,tempi,ierr)
-       vxyzu(4,i) = eni / unit_ergg
-       eos_vars(itemp,i) = tempi
-    case default
-       vxyzu(4,i)   = polyk*densi**(gamma-1.) / (gamma-1.)
-    end select
-    vxyzu(1:3,i) = vxyzstar(1:3)
- enddo
 
  if (id==master) then
     print "(/,a)",       ' STAR SETUP:'
@@ -240,6 +220,8 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
     print "(a,1f10.3)"  ,' Polytropic gamma = ',gamma
     print "(a,3f10.3,/)",'       Pericentre = ',rp
  endif
+
+ call shift_star(npart,xyzh,vxyzu,x0=xyzstar,v0=vxyzstar)
 
  if (id==master) print "(/,a,i10,/)",' Number of particles setup = ',npart
 
@@ -263,48 +245,51 @@ end subroutine setpart
 !
 subroutine write_setupfile(filename)
  use infile_utils, only:write_inopt
+ use setstar,      only:write_options_star
  character(len=*), intent(in) :: filename
  integer, parameter :: iunit = 20
 
  print "(a)",' writing setup options file '//trim(filename)
  open(unit=iunit,file=filename,status='replace',form='formatted')
- write(iunit,"(a)") '# input file for binary setup routines'
+ write(iunit,"(a)") '# input file for tidal disruption setup'
+
+ call write_options_star(star,iunit)
+
+ write(iunit,"(/,a)") '# options for black hole and orbit'
+
  call write_inopt(mhole,          'mhole',          'mass of black hole (solar mass)',             iunit)
- call write_inopt(mstar,          'mstar',          'mass of star       (solar mass)',             iunit)
- call write_inopt(rstar,          'rstar',          'radius of star     (solar radii)',            iunit)
- call write_inopt(stardensprofile,'stardensprofile','star density profile (1=polytrope, 2=kepler)',iunit)
  call write_inopt(beta,           'beta',           'penetration factor',                          iunit)
  call write_inopt(ecc,            'ecc',            'eccentricity (1 for parabolic)',              iunit)
  call write_inopt(norbits,        'norbits',        'number of orbits',                            iunit)
  call write_inopt(dumpsperorbit,  'dumpsperorbit',  'number of dumps per orbit',                   iunit)
- call write_inopt(nr,             'nr',             'particles per star radius (i.e. resolution)', iunit)
  call write_inopt(theta,          'theta',          'inclination of orbit (degrees)',              iunit)
  close(iunit)
 
 end subroutine write_setupfile
 
-subroutine read_setupfile(filename,ierr)
+subroutine read_setupfile(filename,ieos,polyk,ierr)
  use infile_utils, only:open_db_from_file,inopts,read_inopt,close_db
  use io,           only:error
- character(len=*), intent(in)  :: filename
- integer,          intent(out) :: ierr
+ use setstar,      only:read_options_star
+ character(len=*), intent(in)    :: filename
+ integer,          intent(inout) :: ieos
+ real,             intent(inout) :: polyk
+ integer,          intent(out)   :: ierr
  integer, parameter :: iunit = 21
- integer :: nerr
+ integer :: nerr,need_iso
  type(inopts), allocatable :: db(:)
 
  print "(a)",'reading setup options from '//trim(filename)
  nerr = 0
  ierr = 0
  call open_db_from_file(db,filename,iunit,ierr)
+ call read_options_star(star,need_iso,ieos,polyk,db,nerr)
+
  call read_inopt(mhole,          'mhole',          db,min=0.,errcount=nerr)
- call read_inopt(mstar,          'mstar',          db,min=0.,errcount=nerr)
- call read_inopt(rstar,          'rstar',          db,min=0.,errcount=nerr)
- call read_inopt(stardensprofile,'stardensprofile',db,min=1,max=2,errcount=nerr)
  call read_inopt(beta,           'beta',           db,min=0.,errcount=nerr)
  call read_inopt(ecc,            'ecc',            db,min=0.,max=1.,errcount=nerr)
  call read_inopt(norbits,        'norbits',        db,min=0.,errcount=nerr)
  call read_inopt(dumpsperorbit,  'dumpsperorbit',  db,min=0 ,errcount=nerr)
- call read_inopt(nr,             'nr',             db,min=0 ,errcount=nerr)
  call read_inopt(theta,          'theta',          db,       errcount=nerr)
  call close_db(db)
  if (nerr > 0) then

--- a/src/tests/test_gr.F90
+++ b/src/tests/test_gr.F90
@@ -53,11 +53,7 @@ end subroutine test_gr
 !-----------------------------------------------------------------------
 subroutine test_precession(ntests,npass)
  use metric_tools, only:imetric,imet_kerr,imet_schwarzschild
-#ifdef KERR
  use metric,       only:a
-#else
- real :: a
-#endif
  integer, intent(inout) :: ntests,npass
  integer :: nerr(6),norbits,nstepsperorbit
  real    :: dt,period,x0,vy0,tmax,angtol,postol
@@ -103,11 +99,7 @@ end subroutine test_precession
 subroutine test_inccirc(ntests,npass)
  use physcon,      only:pi
  use metric_tools, only:imetric,imet_kerr
-#ifdef KERR
  use metric,       only:a
-#else
- real :: a
-#endif
  integer, intent(inout) :: ntests,npass
  integer :: nerr(6),norbits,nstepsperorbit
  real    :: dt,period,tmax

--- a/src/utils/analysis_kepler.f90
+++ b/src/utils/analysis_kepler.f90
@@ -150,8 +150,8 @@ subroutine phantom_to_kepler_arrays(xyzh,vxyzu,pmass,npart,time,density,rad_grid
  distance_from_bh = sqrt(dot_product(xpos(:),xpos(:)))
  vel_from_bh = sqrt(dot_product(vpos(:),vpos(:)))
  print*,"******************"
-print*,distance_from_bh*udist,"distance from bh",vel_from_bh*unit_velocity,"velfrom bh"
-print*,"*******************"
+ print*,distance_from_bh*udist,"distance from bh",vel_from_bh*unit_velocity,"velfrom bh"
+ print*,"*******************"
  ! sorting particles
  call set_r2func_origin(xpos(1),xpos(2),xpos(3))
  call indexxfunc(npart,r2func_origin,xyzh,iorder)
@@ -276,9 +276,9 @@ print*,"*******************"
     L_i(:)   = Li(:)*pmass
     L_sum(:) = L_sum(:) + L_i(:)
     if (pos_mag == 0.) then
-          omega_particle = 0.
+       omega_particle = 0.
     else
-          omega_particle = sqrt(dot_product(Li(:)/(pos_mag**2),Li(:)/(pos_mag**2)))
+       omega_particle = sqrt(dot_product(Li(:)/(pos_mag**2),Li(:)/(pos_mag**2)))
     endif
 
     write(1,*)pos_mag,omega_particle
@@ -352,7 +352,7 @@ print*,"*******************"
  print*,mass_enclosed(ibin),"/mass_enclosed(ibin)",mass_enclosed(ibin)*umass
  vel_at_infinity = sqrt(2.*total_star)
  if (isnan(vel_at_infinity)) then
-         vel_at_infinity = 0.
+    vel_at_infinity = 0.
  endif
  print*,vel_at_infinity*1.e-5,"vel at infinity in Km/s"
  print*,umass,"umass",udist,"udist",unit_density,"unit_density",unit_velocity,"unit_velocity",utime,"utime"
@@ -424,8 +424,8 @@ subroutine particles_bound_to_star(xpos,vpos,xyzh,vxyzu,pmass,npart,iorder,energ
  count_bound_both = 0
 
  write(output,"(a8,i5.5)") 'compfull',numfile
-   open(5,file=output)
-   write(5,"(18(a22,1x))") &
+ open(5,file=output)
+ write(5,"(18(a22,1x))") &
           comp_label
 
  allocate(index_particle_star(dummy_size),index_particle_bh(dummy_size))
@@ -465,17 +465,17 @@ subroutine particles_bound_to_star(xpos,vpos,xyzh,vxyzu,pmass,npart,iorder,energ
     endif
 
     if (bound_to_bh == .True. .and. bound_to_star == .false.) then
-        count_val = count_val + 1
-        index_particle_bh(index_val_bh) = j
-        particle_bound_bh = particle_bound_bh +1
-        index_val_bh = index_val_bh+1
+       count_val = count_val + 1
+       index_particle_bh(index_val_bh) = j
+       particle_bound_bh = particle_bound_bh +1
+       index_val_bh = index_val_bh+1
     endif
     if (bound_to_bh == .True. .and. bound_to_star == .True.) then
-        count_bound_both = count_bound_both + 1
+       count_bound_both = count_bound_both + 1
     endif
 
     if (bound_to_bh == .false. .and. bound_to_star == .false.) then
-        count_val_unbound = count_val_unbound + 1
+       count_val_unbound = count_val_unbound + 1
     endif
     bound_to_bh = .false.
     bound_to_star = .false.
@@ -547,7 +547,7 @@ subroutine no_per_bin(j,count_particles,double_the_no,number_per_bin,big_bins_no
     if (pos_mag_next - rad_inner > 0.1) then
        number_per_bin=count_particles
        if (number_per_bin < 10) then
-           number_per_bin = 10
+          number_per_bin = 10
        endif
     endif
  endif
@@ -814,20 +814,20 @@ subroutine write_dump_info(fileno,density,temperature,mass,xpos,rad,distance,pos
 
  ! open the file for appending or creating
  if (file_exists) then
-      open(unit=file_id, file=filename, status='old', position="append", action="write", iostat=status)
-      if (status /= 0) then
-           write(*,*) 'Error opening file: ', filename
-           stop
-       endif
+    open(unit=file_id, file=filename, status='old', position="append", action="write", iostat=status)
+    if (status /= 0) then
+       write(*,*) 'Error opening file: ', filename
+       stop
+    endif
 
-else
-      open(unit=file_id, file=filename, status='new', action='write', iostat=status)
-      if (status /= 0) then
-         write(*,*) 'Error creating file: ', filename
-         stop
-      endif
-      ! Write headers to file
-      write(file_id,'(16(a22,1x))') &
+ else
+    open(unit=file_id, file=filename, status='new', action='write', iostat=status)
+    if (status /= 0) then
+       write(*,*) 'Error creating file: ', filename
+       stop
+    endif
+    ! Write headers to file
+    write(file_id,'(16(a22,1x))') &
               "FileNo", &
               "Density",&
               "Temperature",&
@@ -844,10 +844,10 @@ else
                "specPE",&
                "time",&
                "Escape_in"
-endif
-write(file_id,'(i5,1x,15(e18.10,1x))')fileno,density*unit_density,temperature,mass*umass,xpos(1)*udist,xpos(2)*udist,xpos(3)*udist,rad*udist,distance*udist,pos_mag_star*udist,&
+ endif
+ write(file_id,'(i5,1x,15(e18.10,1x))')fileno,density*unit_density,temperature,mass*umass,xpos(1)*udist,xpos(2)*udist,xpos(3)*udist,rad*udist,distance*udist,pos_mag_star*udist,&
                       vel_mag_star*unit_velocity,tot_energy,kinetic_energy,potential_energy,time*utime,vel_at_infinity*1e-5
-close(file_id)
+ close(file_id)
 
 end subroutine write_dump_info
 
@@ -859,42 +859,42 @@ end subroutine write_dump_info
  !+
  !----------------------------------------------------------------
 subroutine write_compo_wrt_bh(xyzh,vxyzu,xpos,vpos,pmass,npart,iorder,array_bh_j,interpolate_comp,columns_compo,comp_label,energy_verified_no,last_particle_with_neg_e)
-   use units , only: udist
+ use units , only: udist
 
-   real,intent(in)    :: xyzh(:,:),vxyzu(:,:)
-   real,intent(in)    :: xpos(3),vpos(3),pmass
-   integer,intent(in) :: npart,iorder(:),columns_compo
-   integer,allocatable,intent(in) :: array_bh_j(:)
-   integer,intent(in) :: energy_verified_no,last_particle_with_neg_e
-   character(len=20),intent(in) :: comp_label(:)
-   real,intent(in)    :: interpolate_comp(:,:)
+ real,intent(in)    :: xyzh(:,:),vxyzu(:,:)
+ real,intent(in)    :: xpos(3),vpos(3),pmass
+ integer,intent(in) :: npart,iorder(:),columns_compo
+ integer,allocatable,intent(in) :: array_bh_j(:)
+ integer,intent(in) :: energy_verified_no,last_particle_with_neg_e
+ character(len=20),intent(in) :: comp_label(:)
+ real,intent(in)    :: interpolate_comp(:,:)
 
-   integer,allocatable :: array_particle_j(:)
-   real,allocatable    :: composition_i(:)
-   integer             :: i,j
-   real                :: pos_to_bh
-   character(len=120)  :: output
+ integer,allocatable :: array_particle_j(:)
+ real,allocatable    :: composition_i(:)
+ integer             :: i,j
+ real                :: pos_to_bh
+ character(len=120)  :: output
 
-   !call particles_bound_to_star(xpos,vpos,xyzh,vxyzu,pmass,npart,iorder,energy_verified_no,last_particle_with_neg_e,array_particle_j,array_bh_j)
-   !call composition_array(interpolate_comp,columns_compo,comp_label)
-   write(output,"(a8)") 'compo_bh'
-   open(4,file=output)
-   write(4,"(19(a22,1x))") &
+ !call particles_bound_to_star(xpos,vpos,xyzh,vxyzu,pmass,npart,iorder,energy_verified_no,last_particle_with_neg_e,array_particle_j,array_bh_j)
+ !call composition_array(interpolate_comp,columns_compo,comp_label)
+ write(output,"(a8)") 'compo_bh'
+ open(4,file=output)
+ write(4,"(19(a22,1x))") &
           "posToBH",      &
           comp_label
 
-   allocate(composition_i(columns_compo))
-   do j = 1, size(array_bh_j)
-      i  = iorder(j) !Access the rank of each particle in radius.
-      pos_to_bh = sqrt(dot_product(xyzh(1:3,i),xyzh(1:3,i)))
-      if (columns_compo /= 0) then
+ allocate(composition_i(columns_compo))
+ do j = 1, size(array_bh_j)
+    i  = iorder(j) !Access the rank of each particle in radius.
+    pos_to_bh = sqrt(dot_product(xyzh(1:3,i),xyzh(1:3,i)))
+    if (columns_compo /= 0) then
        composition_i(:) = interpolate_comp(:,i)
-      endif
-      write(4,'(19(e18.10,1x))') &
+    endif
+    write(4,'(19(e18.10,1x))') &
               pos_to_bh*udist,&
               composition_i(:)
-   enddo
-   close(4)
+ enddo
+ close(4)
 
 end subroutine write_compo_wrt_bh
 

--- a/src/utils/analysis_kepler.f90
+++ b/src/utils/analysis_kepler.f90
@@ -204,29 +204,29 @@ print*,"*******************"
  ! Now we calculate the different quantities of the particles and bin them
  do j=1,energy_verified_no
     i      = iorder(array_particle_j(j))
-    if (j /= energy_verified_no) then 
+    if (j /= energy_verified_no) then
        i_next = iorder(array_particle_j(j+1))
-    else 
+    else
        i_next = iorder(array_particle_j(j))
     endif
 
     call particle_pos_and_vel_wrt_centre(xpos,vpos,xyzh,vxyzu,pos,vel,i,pos_mag,vel_mag)
-    
+
     ! calculating centre of mass position and velocity wrt black hole
     pos_com(:) = pos_com(:) + xyzh(1:3,i)*pmass
     vel_com(:) = vel_com(:) + vxyzu(1:3,i)*pmass
-   
+
     if (j  /=  energy_verified_no) then
        call particle_pos_and_vel_wrt_centre(xpos,vpos,xyzh,vxyzu,pos_next,vel_next,i_next,pos_mag_next,vel_mag_next)
     endif
-   
+
     count_particles = count_particles + 1
     if (count_particles == 1) then
        rad_inner = pos_mag
        !print*,j,"j","first",rad_inner,"rad_inner",count_particles
     endif
-    
-    !print*,pos_mag_next-pos_mag,"difference in pos mag of next and current particle",i,"i",i_next,"i_next",j,"j",j+1,"jnext"    
+
+    !print*,pos_mag_next-pos_mag,"difference in pos mag of next and current particle",i,"i",i_next,"i_next",j,"j",j+1,"jnext"
     call  no_per_bin(j,count_particles,double_the_no,number_per_bin,big_bins_no,energy_verified_no,pos_mag_next,rad_inner)
     if (number_per_bin == count_particles) then
        rad_outer = pos_mag
@@ -236,7 +236,7 @@ print*,"*******************"
        composition_i(:) = interpolate_comp(:,i)
     endif
     composition_sum(:) = composition_sum(:) + composition_i(:)
-    
+
     write(4,'(i9,1x,i5,1x,23(e18.10,1x))') &
                i, &
                ibin, &
@@ -275,17 +275,17 @@ print*,"*******************"
     call cross_product3D(pos(:),vel(:),Li(:))
     L_i(:)   = Li(:)*pmass
     L_sum(:) = L_sum(:) + L_i(:)
-    if (pos_mag == 0.) then 
+    if (pos_mag == 0.) then
           omega_particle = 0.
-    else 
+    else
           omega_particle = sqrt(dot_product(Li(:)/(pos_mag**2),Li(:)/(pos_mag**2)))
     endif
-    
+
     write(1,*)pos_mag,omega_particle
     ! Moment of inertia
     call moment_of_inertia(pos,pos_mag,pmass,i_matrix)
     I_sum(:,:) = I_sum(:,:) + i_matrix(:,:)
-    
+
     if (count_particles==number_per_bin .or. j==energy_verified_no) then
        tot_binned_particles = tot_binned_particles+count_particles
        call radius_of_remnant(array_particle_j,count_particles,number_per_bin,j,energy_verified_no,xpos,vpos,xyzh,vxyzu,iorder,pos_mag,radius_star)
@@ -331,7 +331,7 @@ print*,"*******************"
  print*,mass_enclosed(ibin)*umass,"enclodsed mass",pos_com,"pos com"
  print*,rad_grid(ibin),"Radius MAX"
  pos_com(:) = pos_com(:)/mass_enclosed(ibin)
- print*,pos_com,"pos of com" 
+ print*,pos_com,"pos of com"
  vel_com(:) = vel_com(:)/mass_enclosed(ibin)
  print*,pos_com,"pos_com",xpos,"xpos",vel_com,"vel com",vpos,"vpos"
  print*,ibin,"ibin",tot_binned_particles
@@ -351,12 +351,12 @@ print*,"*******************"
  print*,total_star,"total_star",u_star,"ustar",ke_star,"ke_star"
  print*,mass_enclosed(ibin),"/mass_enclosed(ibin)",mass_enclosed(ibin)*umass
  vel_at_infinity = sqrt(2.*total_star)
- if (isnan(vel_at_infinity)) then 
+ if (isnan(vel_at_infinity)) then
          vel_at_infinity = 0.
  endif
  print*,vel_at_infinity*1.e-5,"vel at infinity in Km/s"
  print*,umass,"umass",udist,"udist",unit_density,"unit_density",unit_velocity,"unit_velocity",utime,"utime"
- ! write information to the dump_info file 
+ ! write information to the dump_info file
  call write_compo_wrt_bh(xyzh,vxyzu,xpos,vpos,pmass,npart,iorder,array_bh_j,interpolate_comp,columns_compo,comp_label,energy_verified_no,last_particle_with_neg_e)
  call write_dump_info(numfile,density(1),temperature(1),mass_enclosed(ibin),xpos,rad_grid(ibin),distance_from_bh,&
                          pos_mag_star,vel_mag_star,total_star,ke_star,u_star,time,vel_at_infinity)
@@ -403,7 +403,7 @@ subroutine particles_bound_to_star(xpos,vpos,xyzh,vxyzu,pmass,npart,iorder,energ
  integer,intent(in)               :: columns_compo
  integer,intent(out)              :: energy_verified_no,last_particle_with_neg_e
  integer,allocatable,intent(out)  :: array_particle_j(:),array_bh_j(:)
- 
+
  character(len=120)  :: output
  integer,allocatable :: index_particle_star(:),index_particle_bh(:)
  integer :: i,j,dummy_size,index_val,particle_bound_bh,index_val_bh,count_val,count_val_unbound,count_bound_both
@@ -411,7 +411,7 @@ subroutine particles_bound_to_star(xpos,vpos,xyzh,vxyzu,pmass,npart,iorder,energ
  real :: potential_i, kinetic_i,energy_i,pos_mag,vel_mag
  logical :: bound_to_bh,bound_to_star
  real,allocatable    :: composition_i(:)
- 
+
  bound_to_bh = .false.
  bound_to_star = .false.
  particle_bound_bh = 0
@@ -429,7 +429,7 @@ subroutine particles_bound_to_star(xpos,vpos,xyzh,vxyzu,pmass,npart,iorder,energ
           comp_label
 
  allocate(index_particle_star(dummy_size),index_particle_bh(dummy_size))
- allocate(composition_i(columns_compo)) 
+ allocate(composition_i(columns_compo))
  do j = 1, npart
 
     i  = iorder(j) !Access the rank of each particle in radius.
@@ -454,7 +454,7 @@ subroutine particles_bound_to_star(xpos,vpos,xyzh,vxyzu,pmass,npart,iorder,energ
     kinetic_i     = 0.5*pmass*vel_mag**2
 
     energy_i = potential_i + kinetic_i + vxyzu(4,i)*pmass
-    
+
     !if energy is less than 0, we have bound system. We can accept these particles.
     if (energy_i < 0. .and. kinetic_i < 0.5*abs(potential_i)) then
        bound_to_star = .True.
@@ -464,19 +464,19 @@ subroutine particles_bound_to_star(xpos,vpos,xyzh,vxyzu,pmass,npart,iorder,energ
        index_val = index_val+1
     endif
 
-    if (bound_to_bh == .True. .and. bound_to_star == .false.) then 
+    if (bound_to_bh == .True. .and. bound_to_star == .false.) then
         count_val = count_val + 1
         index_particle_bh(index_val_bh) = j
         particle_bound_bh = particle_bound_bh +1
         index_val_bh = index_val_bh+1
     endif
-    if (bound_to_bh == .True. .and. bound_to_star == .True.) then 
+    if (bound_to_bh == .True. .and. bound_to_star == .True.) then
         count_bound_both = count_bound_both + 1
-    endif 
+    endif
 
     if (bound_to_bh == .false. .and. bound_to_star == .false.) then
         count_val_unbound = count_val_unbound + 1
-    endif 
+    endif
     bound_to_bh = .false.
     bound_to_star = .false.
  enddo
@@ -496,7 +496,7 @@ subroutine particles_bound_to_star(xpos,vpos,xyzh,vxyzu,pmass,npart,iorder,energ
  allocate(array_bh_j(particle_bound_bh))
  do i=1,particle_bound_bh
     array_bh_j(i) = index_particle_bh(i)
- enddo 
+ enddo
 
  print*,"--------"
  print*,particle_bound_bh,"particle bound to the bh",size(array_bh_j),"array bh j"
@@ -543,13 +543,13 @@ subroutine no_per_bin(j,count_particles,double_the_no,number_per_bin,big_bins_no
        number_per_bin = big_bins_no
        double_the_no = .False.
     endif
- else 
+ else
     if (pos_mag_next - rad_inner > 0.1) then
        number_per_bin=count_particles
-       if (number_per_bin < 10) then 
+       if (number_per_bin < 10) then
            number_per_bin = 10
        endif
-    endif 
+    endif
  endif
  if (j==energy_verified_no) then
     number_per_bin = count_particles
@@ -806,12 +806,12 @@ subroutine write_dump_info(fileno,density,temperature,mass,xpos,rad,distance,pos
  character(len=10) :: filename
  logical :: file_exists
 
- ! set a file name 
+ ! set a file name
  filename = 'dump_info'
- 
+
  ! check if the file exists
  inquire(file=filename, exist=file_exists)
- 
+
  ! open the file for appending or creating
  if (file_exists) then
       open(unit=file_id, file=filename, status='old', position="append", action="write", iostat=status)
@@ -819,17 +819,17 @@ subroutine write_dump_info(fileno,density,temperature,mass,xpos,rad,distance,pos
            write(*,*) 'Error opening file: ', filename
            stop
        endif
-     
+
 else
       open(unit=file_id, file=filename, status='new', action='write', iostat=status)
       if (status /= 0) then
          write(*,*) 'Error creating file: ', filename
          stop
       endif
-      ! Write headers to file 
+      ! Write headers to file
       write(file_id,'(16(a22,1x))') &
               "FileNo", &
-              "Density",& 
+              "Density",&
               "Temperature",&
               "Mass",&
               "x",&
@@ -855,26 +855,26 @@ end subroutine write_dump_info
  !----------------------------------------------------------------
  !+
  !  This subroutine can write a file with composition of particles wrt black hole
- !  
+ !
  !+
  !----------------------------------------------------------------
 subroutine write_compo_wrt_bh(xyzh,vxyzu,xpos,vpos,pmass,npart,iorder,array_bh_j,interpolate_comp,columns_compo,comp_label,energy_verified_no,last_particle_with_neg_e)
    use units , only: udist
-   
+
    real,intent(in)    :: xyzh(:,:),vxyzu(:,:)
    real,intent(in)    :: xpos(3),vpos(3),pmass
-   integer,intent(in) :: npart,iorder(:),columns_compo  
-   integer,allocatable,intent(in) :: array_bh_j(:) 
+   integer,intent(in) :: npart,iorder(:),columns_compo
+   integer,allocatable,intent(in) :: array_bh_j(:)
    integer,intent(in) :: energy_verified_no,last_particle_with_neg_e
    character(len=20),intent(in) :: comp_label(:)
-   real,intent(in)    :: interpolate_comp(:,:) 
-   
-   integer,allocatable :: array_particle_j(:) 
+   real,intent(in)    :: interpolate_comp(:,:)
+
+   integer,allocatable :: array_particle_j(:)
    real,allocatable    :: composition_i(:)
    integer             :: i,j
    real                :: pos_to_bh
    character(len=120)  :: output
-      
+
    !call particles_bound_to_star(xpos,vpos,xyzh,vxyzu,pmass,npart,iorder,energy_verified_no,last_particle_with_neg_e,array_particle_j,array_bh_j)
    !call composition_array(interpolate_comp,columns_compo,comp_label)
    write(output,"(a8)") 'compo_bh'
@@ -891,8 +891,8 @@ subroutine write_compo_wrt_bh(xyzh,vxyzu,xpos,vpos,pmass,npart,iorder,array_bh_j
        composition_i(:) = interpolate_comp(:,i)
       endif
       write(4,'(19(e18.10,1x))') &
-              pos_to_bh*udist,& 
-              composition_i(:)      
+              pos_to_bh*udist,&
+              composition_i(:)
    enddo
    close(4)
 

--- a/src/utils/moddump_tidal.f90
+++ b/src/utils/moddump_tidal.f90
@@ -106,9 +106,9 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  m0 = Mh1
  rt = (m0/ms)**(1./3.) * rs
 
- ! setting a default r0 value 
+ ! setting a default r0 value
  r0 = 10*rt
- 
+
  ! default parameters for binary (overwritten from .tdeparams file)
  use_binary = .false.
  use_sink = .false.
@@ -125,7 +125,7 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  print*,"--------------------------------------------"
  print*,use_binary,"use_binary"
  print*,"--------------------------------------------"
- 
+
  m0 = Mh1
  if (use_binary) then
     select case(iorigin)
@@ -137,7 +137,7 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
        m0 = Mh1 + Mh2
     end select
  endif
- 
+
  rt = (m0/ms)**(1./3.) * rs
  rp = rt/beta
  theta=theta*pi/180.0
@@ -290,7 +290,7 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
     write(*,'(a)') "Use Binary BH = True"
     write(*,'(a,Es12.5,a)')'Eccentricity of the binary black hole system = ', ecc_binary
     write(*,'(a,Es12.5,a)') 'Separation betweent the two black holes = ', semimajoraxis_binary
- elseif (use_sink .and. .not.gr) then 
+ elseif (use_sink .and. .not.gr) then
     write(*,'(a)') "Use Sink particle as BH = True"
  else
     write(*,'(a)') "Use Binary BH = False"

--- a/src/utils/moddump_tidal.f90
+++ b/src/utils/moddump_tidal.f90
@@ -201,7 +201,7 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
                     accradius1,accradius2, &
                     xyzmh_ptmass,vxyz_ptmass,nptmass,ierr)
  elseif (use_sink) then
-   ! single black hole in Newtonian gravity using a sink particle
+    ! single black hole in Newtonian gravity using a sink particle
     nptmass = nptmass + 1
     xyzmh_ptmass(:,nptmass) = 0.
     xyzmh_ptmass(4,nptmass) = m0

--- a/src/utils/utils_orbits.f90
+++ b/src/utils/utils_orbits.f90
@@ -14,9 +14,8 @@ module orbits_data
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: physcon, units, vectorutils
+! :Dependencies: physcon, vectorutils
 !
-! Accepts values in cgs units 
  implicit none
 
  public :: escape, eccentricity_vector, eccentricity_star

--- a/src/utils/utils_orbits.f90
+++ b/src/utils/utils_orbits.f90
@@ -61,7 +61,7 @@ end function escape
  !----------------------------------------------------------------
 function hvector(pos_vec,vel_vec)
  use vectorutils,     only : cross_product3D
- 
+
  real,intent(in) :: pos_vec(3),vel_vec(3)
  real,dimension(3) :: hvector
 
@@ -100,9 +100,9 @@ function  eccentricity_vector(mass1,mass2,pos_vec,vel_vec)
  real               :: pos_vec_mag
 
  vcrossh_vec = vcrossh(pos_vec,vel_vec)
- pos_vec_mag = sqrt(dot_product(pos_vec,pos_vec)) 
+ pos_vec_mag = sqrt(dot_product(pos_vec,pos_vec))
 
- ! eccentricity vector = (rdot cross h )/(G(m1+m2)) - rhat 
+ ! eccentricity vector = (rdot cross h )/(G(m1+m2)) - rhat
  eccentricity_vector(:) = (vcrossh_vec(:)/(gg*(mass1+mass2))) - (pos_vec/pos_vec_mag)
 
 end function eccentricity_vector
@@ -113,12 +113,12 @@ end function eccentricity_vector
  !+
  !----------------------------------------------------------------
 real function eccentricity_star(mass1,mass2,pos_vec,vel_vec)
- 
+
  real, intent(in)  :: pos_vec(3),vel_vec(3)
  real, intent(in)  :: mass1,mass2
  real, dimension(3) :: ecc_vector
  ecc_vector = eccentricity_vector(mass1,mass2,pos_vec,vel_vec)
- 
+
  eccentricity_star = sqrt(dot_product(ecc_vector,ecc_vector))
 
 end function eccentricity_star
@@ -158,10 +158,10 @@ real function period_star(mass1,mass2,pos_vec,vel_vec)
  real, intent(in) :: mass1,mass2
  real, intent(in) :: pos_vec(3),vel_vec(3)
  real :: semimajor
- 
+
  semimajor = semimajor_axis(mass1,mass2,pos_vec,vel_vec)
 
- ! using Kepler's 3rd law to calculated period 
+ ! using Kepler's 3rd law to calculated period
  period_star = sqrt((4*pi**2*abs(semimajor)**3)/(gg*(mass1+mass2)))
 
 end function period_star
@@ -195,16 +195,16 @@ subroutine orbital_angles(mass1,mass2,pos_vec,vel_vec,&
  j_vector = (/0,1,0/)
  k_vector = (/0,0,1/)
 
- ! n vector = k cross h 
+ ! n vector = k cross h
  call cross_product3D(k_vector,h_vector,n_vector)
  n_vector_mag = sqrt(dot_product(n_vector,n_vector))
  n_hat = n_vector/n_vector_mag
 
- ! calculate inclination angle 
+ ! calculate inclination angle
  inclination_angle = acos(dot_product(k_vector,h_hat))
  argument_of_periestron = acos(dot_product(ecc_hat,n_hat))
  longitude_ascending_node = acos(dot_product(i_vector,n_hat))
- 
+
 
 end subroutine orbital_angles
 


### PR DESCRIPTION
Type of PR: 
improved setup procedure

Description:
Cleanup of the setup procedure for tidal disruption events in General Relativity. Previously this required compiling with SETUP=grstar and then moddump using moddump_tidal.f90

Now, setup_grtde calls the new general set_star procedure to setup and relax a star. To avoid the need to switch metrics we simply set M=0 in the Kerr or Schwarzschild metric during relaxation, effectively giving a Minkowski metric during the stellar relaxation  procedure

I also corrected an issue where we had set ireconav = 1 by default in the .in file for GR simulations, which is problematic if anything gets too close to the black hole. Hence the default setting is now ireconav=-1. This fixes #333

Testing:
1000 particle GR tidal disruption event with polytrope works  out-of-the-box

Did you run the bots? yes

Did you update relevant documentation in the docs directory? not yet