### PR TITLE
Wind tunnel setup and injection module

### DIFF
--- a/build/Makefile_setups
+++ b/build/Makefile_setups
@@ -834,7 +834,7 @@ endif
 ifeq ($(SETUP), windtunnel)
 #   Wind tunnel setup
     SETUPFILE= setup_windtunnel.f90
-    SRCINJECT= inject_BHL.f90
+    SRCINJECT= inject_windtunnel.f90
     GRAVITY=yes
     KNOWN_SETUP=yes
     IND_TIMESTEPS=yes

--- a/build/Makefile_setups
+++ b/build/Makefile_setups
@@ -838,6 +838,7 @@ ifeq ($(SETUP), windtunnel)
     GRAVITY=yes
     KNOWN_SETUP=yes
     IND_TIMESTEPS=yes
+    ANALYSIS=analysis_common_envelope.f90
 endif
 
 ifeq ($(SETUP), jet)

--- a/build/Makefile_setups
+++ b/build/Makefile_setups
@@ -597,7 +597,7 @@ ifeq ($(SETUP), blob)
 #   Blob evaporation problem
     PERIODIC=yes
     SETUPFILE= setup_blob.f90
-    DOUBLEPRECISION= no
+    DOUBLEPRECISION=no
     KNOWN_SETUP=yes
 endif
 
@@ -827,6 +827,15 @@ ifeq ($(SETUP), BHL)
 #   Bondi-Hoyle-Lyttleton setup
     SETUPFILE= setup_BHL.f90
     SRCINJECT= inject_BHL.f90
+    KNOWN_SETUP=yes
+    IND_TIMESTEPS=yes
+endif
+
+ifeq ($(SETUP), windtunnel)
+#   Wind tunnel setup
+    SETUPFILE= setup_windtunnel.f90
+    SRCINJECT= inject_BHL.f90
+    GRAVITY=yes
     KNOWN_SETUP=yes
     IND_TIMESTEPS=yes
 endif

--- a/src/main/inject_BHL.f90
+++ b/src/main/inject_BHL.f90
@@ -38,6 +38,7 @@ module inject
  real, public :: BHL_mach = 3.
  real, public :: BHL_r_star = .1
  real, public :: BHL_m_star
+ integer, public :: nstar = 0
 
  ! Particle-related parameters
  real, public :: BHL_closepacked = 1.
@@ -150,7 +151,7 @@ subroutine init_inject(ierr)
     layer_odd(:,:) = layer_even(:,:)
  endif
  max_layers = int(BHL_wind_length*BHL_r_star/distance_between_layers)
- max_particles = int(max_layers*(nodd+neven)/2)
+ max_particles = int(max_layers*(nodd+neven)/2) + nstar
  print *, 'BHL maximum layers: ', max_layers
  print *, 'BHL maximum particles: ', max_particles
  if (max_particles > maxp) call fatal('BHL', 'maxp too small for this simulation, please increase MAXP!')
@@ -188,11 +189,11 @@ subroutine inject_particles(time,dtlast,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
  endif
 
  last_time = time-dtlast
- outer_layer = ceiling(last_time/time_between_layers)
- inner_layer = ceiling(time/time_between_layers)-1 + handled_layers
+ outer_layer = ceiling(last_time/time_between_layers)  ! No. of layers present at t - dt
+ inner_layer = ceiling(time/time_between_layers)-1 + handled_layers  ! No. of layers ought to be present at t
  ! Inject layers
- do i=outer_layer,inner_layer
-    local_time = time - i*time_between_layers
+ do i=outer_layer,inner_layer  ! loop over layers
+    local_time = time - i*time_between_layers  ! time at which layer was injected
     i_limited = mod(i,max_layers)
     i_part = int(i_limited/2)*(nodd+neven)+mod(i_limited,2)*neven
     if (mod(i,2) == 0) then
@@ -222,7 +223,7 @@ subroutine inject_particles(time,dtlast,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
        endif
        print *, np, ' particles (npart=', npart, '/', max_particles, ')'
     endif
-    call inject_or_update_particles(i_part+1, np, xyz, vxyz, h, u, .false.)
+    call inject_or_update_particles(i_part+nstar+1, np, xyz, vxyz, h, u, .false.)
     deallocate(xyz, vxyz, h, u)
  enddo
 

--- a/src/main/inject_BHL.f90
+++ b/src/main/inject_BHL.f90
@@ -38,7 +38,6 @@ module inject
  real, public :: BHL_mach = 3.
  real, public :: BHL_r_star = .1
  real, public :: BHL_m_star
- integer, public :: nstar = 0
 
  ! Particle-related parameters
  real, public :: BHL_closepacked = 1.
@@ -151,7 +150,7 @@ subroutine init_inject(ierr)
     layer_odd(:,:) = layer_even(:,:)
  endif
  max_layers = int(BHL_wind_length*BHL_r_star/distance_between_layers)
- max_particles = int(max_layers*(nodd+neven)/2) + nstar
+ max_particles = int(max_layers*(nodd+neven)/2)
  print *, 'BHL maximum layers: ', max_layers
  print *, 'BHL maximum particles: ', max_particles
  if (max_particles > maxp) call fatal('BHL', 'maxp too small for this simulation, please increase MAXP!')
@@ -223,7 +222,7 @@ subroutine inject_particles(time,dtlast,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
        endif
        print *, np, ' particles (npart=', npart, '/', max_particles, ')'
     endif
-    call inject_or_update_particles(i_part+nstar+1, np, xyz, vxyz, h, u, .false.)
+    call inject_or_update_particles(i_part+1, np, xyz, vxyz, h, u, .false.)
     deallocate(xyz, vxyz, h, u)
  enddo
 

--- a/src/main/inject_windtunnel.f90
+++ b/src/main/inject_windtunnel.f90
@@ -1,0 +1,347 @@
+!--------------------------------------------------------------------------!
+! The Phantom Smoothed Particle Hydrodynamics code, by Daniel Price et al. !
+! Copyright (c) 2007-2023 The Authors (see AUTHORS)                        !
+! See LICENCE file for usage and distribution conditions                   !
+! http://phantomsph.github.io/                                             !
+!--------------------------------------------------------------------------!
+module inject
+!
+! Handles injection for gas sphere in wind tunnel
+!
+!
+! :Owner: Mike Lau
+!
+! :Runtime parameters:
+!   - lattice_type         : *0: cubic distribution, 1: closepacked distribution*
+!   - BHL_handled_layers   : *(integer) number of handled BHL wind layers*
+!   - mach_inf             : *BHL wind mach number*
+!   - Rstar                : *BHL star radius (in accretion radii)*
+!   - BHL_radius           : *radius of the wind cylinder (in star radii)*
+!   - BHL_wind_injection_x : *x position of the wind injection boundary (in star radii)*
+!   - BHL_wind_length      : *crude wind length (in star radii)*
+!
+! :Dependencies: dim, eos, infile_utils, io, part, partinject, physcon,
+!   units
+!
+ implicit none
+ character(len=*), parameter, public :: inject_type = 'windtunnel'
+
+ public :: init_inject,inject_particles,write_options_inject,read_options_inject,&
+      set_default_options_inject
+!
+!--runtime settings for this module
+!
+ ! Main parameters: model MS6 from Ruffert & Arnett (1994)
+ real,    public :: mach_inf = 1.
+ real,    public :: rho_inf = 1.
+ real,    public :: cs_inf = 1.
+ real,    public :: Rstar = .1
+ integer, public :: nstar  = 0
+
+ ! Particle-related parameters
+ integer, public :: lattice_type = 1
+ real,    public :: BHL_handled_layers = 4.
+ real,    public :: BHL_wind_cylinder_radius = 30.
+ real,    public :: BHL_wind_injection_x = -10.
+ real,    public :: BHL_wind_length = 100.
+
+ private
+ integer :: handled_layers
+ real    :: wind_cylinder_radius,wind_injection_x,psep,distance_between_layers,&
+            time_between_layers,h_inf,u_inf,v_inf
+ integer :: max_layers,max_particles,nodd,neven
+ logical :: first_run = .true.
+ real, allocatable :: layer_even(:,:),layer_odd(:,:)
+
+ logical, parameter :: verbose = .false.
+
+contains
+!-----------------------------------------------------------------------
+!+
+!  Initialize global variables or arrays needed for injection routine
+!+
+!-----------------------------------------------------------------------
+subroutine init_inject(ierr)
+ use physcon,    only:gg,pi
+ use eos,        only:gamma
+ use part,       only:hfact,massoftype,igas
+ use dim,        only:maxp
+ use io,         only:fatal
+ integer, intent(out) :: ierr
+ real :: pmass,element_volume,y,z
+ integer :: size_y, size_z, pass, i, j
+
+ ierr = 0
+
+ v_inf = mach_inf*cs_inf
+ u_inf = cs_inf**2 / (gamma*(gamma-1.))
+ handled_layers = int(BHL_handled_layers)
+ wind_cylinder_radius = BHL_wind_cylinder_radius * Rstar
+ wind_injection_x = BHL_wind_injection_x * Rstar
+ pmass = massoftype(igas)
+
+ ! Calculate particle separation between layers given rho_inf, depending on lattice type
+ element_volume = pmass / rho_inf
+ if (lattice_type == 1) then
+    psep = (sqrt(2.)*element_volume)**(1./3.)
+ elseif (lattice_type == 0) then
+    psep = element_volume**(1./3.) 
+ else
+    call fatal("init_inject",'unknown lattice_type (must be 0 or 1)')
+ endif
+
+ if (lattice_type == 1) then
+    distance_between_layers = psep*sqrt(6.)/3.
+    size_y = ceiling(3.*wind_cylinder_radius/psep)
+    size_z = ceiling(3.*wind_cylinder_radius/(sqrt(3.)*psep/2.))
+    do pass=1,2
+       if (pass == 2) then
+          if (allocated(layer_even)) deallocate(layer_even)
+          if (allocated(layer_odd)) deallocate(layer_odd)
+          allocate(layer_even(2,neven), layer_odd(2,nodd))
+       endif
+       neven = 0
+       nodd = 0
+       do i=1,size_y
+          do j=1,size_z
+             ! Even layer
+             y = -1.5*wind_cylinder_radius + (i-1)*psep
+             z = -1.5*wind_cylinder_radius + (j-1)*psep*sqrt(3.)/2.
+             if (mod(j,2) == 0) y = y + .5*psep
+             if (y**2+z**2  <  wind_cylinder_radius**2) then
+                neven = neven + 1
+                if (pass == 2) layer_even(:,neven) = (/ y,z /)
+             endif
+             ! Odd layer
+             y = y + psep*.5
+             z = z + psep*sqrt(3.)/6.
+             if (y**2+z**2  <  wind_cylinder_radius**2) then
+                nodd = nodd + 1
+                if (pass == 2) layer_odd(:,nodd) = (/ y,z /)
+             endif
+          enddo
+       enddo
+    enddo
+ else
+    distance_between_layers = psep
+    size_y = ceiling(3.*wind_cylinder_radius/psep)
+    size_z = size_y
+    do pass=1,2
+       if  (pass == 2) allocate(layer_even(2,neven), layer_odd(2,neven))
+       neven = 0
+       do i=1,size_y
+          do j=1,size_z
+             y = -1.5*wind_cylinder_radius+(i-1)*psep
+             z = -1.5*wind_cylinder_radius+(j-1)*psep
+             if (y**2+z**2  <  wind_cylinder_radius**2) then
+                neven = neven + 1
+                if (pass == 2) layer_even(:,neven) = (/ y,z /)
+             endif
+          enddo
+       enddo
+    enddo
+    layer_odd(:,:) = layer_even(:,:)
+ endif
+ max_layers = int(BHL_wind_length*Rstar/distance_between_layers)
+ max_particles = int(max_layers*(nodd+neven)/2) + nstar
+ print *, 'BHL maximum layers: ', max_layers
+ print *, 'BHL maximum particles: ', max_particles
+ print *, 'nstar: ',nstar  
+ if (max_particles > maxp) call fatal('BHL', 'maxp too small for this simulation, please increase MAXP!')
+ time_between_layers = distance_between_layers/v_inf
+ print *, 'distance_between_layers: ',distance_between_layers  
+ print *, 'time_between_layers: ',time_between_layers  
+ print *, 'pmass: ',pmass
+ h_inf = hfact*(pmass/rho_inf)**(1./3.)
+ !if (setup) then
+!    tmax = (100.*abs(wind_injection_x)/v_inf)/utime
+! endif
+
+end subroutine init_inject
+
+!-----------------------------------------------------------------------
+!+
+!  Main routine handling wind injection.
+!+
+!-----------------------------------------------------------------------
+subroutine inject_particles(time,dtlast,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
+                            npart,npartoftype,dtinject)
+ use physcon,  only:gg,pi
+ use units,    only:utime
+ real,    intent(in)    :: time, dtlast
+ real,    intent(inout) :: xyzh(:,:), vxyzu(:,:), xyzmh_ptmass(:,:), vxyz_ptmass(:,:)
+ integer, intent(inout) :: npart
+ integer, intent(inout) :: npartoftype(:)
+ real,    intent(out)   :: dtinject
+
+ real :: last_time, local_time, x, irrational_number_close_to_one
+ integer :: inner_layer, outer_layer, i, i_limited, i_part, np, ierr
+ real, allocatable :: xyz(:,:), vxyz(:,:), h(:), u(:)
+
+ if (first_run) then
+    call init_inject(ierr)
+    first_run = .false.
+ endif
+
+ last_time = time-dtlast
+ outer_layer = ceiling(last_time/time_between_layers)  ! No. of layers present at t - dt
+ inner_layer = ceiling(time/time_between_layers)-1 + handled_layers  ! No. of layers ought to be present at t
+ ! Inject layers
+ do i=outer_layer,inner_layer  ! loop over layers
+    local_time = time - i*time_between_layers  ! time at which layer was injected
+    i_limited = mod(i,max_layers)
+    i_part = int(i_limited/2)*(nodd+neven)+mod(i_limited,2)*neven
+    if (mod(i,2) == 0) then
+       allocate(xyz(3,neven), vxyz(3,neven), h(neven), u(neven))
+       xyz(2:3,:) = layer_even(:,:)
+       np = neven
+    else
+       allocate(xyz(3,nodd), vxyz(3,nodd), h(nodd), u(nodd))
+       xyz(2:3,:) = layer_odd(:,:)
+       np = nodd
+    endif
+    x = wind_injection_x + local_time*v_inf
+    xyz(1,:) = x
+    vxyz(1,:) = v_inf
+    vxyz(2:3,:) = 0.
+    h(:) = h_inf
+    u(:) = u_inf
+    if (verbose) then
+       if (i_part  <  npart) then
+          if (i  >  max_layers) then
+             print *, 'Recycling (i=', i, ', max_layers=', max_layers, ', i_part=', i_part, '):'
+          else
+             print *, 'Moving:'
+          endif
+       else
+          print *, 'Injecting:'
+       endif
+       print *, np, ' particles (npart=', npart, '/', max_particles, ')'
+    endif
+    call inject_or_update_particles(i_part+nstar+1, np, xyz, vxyz, h, u, .false.)
+    deallocate(xyz, vxyz, h, u)
+ enddo
+
+ irrational_number_close_to_one = 3./pi
+ dtinject = (irrational_number_close_to_one*time_between_layers)/utime
+
+end subroutine inject_particles
+
+!
+! Inject gas or boundary particles
+!
+subroutine inject_or_update_particles(ifirst, n, position, velocity, h, u, boundary)
+ use part,       only:igas,iboundary,npart,npartoftype,xyzh,vxyzu
+ use partinject, only:add_or_update_particle
+ implicit none
+ integer, intent(in) :: ifirst, n
+ double precision, intent(in) :: position(3,n), velocity(3,n), h(n), u(n)
+ logical, intent(in) :: boundary
+
+ integer :: i, itype
+ real :: position_u(3), velocity_u(3)
+
+ if (boundary) then
+    itype = iboundary
+ else
+    itype = igas
+ endif
+
+ do i=1,n
+    position_u(:) = position(:,i)
+    velocity_u(:) = velocity(:,i)
+    call add_or_update_particle(itype,position_u,velocity_u,h(i),u(i),&
+     ifirst+i-1,npart,npartoftype,xyzh,vxyzu)
+ enddo
+
+end subroutine inject_or_update_particles
+
+!-----------------------------------------------------------------------
+!+
+!  Writes input options to the input file
+!+
+!-----------------------------------------------------------------------
+subroutine write_options_inject(iunit)
+ use infile_utils, only:write_inopt
+ integer, intent(in) :: iunit
+
+ call write_inopt(mach_inf,'mach_inf','BHL wind mach number',iunit)
+ call write_inopt(cs_inf,'cs_inf','ambient sound speed',iunit)
+ call write_inopt(rho_inf,'rho_inf','ambient density',iunit)
+ call write_inopt(Rstar,'Rstar','BHL star radius (in accretion radii)',iunit)
+ call write_inopt(nstar,'nstar','No. of particles making up star',iunit)
+ call write_inopt(lattice_type,'lattice_type','0: cubic distribution, 1: closepacked distribution',iunit)
+ call write_inopt(BHL_handled_layers,'BHL_handled_layers','(integer) number of handled BHL wind layers',iunit)
+ call write_inopt(BHL_wind_cylinder_radius,'BHL_radius','radius of the wind cylinder (in star radii)',iunit)
+ call write_inopt(BHL_wind_injection_x,'BHL_wind_injection_x','x position of the wind injection boundary (in star radii)',iunit)
+ call write_inopt(BHL_wind_length,'BHL_wind_length','crude wind length (in star radii)',iunit)
+
+end subroutine write_options_inject
+
+!-----------------------------------------------------------------------
+!+
+!  Reads input options from the input file.
+!+
+!-----------------------------------------------------------------------
+subroutine read_options_inject(name,valstring,imatch,igotall,ierr)
+ use io, only: fatal, error, warning
+ character(len=*), intent(in)  :: name,valstring
+ logical,          intent(out) :: imatch,igotall
+ integer,          intent(out) :: ierr
+
+ integer, save :: ngot = 0
+ character(len=30), parameter :: label = 'read_options_inject'
+
+ imatch  = .true.
+ igotall = .false.
+ select case(trim(name))
+ case('mach_inf')
+    read(valstring,*,iostat=ierr) mach_inf
+    ngot = ngot + 1
+    if (mach_inf <= 0.)    call fatal(label,'invalid setting for mach_inf (<=0)')
+ case('cs_inf')
+    read(valstring,*,iostat=ierr) cs_inf
+    ngot = ngot + 1
+    if (cs_inf <= 0.) call fatal(label,'cs_inf must be positive')
+ case('rho_inf')
+    read(valstring,*,iostat=ierr) rho_inf
+    ngot = ngot + 1
+    if (rho_inf <= 0.) call fatal(label,'rho_inf must be positive')
+ case('nstar')
+    read(valstring,*,iostat=ierr) nstar
+    ngot = ngot + 1
+ case('Rstar')
+    read(valstring,*,iostat=ierr) Rstar
+    ngot = ngot + 1
+    if (Rstar <= 0.)    call fatal(label,'invalid setting for Rstar (<=0)')
+ case('lattice_type')
+    read(valstring,*,iostat=ierr) lattice_type
+    ngot = ngot + 1
+    if (lattice_type/=0 .and. lattice_type/=1)    call fatal(label,'lattice_type must be 0 or 1')
+ case('BHL_handled_layers')
+    read(valstring,*,iostat=ierr) BHL_handled_layers
+    ngot = ngot + 1
+    if (dble(int(BHL_handled_layers))  /=  BHL_handled_layers) call fatal(label,'BHL_handled_layers must be integer')
+    if (int(BHL_handled_layers)  <  0) call fatal(label,'BHL_handled_layers must be positive or zero')
+ case('BHL_radius')
+    read(valstring,*,iostat=ierr) BHL_wind_cylinder_radius
+    ngot = ngot + 1
+    if (BHL_wind_cylinder_radius <= 0.) call fatal(label,'BHL_wind_cylinder_radius must be >0')
+ case('BHL_wind_injection_x')
+    read(valstring,*,iostat=ierr) BHL_wind_injection_x
+    ngot = ngot + 1
+ case('BHL_wind_length')
+    read(valstring,*,iostat=ierr) BHL_wind_length
+    ngot = ngot + 1
+    if (BHL_wind_length <= 0.) call fatal(label,'BHL_wind_length must be positive')
+ end select
+
+ igotall = (ngot >= 10)
+end subroutine read_options_inject
+
+subroutine set_default_options_inject(flag)
+
+ integer, optional, intent(in) :: flag
+end subroutine set_default_options_inject
+
+end module inject

--- a/src/main/inject_windtunnel.f90
+++ b/src/main/inject_windtunnel.f90
@@ -40,7 +40,7 @@ module inject
 
  ! Particle-related parameters
  integer, public :: lattice_type = 1
- real,    public :: handled_layers = 4
+ integer, public :: handled_layers = 4
  real,    public :: wind_radius = 30.
  real,    public :: wind_injection_x = -10.
  real,    public :: wind_length = 100.
@@ -146,7 +146,8 @@ subroutine init_inject(ierr)
  max_particles = int(max_layers*(nodd+neven)/2) + nstar
  time_between_layers = distance_between_layers/v_inf
 
- call print_summary(v_inf,cs_inf,rho_inf,pres_inf,mach,pmass,distance_between_layers,time_between_layers,max_layers,nstar,max_particles)
+ call print_summary(v_inf,cs_inf,rho_inf,pres_inf,mach,pmass,distance_between_layers,&
+                    time_between_layers,max_layers,nstar,max_particles)
 
  if (max_particles > maxp) call fatal('windtunnel', 'maxp too small for this simulation, please increase MAXP!')
 

--- a/src/main/inject_windtunnel.f90
+++ b/src/main/inject_windtunnel.f90
@@ -146,9 +146,9 @@ subroutine init_inject(ierr)
  max_particles = int(max_layers*(nodd+neven)/2) + nstar
  time_between_layers = distance_between_layers/v_inf
 
- if (max_particles > maxp) call fatal('windtunnel', 'maxp too small for this simulation, please increase MAXP!')
-
  call print_summary(v_inf,cs_inf,rho_inf,pres_inf,mach,pmass,distance_between_layers,time_between_layers,max_layers,nstar,max_particles)
+
+ if (max_particles > maxp) call fatal('windtunnel', 'maxp too small for this simulation, please increase MAXP!')
 
 end subroutine init_inject
 

--- a/src/setup/set_star_utils.f90
+++ b/src/setup/set_star_utils.f90
@@ -269,10 +269,10 @@ subroutine set_star_density(lattice,id,master,rmin,Rstar,Mstar,hfact,&
  npart_old = npart
  n = np
  mass_is_set = .false.
- if (npart_old /= 0 .and. massoftype(igas) > tiny(0.)) then
+ if (massoftype(igas) > tiny(0.)) then
     n = nint(Mstar/massoftype(igas))
     mass_is_set = .true.
-    !print "(a,i0)",' WARNING: particle mass is already set, using np = ',n
+    print "(a,i0)",' WARNING: particle mass is already set, using np = ',n
  endif
  !
  ! place particles in sphere

--- a/src/setup/setup_binary.f90
+++ b/src/setup/setup_binary.f90
@@ -88,7 +88,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,&
 !
  npart = 0
  npartoftype(:) = 0
- massoftype = 1d-9
+ massoftype = 0.
 
  xyzh(:,:)  = 0.
  vxyzu(:,:) = 0.

--- a/src/setup/setup_windtunnel.f90
+++ b/src/setup/setup_windtunnel.f90
@@ -117,10 +117,10 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
     stop 'please check and edit .setup file and rerun phantomsetup'
  endif
  
- call check_setup(pmass,ierr)
- if (ierr /= 0) call fatal('windtunnel','errors in setup parameters')
  pmass = Mstar / real(nstar)
  massoftype(igas) = pmass
+ call check_setup(pmass,ierr)
+ if (ierr /= 0) call fatal('windtunnel','errors in setup parameters')
 
 
  ! Initialise particle injection
@@ -259,7 +259,7 @@ end subroutine read_setupfile
 !+
 !-----------------------------------------------------------------------
 subroutine check_setup(pmass,ierr)
- real, intent(in) :: pmass
+ real, intent(in)     :: pmass
  integer, intent(out) :: ierr
  real                 :: min_layer_sep
 

--- a/src/setup/setup_windtunnel.f90
+++ b/src/setup/setup_windtunnel.f90
@@ -80,7 +80,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
 
  ! Wind parameters (see inject_windtunnel module)
  v_inf    = 230e5 / unit_velocity
- rho_inf  = 4.e-4 / unit_density
+ rho_inf  = 4.e-2 / unit_density
  pres_inf = 6.6e10 / unit_pressure
 
  ! Star parameters

--- a/src/setup/setup_windtunnel.f90
+++ b/src/setup/setup_windtunnel.f90
@@ -1,0 +1,126 @@
+!--------------------------------------------------------------------------!
+! The Phantom Smoothed Particle Hydrodynamics code, by Daniel Price et al. !
+! Copyright (c) 2007-2023 The Authors (see AUTHORS)                        !
+! See LICENCE file for usage and distribution conditions                   !
+! http://phantomsph.bitbucket.io/                                          !
+!--------------------------------------------------------------------------!
+module setup
+!
+! this module does setup
+!
+! :References: None
+!
+! :Owner: Daniel Price
+!
+! :Runtime parameters: None
+!
+! :Dependencies: inject, part, physcon, units
+!
+ use io, only:master
+
+ implicit none
+ public :: setpart
+
+ private
+
+contains
+
+!----------------------------------------------------------------
+!+
+!  setup for gas sphere inside wind tunnel
+!+
+!----------------------------------------------------------------
+subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,time,fileprefix)
+ use part,        only:ihsoft,igas
+ use eos,         only:ieos,gmw
+ use setstar_utils,only:set_star_density
+ use rho_profile, only:rho_polytrope
+ use extern_densprofile, only:nrhotab
+ use physcon,     only:solarm,solarr
+ use units,       only:udist,umass,utime,set_units
+ use inject,      only:init_inject,BHL_r_star,BHL_m_star,BHL_mach,BHL_pmass,BHL_closepacked,BHL_handled_layers,&
+                       BHL_wind_cylinder_radius,BHL_wind_injection_x,BHL_wind_length,BHL_psep
+ use mpidomain,   only:i_belong
+ use timestep,    only:dtmax,tmax
+ integer,           intent(in)    :: id
+ integer,           intent(inout) :: npart
+ integer,           intent(out)   :: npartoftype(:)
+ real,              intent(out)   :: xyzh(:,:),vxyzu(:,:),massoftype(:),polyk,gamma,hfact
+ real,              intent(inout) :: time
+ character(len=20), intent(in)    :: fileprefix
+ real               :: m,hacc,rhocentre,rmin,tcrush,rho_inf,v_inf,pres_inf,cs_inf,&
+                       pmass,element_volume,rho_star
+ real, allocatable  :: r(:),den(:)
+ integer            :: ierr,npts,nstar
+ logical            :: use_exactN
+ character(len=30)  :: lattice
+ 
+ call set_units(mass=solarm,dist=solarr,G=1.d0)
+ !
+ !--general parameters
+ !
+ time  = 0.
+ polyk = 1. ! not used but needs to be initialised to non-zero value
+ gamma = 5./3.
+ ieos  = 2
+ gmw   = 0.6
+
+ ! Wind parameters (see inject_BHL module)
+ BHL_mach = 1.31
+ rho_inf = 6.8e-5
+ pres_inf = 5.9e-6
+ cs_inf = sqrt(gamma*pres_inf/rho_inf)
+ v_inf = BHL_mach*cs_inf
+
+ ! Star parameters
+ BHL_r_star = 0.1
+ BHL_m_star = 1.e-3
+ nstar = 10000
+ pmass = BHL_m_star / real(nstar)
+ massoftype(igas) = pmass
+ lattice = 'closepacked'
+ use_exactN = .true.
+
+ ! Wind injection settings
+ BHL_closepacked = 1.           ! do not change, this is hardwired at the moment
+ BHL_handled_layers = 4.
+ BHL_wind_cylinder_radius = 5.  ! in units of Rstar
+ BHL_wind_injection_x = -5.     ! in units of Rstar
+ BHL_wind_length = 20.          ! in units of Rstar
+
+ ! Calculate particle separation between layers given rho_inf, depending on lattice type
+ element_volume = pmass / rho_inf
+ if (BHL_closepacked == 1.) then
+    BHL_psep = (sqrt(2.)*element_volume)**(1./3.)
+ else
+    BHL_psep = element_volume**(1./3.) 
+ endif
+ BHL_psep = BHL_psep / BHL_r_star  ! need to provide in units of Rstar, separation between layers of wind particle
+
+ ! Set default tmax and dtmax
+ rho_star = BHL_m_star/BHL_r_star**3
+ tcrush = 2.*BHL_r_star*sqrt(rho_star/rho_inf)/v_inf
+ dtmax = 1.6*0.05*tcrush
+ tmax  = 1.6*2.5*tcrush
+ 
+ ! Set star
+!  allocate(r(nrhotab),den(nrhotab))
+!  call rho_polytrope(gamma,polyk,BHL_m_star,r,den,npts,rhocentre,set_polyk=.true.,Rstar=BHL_r_star)
+!  rmin = r(1)
+!  call set_star_density(lattice,id,master,rmin,BHL_r_star,BHL_m_star,hfact,&
+!                        npts,den,r,npart,npartoftype,massoftype,xyzh,use_exactN,np,i_belong)
+!  deallocate(r,den)
+
+
+ call init_inject(ierr)
+ npart = 0
+ npartoftype(:) = 0
+ xyzh(:,:)  = 0.
+ vxyzu(:,:) = 0.
+ 
+ print *, "udist = ", udist, "; umass = ", umass, "; utime = ", utime
+
+end subroutine setpart
+    
+end module setup
+    

--- a/src/setup/setup_windtunnel.f90
+++ b/src/setup/setup_windtunnel.f90
@@ -16,10 +16,15 @@ module setup
 !
 ! :Dependencies: inject, part, physcon, units
 !
- use io, only:master
+ use io,     only:master,fatal
+ use inject, only:init_inject,nstar,Rstar,lattice_type,handled_layers,&
+                  wind_radius,wind_injection_x,wind_length,&
+                  rho_inf,pres_inf,v_inf
 
  implicit none
  public :: setpart
+
+ real    :: Mstar
 
  private
 
@@ -37,16 +42,13 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use rho_profile, only:rho_polytrope
  use extern_densprofile, only:nrhotab
  use physcon,     only:solarm,solarr
- use units,       only:udist,umass,utime,set_units
- use inject,      only:init_inject,nstar,Rstar,mach_inf,lattice_type,BHL_handled_layers,&
-                       BHL_wind_cylinder_radius,BHL_wind_injection_x,BHL_wind_length,&
-                       cs_inf,rho_inf
+ use units,       only:udist,umass,utime,set_units,unit_velocity,unit_density,unit_pressure
+ use setunits,    only:mass_unit,dist_unit
  use mpidomain,   only:i_belong
  use timestep,    only:dtmax,tmax
  use unifdis,     only:mask_prototype
  use kernel,      only:hfact_default
  use setup_params,only:rhozero,npart_total
- use mpidomain,   only:i_belong
  use table_utils, only:yinterp
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
@@ -54,16 +56,21 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  real,              intent(out)   :: xyzh(:,:),vxyzu(:,:),massoftype(:),polyk,gamma,hfact
  real,              intent(inout) :: time
  character(len=20), intent(in)    :: fileprefix
- real               :: rhocentre,rmin,tcrush,v_inf,pres_inf,pmass,rho_star,Mstar,densi,presi,ri
+ real               :: rhocentre,rmin,pmass,densi,presi,ri
  real, allocatable  :: r(:),den(:),pres(:)
  integer            :: ierr,npts,np,i
- logical            :: use_exactN
+ logical            :: use_exactN,setexists
  character(len=30)  :: lattice
+ character(len=120) :: setupfile
  
  call set_units(mass=solarm,dist=solarr,G=1.)
  !
- !--general parameters
+ ! Initialise parameters, including those that will not be included in *.setup
  !
+ ! units
+ mass_unit = 'solarm'
+ dist_unit = 'solarr'
+
  time  = 0.
  polyk = 1. ! not used but needs to be initialised to non-zero value
  gamma = 5./3.
@@ -71,35 +78,51 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  gmw   = 0.6
  hfact = hfact_default
 
- ! Wind parameters (see inject_BHL module)
- mach_inf = 1.55
- rho_inf  = 0.0068
- pres_inf = 5.64e-4
- cs_inf   = sqrt(gamma*pres_inf/rho_inf)
- v_inf    = mach_inf*cs_inf
+ ! Wind parameters (see inject_windtunnel module)
+ v_inf    = 230e5 / unit_velocity
+ rho_inf  = 4.e-4 / unit_density
+ pres_inf = 6.6e10 / unit_pressure
 
  ! Star parameters
  Rstar = 0.1
  Mstar = 1.e-3
- nstar = 10000000
+ nstar = 1000
  lattice = 'closepacked'
  use_exactN = .true.
- pmass = Mstar / real(nstar)
- massoftype(igas) = pmass
 
  ! Wind injection settings
  lattice_type = 1
- BHL_handled_layers = 4.
- BHL_wind_cylinder_radius = 10. ! in units of Rstar
- BHL_wind_injection_x = -5.     ! in units of Rstar
- BHL_wind_length = 20.          ! in units of Rstar
+ handled_layers = 4
+ wind_radius = 10. ! in units of Rstar
+ wind_injection_x = -2.     ! in units of Rstar
+ wind_length = 15.          ! in units of Rstar
 
  ! Set default tmax and dtmax
- rho_star = Mstar/Rstar**3
- tcrush = 2.*Rstar*sqrt(rho_star/rho_inf)/v_inf
- dtmax = 0.1!1.6*0.05*tcrush
- tmax  = 45.2!1.6*2.5*tcrush
+ dtmax = 0.1
+ tmax  = 6.8
+
+ ! determine if the .setup file exists
+ setupfile = trim(fileprefix)//'.setup'
+ inquire(file=setupfile,exist=setexists)
+ if (setexists) then
+    call read_setupfile(setupfile,ierr)
+    if (ierr /= 0) then
+       if (id==master) call write_setupfile(setupfile)
+       stop 'please rerun phantomsetup with revised .setup file'
+    endif
+    !--Prompt to get inputs and write to file
+ elseif (id==master) then
+    print "(a,/)",trim(setupfile)//' not found: using default parameters'
+    call write_setupfile(setupfile)
+    stop 'please check and edit .setup file and rerun phantomsetup'
+ endif
  
+ call check_setup(pmass,ierr)
+ if (ierr /= 0) call fatal('windtunnel','errors in setup parameters')
+ pmass = Mstar / real(nstar)
+ massoftype(igas) = pmass
+
+
  ! Initialise particle injection
  call init_inject(ierr)
  npart = 0
@@ -123,13 +146,141 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
     presi = yinterp(pres(1:npts),r(1:npts),ri)
     vxyzu(4,i) =  presi / ( (gamma-1.) * densi)
  enddo
- nstar = npart
  
  deallocate(r,den,pres)
  
  print*, "udist = ", udist, "; umass = ", umass, "; utime = ", utime
 
 end subroutine setpart
+
+
+
+!-----------------------------------------------------------------------
+!+
+!  Write setup parameters to input file
+!+
+!-----------------------------------------------------------------------
+subroutine write_setupfile(filename)
+ use infile_utils,  only:write_inopt
+ use dim,           only:tagline
+ use eos,           only:gamma
+ use setunits,      only:write_options_units
+ use units,         only:unit_density,unit_pressure,unit_velocity
+ character(len=*), intent(in) :: filename
+ integer,          parameter  :: iunit = 20
+
+ write(*,"(a)") ' Writing '//trim(filename)
+ open(unit=iunit,file=filename,status='replace',form='formatted')
+ write(iunit,"(a)") '# '//trim(tagline)
+ write(iunit,"(a)") '# input file for Phantom wind tunnel setup'
+
+ call write_options_units(iunit)
+
+ write(iunit,"(/,a)") '# sphere settings'
+ call write_inopt(nstar,'nstar','number of particles resolving gas sphere',iunit)
+ call write_inopt(Mstar,'Mstar','sphere mass in code units',iunit)
+ call write_inopt(Rstar,'Rstar','sphere radius in code units',iunit)
+ 
+ write(iunit,"(/,a)") '# wind settings'
+ call write_inopt(v_inf*unit_velocity/1.e5,'v_inf','wind speed / km s^-1',iunit)
+ call write_inopt(rho_inf*unit_density,'rho_inf','wind density / g cm^-3',iunit)
+ call write_inopt(pres_inf*unit_pressure,'pres_inf','wind pressure / dyn cm^2',iunit)
+ call write_inopt(gamma,'gamma','adiabatic index',iunit)
+
+ write(iunit,"(/,a)") '# wind injection settings'
+ call write_inopt(lattice_type,'lattice_type','0: cubic, 1: close-packed cubic',iunit)
+ call write_inopt(handled_layers,'handled_layers','number of handled layers',iunit)
+ call write_inopt(wind_radius,'wind_radius','injection radius in units of Rstar',iunit)
+ call write_inopt(wind_injection_x,'wind_injection_x','injection x in units of Rstar',iunit)
+ call write_inopt(wind_length,'wind_length','wind length in units of Rstar',iunit)
+
+ close(iunit)
+
+end subroutine write_setupfile
+
+
+!-----------------------------------------------------------------------
+!+
+!  Read setup parameters from input file
+!+
+!-----------------------------------------------------------------------
+subroutine read_setupfile(filename,ierr)
+ use infile_utils,  only:open_db_from_file,inopts,close_db,read_inopt
+ use io,            only:error
+ use units,         only:select_unit,unit_density,unit_pressure,unit_velocity
+ use setunits,      only:read_options_and_set_units
+ use eos,           only:gamma
+ character(len=*), intent(in)  :: filename
+ integer,          intent(out) :: ierr
+ integer,          parameter   :: lu = 21
+ integer                       :: nerr
+ type(inopts), allocatable     :: db(:)
+
+ call open_db_from_file(db,filename,lu,ierr)
+ if (ierr /= 0) return
+
+ nerr = 0
+
+ call read_options_and_set_units(db,nerr)
+
+ call read_inopt(nstar,'nstar',db,errcount=nerr)
+ call read_inopt(Mstar,'Mstar',db,errcount=nerr)
+ call read_inopt(Rstar,'Rstar',db,errcount=nerr)
+
+ call read_inopt(v_inf,'v_inf',db,errcount=nerr)
+ call read_inopt(rho_inf,'rho_inf',db,errcount=nerr)
+ call read_inopt(pres_inf,'pres_inf',db,errcount=nerr)
+ call read_inopt(gamma,'gamma',db,errcount=nerr)
+
+ ! Convert wind quantities to code units
+ v_inf = v_inf / unit_velocity * 1.e5
+ rho_inf = rho_inf / unit_density
+ pres_inf = pres_inf / unit_pressure
+
+ call read_inopt(lattice_type,'lattice_type',db,errcount=nerr)
+ call read_inopt(handled_layers,'handled_layers',db,errcount=nerr)
+ call read_inopt(wind_radius,'wind_radius',db,errcount=nerr)
+ call read_inopt(wind_injection_x,'wind_injection_x',db,errcount=nerr)
+ call read_inopt(wind_length,'wind_length',db,errcount=nerr)
+
+ if (nerr > 0) then
+    print "(1x,a,i2,a)",'setup_windtunnel: ',nerr,' error(s) during read of setup file'
+    ierr = 1
+ endif
+
+ call close_db(db)
+
+end subroutine read_setupfile
+
+
+!-----------------------------------------------------------------------
+!+
+!  Check that setup is sensible
+!+
+!-----------------------------------------------------------------------
+subroutine check_setup(pmass,ierr)
+ real, intent(in) :: pmass
+ integer, intent(out) :: ierr
+ real                 :: min_layer_sep
+
+ ierr = 0
+
+ min_layer_sep = (pmass / rho_inf)**(1./3.)
+
+ if ( abs(wind_injection_x - 1.)*Rstar < real(handled_layers)*min_layer_sep ) then
+    print*,'error: Handled layers overlap with sphere. Try decreasing wind_injection_x or handled_layers'
+    ierr = 1
+ endif
+ if (wind_radius < 1.) then
+    print*,'error: Wind cross-section should not be smaller than the sphere'
+    ierr = 1
+ endif
+ if ( wind_injection_x + wind_length < 1. ) then
+    print*,'error: Wind not long enough to cover initial sphere position. Try increasing wind_injection_x or wind_length'
+    ierr = 1
+ endif
+
+end subroutine check_setup
     
 end module setup
     

--- a/src/setup/setup_windtunnel.f90
+++ b/src/setup/setup_windtunnel.f90
@@ -72,16 +72,16 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  hfact = hfact_default
 
  ! Wind parameters (see inject_BHL module)
- mach_inf = 1.31
- rho_inf  = 6.8e-5
- pres_inf = 5.9e-6
+ mach_inf = 1.55
+ rho_inf  = 0.0068
+ pres_inf = 5.64e-4
  cs_inf   = sqrt(gamma*pres_inf/rho_inf)
  v_inf    = mach_inf*cs_inf
 
  ! Star parameters
  Rstar = 0.1
  Mstar = 1.e-3
- nstar = 1000000
+ nstar = 10000000
  lattice = 'closepacked'
  use_exactN = .true.
  pmass = Mstar / real(nstar)
@@ -92,13 +92,13 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  BHL_handled_layers = 4.
  BHL_wind_cylinder_radius = 10. ! in units of Rstar
  BHL_wind_injection_x = -5.     ! in units of Rstar
- BHL_wind_length = 50.          ! in units of Rstar
+ BHL_wind_length = 20.          ! in units of Rstar
 
  ! Set default tmax and dtmax
  rho_star = Mstar/Rstar**3
  tcrush = 2.*Rstar*sqrt(rho_star/rho_inf)/v_inf
  dtmax = 0.1!1.6*0.05*tcrush
- tmax  = 1.6*2.5*tcrush
+ tmax  = 45.2!1.6*2.5*tcrush
  
  ! Initialise particle injection
  call init_inject(ierr)


### PR DESCRIPTION
New setup and injection module "windtunnel" for gas polytrope in a windtunnel. Input parameters include wind speed, wind pressure, wind density, sphere radius, and sphere mass.
- Note that I have changed the logic of `set_star_density` to "know" `mass_is_set = .true.` when `massoftype(igas) > tiny(0.)` (indifferent to the value of npart). This is needed for the wind tunnel, where the particle mass must be known and set before setting up the star, so that the wind can be initialised. An implication of this is that `massoftype` should not be initialised to zero in `setup_binary`, which seems to be unnecessary anyway.

Future work:
- Generalise the gas polytrope to any "star" that can already be set up using the `setstar` module
- Allow for arbitrary EoS, which is currently hard-wired to be an ideal gas EoS.
- Perhaps combine this with the BHL modules.
