### PR TITLE
(eos) bug fixed in generalised Farris eos 13

### DIFF
--- a/src/main/eos.F90
+++ b/src/main/eos.F90
@@ -348,7 +348,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,tempi,eni,gam
     mass = 0
 
     do i=1,nptmass
-       mass_r = r1+xyzmh_ptmass(4,i)/sqrt((xi-xyzmh_ptmass(1,i))**2 + (yi-xyzmh_ptmass(2,i))**2 + (zi-xyzmh_ptmass(3,i))**2)
+       mass_r = mass_r+xyzmh_ptmass(4,i)/sqrt((xi-xyzmh_ptmass(1,i))**2 + (yi-xyzmh_ptmass(2,i))**2 + (zi-xyzmh_ptmass(3,i))**2)
        mass = mass + xyzmh_ptmass(4,i)
     enddo
     ponrhoi=polyk*(mass_r)**(2*qfacdisc)/mass**(2*qfacdisc)


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
The Farris generalised equation was using a radius instead of a mass in the summation

Testing:
None, obvious bug.

Did you run the bots? no

Did you update relevant documentation in the docs directory? no