### PR TITLE
Optimise implicit radiation solving

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -538,7 +538,7 @@ SOURCES= physcon.f90 ${CONFIG} ${SRCKERNEL} io.F90 units.f90 \
          utils_filenames.f90 utils_summary.F90 ${SRCCHEM} ${SRCDUST} \
          mpi_memory.f90 mpi_derivs.F90 mpi_tree.F90 kdtree.F90 linklist_kdtree.F90 utils_healpix.f90 utils_raytracer.f90 \
          partinject.F90 utils_inject.f90 dust_formation.f90 ptmass_radiation.f90 ptmass_heating.f90 \
-         utils_deriv.f90 radiation_implicit.f90 ${SRCTURB} \
+         utils_deriv.f90 utils_implicit.f90 radiation_implicit.f90 ${SRCTURB} \
          ${SRCINJECT_DEPS} wind_equations.f90 wind.F90 ${SRCINJECT} \
          ${SRCKROME} memory.F90 ${SRCREADWRITE_DUMPS}  \
          quitdump.f90 ptmass.F90 \

--- a/src/main/radiation_implicit.f90
+++ b/src/main/radiation_implicit.f90
@@ -820,11 +820,11 @@ subroutine update_gas_radiation_energy(ivar,vari,npart,ncompactlocal,&
           !     (<1 K), then we abandon the gas-dust coupling term.
           !
           call set_heating_cooling_low_rhoT(i,EU0(1,i),EU0(2,i),origEU(1,i),origEU(2,i),&
-                                            EU0(3,i),dti,diffusion_denominator,&
-                                            pres_numerator,radpresdenom,rhoi,xnH2,heatingISRi,e_planetesimali,&
-                                            metallicity,gas_temp,ieqtype,betaval,betaval_d,gammaval,&
-                                            chival,tfour,dust_tempi,gas_dust_val,dustgammaval,gas_dust_cooling,&
-                                            cosmic_ray,cooling_line,photoelectric,h2form,dust_heating,dust_term,skip_quartic,U1i,ierr)
+                                            EU0(3,i),dti,diffusion_denominator,pres_numerator,radpresdenom,&
+                                            rhoi,xnH2,heatingISRi,e_planetesimali,metallicity,gas_temp,ieqtype,&
+                                            betaval,betaval_d,gammaval,chival,tfour,dust_tempi,gas_dust_val,&
+                                            dustgammaval,gas_dust_cooling,cosmic_ray,cooling_line,photoelectric,&
+                                            h2form,dust_heating,dust_term,skip_quartic,U1i,ierr)
           if (ierr > 0) then
              !$omp critical (moresweepset)
              moresweep = .true.

--- a/src/main/radiation_implicit.f90
+++ b/src/main/radiation_implicit.f90
@@ -550,15 +550,14 @@ subroutine compute_flux(ivar,ijvar,ncompact,npart,icompactmax,varij2,vari,EU0,va
  logical, intent(in) :: mask(npart)
  real, intent(inout) :: radprop(:,:),EU0(6,npart)
  real, intent(out)   :: varinew(3,npart)  ! we use this parallel loop to set varinew to zero
- integer             :: i,j,k,n,icompact,ierr
+ integer             :: i,j,k,n,icompact
  real                :: rhoi,rhoj,pmjdWrunix,pmjdWruniy,pmjdWruniz,dedx(3),dradenij,rhoiEU0
  real                :: gradE1i,opacity,radRi,EU01i
 
  !$omp do schedule(runtime)&
  !$omp private(i,j,k,n,dedx,rhoi,rhoj,icompact)&
  !$omp private(pmjdWrunix,pmjdWruniy,pmjdWruniz,dradenij)&
- !$omp private(gradE1i,opacity,radRi,EU01i)&
- !$omp reduction(max:ierr)
+ !$omp private(gradE1i,opacity,radRi,EU01i)
 
  do n = 1,ncompact
     i = ivar(3,n)
@@ -597,10 +596,10 @@ subroutine compute_flux(ivar,ijvar,ncompact,npart,icompactmax,varij2,vari,EU0,va
        if (dustRT) then
           if (dust_temp(i) < Tdust_threshold) opacity = nucleation(idkappa,i)
        endif
-       if (opacity < 0.) then
-          ierr = max(ierr,ierr_negative_opacity)
-          call error(label,'Negative opacity',val=opacity)
-       endif
+      !  if (opacity < 0.) then
+      !     ierr = max(ierr,ierr_negative_opacity)
+      !     call error(label,'Negative opacity',val=opacity)
+      !  endif
 
        if (limit_radiation_flux) then
           radRi = get_rad_R(rhoi,EU01i,dedx,opacity)

--- a/src/main/utils_deriv.f90
+++ b/src/main/utils_deriv.f90
@@ -18,7 +18,7 @@ module derivutils
 !
  use timing, only: timers,itimer_dens,itimer_force,itimer_link,itimer_extf,itimer_balance,itimer_cons2prim,&
                    itimer_radiation,itimer_rad_save,itimer_rad_neighlist,itimer_rad_arrays,itimer_rad_its,&
-                   itimer_rad_flux,itimer_rad_lambda,itimer_rad_diff,itimer_rad_update,itimer_rad_store
+                   itimer_rad_flux,itimer_rad_diff,itimer_rad_update,itimer_rad_store
 
  implicit none
 
@@ -69,8 +69,6 @@ subroutine do_timing(label,tlast,tcpulast,start,lunit)
     itimer = itimer_rad_its
  case ('radflux')
     itimer = itimer_rad_flux
- case ('radlambda')
-    itimer = itimer_rad_lambda
  case ('raddiff')
     itimer = itimer_rad_diff
  case ('radupdate')

--- a/src/main/utils_implicit.f90
+++ b/src/main/utils_implicit.f90
@@ -1,0 +1,57 @@
+!--------------------------------------------------------------------------!
+! The Phantom Smoothed Particle Hydrodynamics code, by Daniel Price et al. !
+! Copyright (c) 2007-2023 The Authors (see AUTHORS)                        !
+! See LICENCE file for usage and distribution conditions                   !
+! http://phantomsph.github.io/                                             !
+!--------------------------------------------------------------------------!
+module implicit
+!
+! Utility routines for implicit radiative diffusion
+!   
+! :References:
+!
+! :Owner: Mike Lau
+!
+! :Runtime parameters: None
+!
+! :Dependencies:
+!
+ implicit none
+ integer              :: ncompact,ncompactlocal,icompactmax,nneigh_average
+ real,    allocatable :: vari(:,:),varij(:,:),varij2(:,:),varinew(:,:)
+ integer, allocatable :: ivar(:,:),ijvar(:)
+ logical, allocatable :: mask(:)
+ logical              :: done_allocation = .false.
+
+contains
+
+!---------------------------------------------------------
+!+
+!  allocate arrays for compacted neighbour lists
+!+
+!---------------------------------------------------------
+subroutine allocate_memory_implicit(npart,radkern,hfact,ierr)
+ use io,      only:fatal
+ use physcon, only:pi
+ integer, intent(in)  :: npart
+ real,    intent(in)  :: radkern,hfact
+ integer, intent(out) :: ierr
+
+ if (done_allocation) then
+    return
+ else
+    nneigh_average = int(4./3.*pi*(radkern*hfact)**3) + 1
+    icompactmax = int(1.2*10.*nneigh_average*npart)
+    allocate(ivar(3,npart),stat=ierr)
+    if (ierr/=0) call fatal('radiation_implicit','cannot allocate memory for ivar')
+    allocate(ijvar(icompactmax),stat=ierr)
+    if (ierr/=0) call fatal('radiation_implicit','cannot allocate memory for ijvar')
+    allocate(vari(2,npart),varij(2,icompactmax),varij2(4,icompactmax),varinew(3,npart),mask(npart),stat=ierr)
+    if (ierr/=0) call fatal('radiation_implicit','cannot allocate memory for vari, varij, varij2, varinew, mask')
+    done_allocation = .true.
+ endif
+
+end subroutine allocate_memory_implicit
+
+
+end module implicit

--- a/src/main/utils_timing.f90
+++ b/src/main/utils_timing.f90
@@ -56,15 +56,14 @@ module timing
                                  itimer_rad_arrays    = 15, &
                                  itimer_rad_its       = 16, &
                                  itimer_rad_flux      = 17, &
-                                 itimer_rad_lambda    = 18, &
-                                 itimer_rad_diff      = 19, &
-                                 itimer_rad_update    = 20, &
-                                 itimer_rad_store     = 21, &
-                                 itimer_cons2prim     = 22, &
-                                 itimer_extf          = 23, &
-                                 itimer_ev            = 24, &
-                                 itimer_io            = 25
- integer, public, parameter :: ntimers = 25 ! should be equal to the largest itimer index
+                                 itimer_rad_diff      = 18, &
+                                 itimer_rad_update    = 19, &
+                                 itimer_rad_store     = 20, &
+                                 itimer_cons2prim     = 21, &
+                                 itimer_extf          = 22, &
+                                 itimer_ev            = 23, &
+                                 itimer_io            = 24
+ integer, public, parameter :: ntimers = 24 ! should be equal to the largest itimer index
  type(timer), public :: timers(ntimers)
 
  private
@@ -97,7 +96,6 @@ subroutine setup_timers
  call init_timer(itimer_rad_arrays  , 'arrays',      itimer_radiation  )
  call init_timer(itimer_rad_its     , 'its',         itimer_radiation  )
  call init_timer(itimer_rad_flux    , 'flux',        itimer_rad_its    )
- call init_timer(itimer_rad_lambda  , 'lambda',      itimer_rad_its    )
  call init_timer(itimer_rad_diff    , 'diff',        itimer_rad_its    )
  call init_timer(itimer_rad_update  , 'update',      itimer_rad_its    )
  call init_timer(itimer_rad_store   , 'store',       itimer_radiation  )

--- a/src/tests/test_radiation.f90
+++ b/src/tests/test_radiation.f90
@@ -66,7 +66,7 @@ subroutine test_radiation(ntests,npass)
 
     if (.not.mpi) then
        implicit_radiation = .true.
-       tol_rad = 1.e-5
+       tol_rad = 1.e-6
        call test_radiation_diffusion(ntests,npass)
     endif
  endif

--- a/src/tests/test_radiation.f90
+++ b/src/tests/test_radiation.f90
@@ -218,7 +218,7 @@ end subroutine test_exchange_terms
 !+
 !---------------------------------------------------------
 subroutine test_implicit_matches_explicit(ntests,npass)
- use part,     only:dvdx,npart,xyzh,vxyzu,dvdx_label,rad,radprop,drad,&
+ use part,     only:npart,xyzh,vxyzu,rad,radprop,drad,&
                     xyzh_label,init_part,radprop_label
  use boundary, only:xmin,xmax,ymin,ymax,zmin,zmax
  use options,  only:implicit_radiation,tolh
@@ -228,12 +228,11 @@ subroutine test_implicit_matches_explicit(ntests,npass)
  use timestep, only:dtmax
  use radiation_implicit, only:do_radiation_implicit
  integer, intent(inout) :: ntests,npass
- real(kind=kind(dvdx)), allocatable :: dvdx_explicit(:,:)
  real(kind=kind(radprop)), allocatable :: flux_explicit(:,:)
  real :: kappa_code,c_code,xi0,rho0,errmax_e,tol_e,tolh_old,pmassi !,exact(9)
  integer :: i,j,itry,nerr_e(9),ierr
 
- if (id==master) write(*,"(/,a)") '--> checking implicit routine matches explicit for dvdx/flux terms'
+ if (id==master) write(*,"(/,a)") '--> checking implicit routine matches explicit for flux terms'
 
  implicit_radiation = .false.
  iverbose = 0
@@ -255,30 +254,17 @@ subroutine test_implicit_matches_explicit(ntests,npass)
     if (itry==1) then
        call get_derivs_global()  ! twice to get density on neighbours correct
 
-       !--allocate and copy dvdx (note: dvdx_explicit = dvdx works
-       !  but gives compiler warnings so we do this with source=)
-       allocate(dvdx_explicit, source=dvdx)
-
        !--allocate and copy flux
        allocate(flux_explicit(3,npart))
        flux_explicit = radprop(ifluxx:ifluxz,1:npart)
-       dvdx = 0.
     else
-       dvdx = 0.
        radprop = 0.
        call do_radiation_implicit(1.e-24,npart,rad,xyzh,vxyzu,radprop,drad,ierr)
     endif
  enddo
 
  ! now check that things match
- nerr_e = 0
- errmax_e = 0.
  tol_e = 1.e-15
- do j=1,9
-    call checkval(npart,dvdx(j,:),dvdx_explicit(j,:),tol_e,nerr_e(j),dvdx_label(j))
- enddo
- call update_test_scores(ntests,nerr_e,npass)
-
  nerr_e = 0
  errmax_e = 0.
  do j=1,3


### PR DESCRIPTION
Summary of changes:
- Iterate only over subset of particles that have not converged.
- Lower `tol_rad` from 10^-5 to 10^-6 in test suite so that calculation of dxi/dt with implicit radiation is accurate enough when iterating over individual particles. 
- Move allocation of compacted neighbour list and neighbour arrays into new module `implicit` (utils_implicit.f90).
- Only allocate arrays if unallocated, as opposed to doing so every time step.
- Remove calculation of redundant dvdx in `fill_arrays` (it is identical to the calculation in density). Remove check for `dvdx` in the test suite.
- Put calculation of flux limiter lambda and Eddington factor into the `compute_flux` particle loop. Remove timing for computing lambda and eddington.
- Cache cv, lambda, eddington, and opacity in `EU0(6,npart)` array.