### PR TITLE
(build) fix issues with SYSTEM=rusty

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         sudo echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update
         INTELVERSION=$(apt-cache show intel-oneapi-compiler-fortran | grep Version | head -1)
         echo "::set-output name=intelversion::$INTELVERSION"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,9 @@ jobs:
     - name: "Nuke the github workspace before doing anything"
       run: rm -r ${{ github.workspace }} && mkdir ${{ github.workspace }}
 
+    - name: Update package list
+      run: sudo apt-get update
+
     - name: Setup Intel repo
       if: matrix.system == 'ifort'
       id: intel-repo
@@ -75,7 +78,6 @@ jobs:
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         sudo echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-        sudo apt-get update
         INTELVERSION=$(apt-cache show intel-oneapi-compiler-fortran | grep Version | head -1)
         echo "::set-output name=intelversion::$INTELVERSION"
 

--- a/build/Makefile_defaults_ifort
+++ b/build/Makefile_defaults_ifort
@@ -14,7 +14,7 @@ LIBCXX = -cxxlib
 KNOWN_SYSTEM=yes
 
 # for ifort version 18+ -openmp flag is obsolete
-IFORT_VERSION_MAJOR=${shell ifort -v 2>&1 | cut -d' ' -f 3 | cut -d'.' -f 1}
+IFORT_VERSION_MAJOR=${shell ifort -v 2>&1 | head -1 | cut -d' ' -f 3 | cut -d'.' -f 1}
 ifeq ($(shell [ $(IFORT_VERSION_MAJOR) -gt 17 ] && echo true),true)
     OMPFLAGS= -qopenmp
 else

--- a/build/Makefile_systems
+++ b/build/Makefile_systems
@@ -113,11 +113,10 @@ endif
 ifeq ($(SYSTEM), rusty)
 #   Flatiron CCA rusty cluster rome node, AMD EPYC 7742
     include Makefile_defaults_ifort
-    FFLAGS= -Ofast -mcmodel=medium -march=znver2
+    OMPFLAGS=-qopenmp
     NOMP=64
-    QSYS = slurm
-    QNAME='rome'
-    QPARTITION='cca'
+    QSYS=slurm
+    QPARTITION='gen'
     WALLTIME='168:00:00'
 endif
 
@@ -128,7 +127,7 @@ ifeq ($(SYSTEM), ipopeyearch)
     NOMP=64
     QSYS = slurm
     QNAME='icelake'
-    QPARTITION='cca'
+    QPARTITION='gen'
     WALLTIME='168:00:00'
 endif
 

--- a/docs/disc.rst
+++ b/docs/disc.rst
@@ -89,7 +89,7 @@ the .setup file correct. Answer 2 for the number of stars::
 
      >>> please edit disc.setup to set parameters for your problem then rerun  phantomsetup <<<
 
-After answering the questions, this will create a file called sim.setup which    contains setup options. Open this file in your favourite text editor to proceed...
+After answering the questions, this will create a file called sim.setup which contains setup options. Open this file in your favourite text editor to proceed...
 
 edit the .setup file and rerun phantomsetup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -138,7 +138,7 @@ The above procedure prints a .discparams file (in the above example would be
 called disc.discparams) that contains some of the parameters used to
 initialise the disc setup.
 
-For a circumbinary disc the equation of state is set to a vertically isothermal equation of state (ieos=3) where the radius is taken with respect to *the coordinate origin*. See :doc:`Equations of state available in Phantom <Equations of state available in Phantom>`
+For a circumbinary disc the equation of state is set to a vertically isothermal equation of state (ieos=3) where the radius is taken with respect to *the coordinate origin*. See :doc:`Equations of state available in Phantom <eos>`
 
 check the .in file and proceed to run phantom
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -181,9 +181,9 @@ which produces::
   secondary mass          :    1.00
   mass ratio              :    1.00
 
-For a circumprimary disc the equation of state is set to ieos=6, such that the radius is taken with respect to the first sink particle in the simulation. See :doc:`Equations of state available in Phantom <Equations of state available in Phantom>`
+For a circumprimary disc the equation of state is set to ieos=6, such that the radius is taken with respect to the first sink particle in the simulation. See :doc:`Equations of state available in Phantom <eos>`
 
-The Farris et al. (2014) equation of state (ieos=14 for a binary or ieos=13 if there are more than two stars) is also useful for a flyby simulation if one does not want to have excessively cold material around the secondary
+The Farris et al. (2014) :doc:`equation of state <eos>` (ieos=14 for a binary or ieos=13 if there are more than two stars) is also useful for a flyby simulation if one does not want to have excessively cold material around the secondary
 
 
 Protoplanetary disc with embedded planets

--- a/docs/flatiron.rst
+++ b/docs/flatiron.rst
@@ -1,0 +1,165 @@
+Getting started on Rusty (Flatiron cluster)
+===========================================
+
+See also :doc:`general instructions for running phantom on a remote cluster <clusters>`.
+
+We assume you already have a Flatiron username and account
+
+First time you log in
+---------------------
+
+Make sure you log in with the -Y flag to enable X-Windows forwarding::
+
+   $ ssh -Y -p 61022 <USER>@gateway.flatironinstitute.org
+   $ ssh -Y rusty
+
+show available software::
+
+   $ module avail
+
+load intel compilers and splash::
+
+   $ module load intel-oneapi-compilers/2023.0.0
+   $ module load splash/3.8.3
+
+Get phantom
+~~~~~~~~~~~
+
+Clone a copy of phantom into your home directory::
+
+   $ git clone https://github.com/danieljprice/phantom.git
+
+Set your username and email address
+-----------------------------------
+
+Ensure that your name and email address are set, as follows::
+
+   cd phantom
+   git config --global user.name "Joe Bloggs"
+   git config --global user.email "joe.bloggs@monash.edu"
+
+Please use your full name in the format above, as this is what appears
+in the commit logs (and in the AUTHORS file).
+
+edit your .bashrc file
+----------------------
+
+I put the “module load” commands in a file called ~/.modules which
+contains the modules I want every time I log in. For example::
+
+   $ cat .modules
+   module load intel-oneapi-compilers/2023.0.0
+
+Then, add the following lines to your ~/.bashrc::
+
+   source ~/.modules
+   export SYSTEM=rusty
+   ulimit -s unlimited
+   export OMP_STACKSIZE=512M
+   export OMP_SCHEDULE=dynamic
+
+Now, when you login again, all these should be set automatically.
+
+Performing a calculation
+------------------------
+
+You should *not* perform calculations in your home space - this is for
+code and small files. Calculations should be run in the “ceph” area
+in /mnt/ceph/users/$USER/
+
+On other machines I usually make a soft link / shortcut called “runs” pointing to the directory where I want to run my calculations::
+
+   $ cd
+   $ ln -s /mnt/ceph/users/$USER runs
+   $ cd runs
+   $ pwd -P
+   /mnt/ceph/users/USERNAME
+
+However on the Flatiron machines there is already a shortcut called "ceph" in your homespace.
+
+Then make a subdirectory for the name of the calculation you want to run
+(e.g. shock)::
+
+   $ mkdir shock
+   $ cd shock
+   $ ~/phantom/scripts/writemake.sh shock > Makefile
+   $ make shock
+   $ make
+   $ ./phantomsetup shock
+
+To run the code, you need to write a slurm script. You can get an
+example by typing “make qscript”::
+
+   $ make qscript NOMP=10 INFILE=shock.in > run.q
+
+should produce something like::
+
+   $ cat run.q
+   #!/bin/bash
+   #SBATCH --ntasks=1
+   #SBATCH --cpus-per-task=10
+   #SBATCH --job-name=audiencia
+   #SBATCH --partition=gen
+   #SBATCH --output=shock.in.qout
+   #SBATCH --mail-type=BEGIN
+   #SBATCH --mail-type=FAIL
+   #SBATCH --mail-type=END
+   #SBATCH --mail-user=daniel.price@monash.edu
+   #SBATCH --time=0-168:00:00
+   #SBATCH --mem=16G
+   echo "HOSTNAME = $HOSTNAME"
+   echo "HOSTTYPE = $HOSTTYPE"
+   echo Time is `date`
+   echo Directory is `pwd`
+
+   ulimit -s unlimited
+   export OMP_SCHEDULE="dynamic"
+   export OMP_NUM_THREADS=10
+   export OMP_STACKSIZE=1024m
+
+   echo "starting phantom run..."
+   export outfile=`grep logfile "shock.in" | sed "s/logfile =//g" | sed "s/   \\!.*//g" | sed "s/\s//g"`
+   echo "writing output to $outfile"
+   ./phantom shock.in >& $outfile
+
+You can then submit this to the "temp" queue using::
+
+   $ sbatch -p temp run.q
+   Submitted batch job 2547013
+
+check status using::
+
+   $ squeue -u $USER
+             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
+           2547013      temp audienci   dprice  R       0:02      1 worker3109
+
+Once the job is running, follow the output log using the tail -f command::
+
+   $ tail -f shock01.log
+
+splash on rusty
+~~~~~~~~~~~~~~~~
+
+There is a version of splash you can get by loading the relevant module::
+
+   module load splash/3.8.3
+
+(module load splash). Alternatively, you can also
+install splash in your home space::
+
+   cd
+   git clone https://github.com/danieljprice/splash
+   cd splash; git clone https://github.com/danieljprice/giza
+   make withgiza SYSTEM=ifort
+
+You can add this directory in your path by putting the following lines
+in your ~/.bashrc file::
+
+   export PATH=$HOME/splash/bin:${PATH}
+   export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$HOME/splash/giza/lib
+
+more info
+~~~~~~~~~
+
+For more information on the actual machine `read the
+userguide <https://wiki.flatironinstitute.org/SCC/Hardware/Rusty>`__

--- a/scripts/buildbot.sh
+++ b/scripts/buildbot.sh
@@ -72,11 +72,12 @@ echo "url = $url";
 pwd=$PWD;
 phantomdir="$pwd/../";
 listofcomponents='main setup analysis utils';
-#listofcomponents='analysis'
+listofcomponents='setup'
 #
 # get list of targets, components and setups to check
 #
 allsetups=`grep 'ifeq ($(SETUP)' $phantomdir/build/Makefile_setups | grep -v skip | cut -d, -f 2 | cut -d')' -f 1`
+allsetups='star'
 setuparr=($allsetups)
 batchsize=$(( ${#setuparr[@]} / $nbatch + 1 ))
 offset=$(( ($batch-1) * $batchsize ))
@@ -195,14 +196,15 @@ check_phantomsetup ()
    #
    # run phantomsetup up to 3 times to successfully create/rewrite the .setup file
    #
+   infile="${prefix}.in"
    ./phantomsetup $prefix < myinput.txt > /dev/null;
    ./phantomsetup $prefix < myinput.txt > /dev/null;
    if [ -e "$prefix.setup" ]; then
       print_result "creates .setup file" $pass;
+      #test_setupfile_options "$prefix" "$prefix.setup" $infile;
    else
       print_result "no .setup file" $warn;
    fi
-   infile="${prefix}.in"
    if [ -e "$infile" ]; then
       print_result "creates .in file" $pass;
       #
@@ -245,6 +247,39 @@ check_phantomsetup ()
    if [ $myfail -gt 0 ]; then
       echo $setup >> $faillogsetup;
    fi
+}
+#
+# check that all possible values of certain
+# variables in the .setup file work
+#
+test_setupfile_options()
+{
+   myfail=0;
+   setup=$1;
+   setupfile=$2;
+   infile=$3;
+   range=''
+   if [ "X$setup"=="Xstar" ]; then
+      param='iprofile'
+      range='1 2 3 4 5 6 7'
+   fi
+   for x in $range; do
+       valstring="$param = $x"
+       echo "checking $valstring"
+       sed "s/$param.*=.*$/$valstring/" $setupfile > ${setupfile}.tmp
+       cp ${setupfile}.tmp $setupfile
+       rm $infile
+       ./phantomsetup $setupfile < /dev/null > /dev/null;
+       ./phantomsetup $setupfile < /dev/null;
+
+       if [ -e $infile ]; then
+          print_result "successful phantomsetup with $valstring" $pass;
+       else
+          print_result "FAIL: failed to create .in file with $valstring" $fail;
+          myfail=$(( myfail + 1 ));
+          echo $setup $valstring >> $faillogsetup;
+       fi
+   done
 }
 #
 # unit tests for phantomanalysis utility

--- a/scripts/buildbot.sh
+++ b/scripts/buildbot.sh
@@ -72,12 +72,12 @@ echo "url = $url";
 pwd=$PWD;
 phantomdir="$pwd/../";
 listofcomponents='main setup analysis utils';
-listofcomponents='setup'
+#listofcomponents='setup'
 #
 # get list of targets, components and setups to check
 #
 allsetups=`grep 'ifeq ($(SETUP)' $phantomdir/build/Makefile_setups | grep -v skip | cut -d, -f 2 | cut -d')' -f 1`
-allsetups='star'
+#allsetups='star'
 setuparr=($allsetups)
 batchsize=$(( ${#setuparr[@]} / $nbatch + 1 ))
 offset=$(( ($batch-1) * $batchsize ))


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
ifort -v give a multi-line output on this cluster, resulting in an error determining the ifort version, this is now fixed in the default options for the ifort compiler

Testing:
compile phantom with SYSTEM=rusty on the flatiron cluster

Did you run the bots? no

Did you update relevant documentation in the docs directory? yes...