### PR TITLE
Signal speed used in tcour should include radiation pressure

### DIFF
--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -2043,6 +2043,10 @@ subroutine get_stress(pri,spsoundi,rhoi,rho1i,xi,yi,zi, &
 !
     pro2i  = (pri + radPi)*rho1i*rho1i + stressiso
     vwavei = spsoundi
+
+    if (do_radiation) then
+       vwavei = sqrt(vwavei*vwavei + 4.*radPi/(3.*rhoi))  ! Commercon et al. (2011)
+    endif
  endif
 
 end subroutine get_stress


### PR DESCRIPTION
Add contribution of radiation pressure to signal speed when using radiation (e.g., Eq 10 in https://arxiv.org/abs/1102.1216). We should have cs = (5/3*Pgas/rho + 4/3*Prad/rho)^1/2. Otherwise, tcour may be underestimated.