### PR TITLE
fix bug in set star with undefined need_iso

### DIFF
--- a/src/setup/set_star.f90
+++ b/src/setup/set_star.f90
@@ -413,6 +413,7 @@ subroutine set_defaults_given_profile(iprofile,filename,need_iso,ieos,mstar,poly
  integer, intent(inout) :: ieos
  real,    intent(inout) :: mstar,polyk
 
+ need_iso = 0
  select case(iprofile)
  case(ifromfile)
     ! Read the density profile from file (e.g. for neutron star)


### PR DESCRIPTION
Type of PR: 
Bug fix 

Description:
fix bug in set star with undefined need_iso

Testing:
make SETUP=binary
./phantomsetup crap

Did you run the bots? no

Did you update relevant documentation in the docs directory? no