### PR TITLE
Correct a bug preventing the initialization of dust properties in 1 fluid with dustgrowth in moddump_dustadd

### DIFF
--- a/src/utils/moddump_dustadd.f90
+++ b/src/utils/moddump_dustadd.f90
@@ -154,10 +154,10 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
           enddo
 
        enddo
+    endif
 
-       if (use_dustgrowth) then
-          call set_dustprop(npart)
-       endif
+    if (use_dustgrowth) then
+       call set_dustprop(npart)
     endif
  endif
 


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
Correct a bug preventing the initialization of dust properties in 1 fluid with dustgrowth in moddump_dustadd.
The initialization of the dust properties couldn't be done because the routine was in the loop for 2 fluids only.

Testing:
Add dust to a gas simulation in one fluid with moddump_dustadd.

Did you run the bots? no

Did you update relevant documentation in the docs directory? no