### PR TITLE
New moddump that converts non-radiative dump to radiative dump

### DIFF
--- a/src/setup/set_star.f90
+++ b/src/setup/set_star.f90
@@ -700,11 +700,16 @@ subroutine read_options_star(star,need_iso,ieos,polyk,db,nerr,label)
  select case(star%iprofile)
  case(imesa)
     ! core softening options
+    call read_inopt(star%isinkcore,'isinkcore'//trim(c),db,errcount=nerr)
+
+    if (star%isinkcore) then
+       call read_inopt(lcore_lsun,'lcore'//trim(c),db,errcount=nerr,min=0.)
+       star%lcore = lcore_lsun*real(solarl/unit_luminosity)
+    endif
+
     call read_inopt(star%isoftcore,'isoftcore'//trim(c),db,errcount=nerr,min=0)
-    if (star%isoftcore==2) star%isofteningopt=3
 
     if (star%isoftcore <= 0) then ! sink particle core without softening
-       call read_inopt(star%isinkcore,'isinkcore'//trim(c),db,errcount=nerr)
        if (star%isinkcore) then
           call read_inopt(mcore_msun,'mcore'//trim(c),db,errcount=nerr,min=0.)
           star%mcore = mcore_msun*real(solarm/umass)
@@ -712,11 +717,13 @@ subroutine read_options_star(star,need_iso,ieos,polyk,db,nerr,label)
           star%hsoft = hsoft_rsun*real(solarr/udist)
        endif
     else
-       star%isinkcore = .true.
-       call read_inopt(star%input_profile,'input_profile'//trim(c),db,errcount=nerr)
        call read_inopt(star%outputfilename,'outputfilename'//trim(c),db,errcount=nerr)
-       if (star%isoftcore==1) call read_inopt(star%isofteningopt,'isofteningopt'//trim(c),&
-                                              db,errcount=nerr,min=0)
+       if (star%isoftcore==2) then
+          star%isofteningopt=3
+       elseif (star%isoftcore==1) then
+          call read_inopt(star%isofteningopt,'isofteningopt'//trim(c),db,errcount=nerr,min=0)
+       endif
+
        if ((star%isofteningopt==1) .or. (star%isofteningopt==3)) then
           call read_inopt(rcore_rsun,'rcore'//trim(c),db,errcount=nerr,min=0.)
           star%rcore = rcore_rsun*real(solarr/udist)
@@ -726,8 +733,6 @@ subroutine read_options_star(star,need_iso,ieos,polyk,db,nerr,label)
           call read_inopt(mcore_msun,'mcore'//trim(c),db,errcount=nerr,min=0.)
           star%mcore = mcore_msun*real(solarm/umass)
        endif
-       call read_inopt(lcore_lsun,'lcore'//trim(c),db,errcount=nerr,min=0.)
-       star%lcore = lcore_lsun*real(solarl/unit_luminosity)
     endif
  case(ievrard)
     call read_inopt(star%ui_coef,'ui_coef'//trim(c),db,errcount=nerr,min=0.)

--- a/src/utils/moddump_LTE_to_rad.f90
+++ b/src/utils/moddump_LTE_to_rad.f90
@@ -1,0 +1,68 @@
+!--------------------------------------------------------------------------!
+! The Phantom Smoothed Particle Hydrodynamics code, by Daniel Price et al. !
+! Copyright (c) 2007-2024 The Authors (see AUTHORS)                        !
+! See LICENCE file for usage and distribution conditions                   !
+! http://phantomsph.github.io/                                             !
+!--------------------------------------------------------------------------!
+module moddump
+!
+! Convert non-radiation dump (assuming LTE, ieos=12) to radiation dump
+!
+! :References: None
+!
+! :Owner: Mike Lau
+!
+! :Runtime parameters: None
+!
+! :Dependencies: dim, eos, io, part
+!
+ implicit none
+
+contains
+
+subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
+ use units,            only:unit_density,unit_opacity,unit_ergg
+ use dim,              only:do_radiation
+ use io,               only:fatal
+ use eos,              only:gmw,gamma,X_in,Z_in
+ use eos_idealplusrad, only:get_idealplusrad_temp
+ use eos_mesa,         only:init_eos_mesa
+ use part,             only:igas,rad,iradxi,ikappa,rhoh,radprop,ithick
+ use radiation_utils,  only:radiation_and_gas_temperature_equal,ugas_from_Tgas
+ use mesa_microphysics,only:get_kappa_mesa
+ integer, intent(inout) :: npart
+ integer, intent(inout) :: npartoftype(:)
+ real,    intent(inout) :: massoftype(:)
+ real,    intent(inout) :: xyzh(:,:),vxyzu(:,:)
+ integer                :: i,ierr
+ real                   :: pmass,mu,rhoi,kappa_cgs,kapt,kapr,rho_cgs,ugasi,tempi,gamma_fixed
+
+ if (.not. do_radiation) call fatal("moddump_LTE_to_rad","Not compiled with radiation")
+
+ mu = gmw
+ gamma_fixed = 5/3.  ! gamma should be exactly 5/3, because that is what ieos=12 assumes
+ gamma = gamma_fixed
+ print*,'Assuming gmw = ',mu,' and gamma=',gamma,'X = ',X_in,'Z = ',Z_in  ! X and Z are only used for calculating opacity
+ call init_eos_mesa(X_in,Z_in,ierr)
+
+ pmass = massoftype(igas)
+ do i=1,npart
+    rhoi = rhoh(xyzh(4,i),pmass)
+    rho_cgs = rhoi*unit_density
+    call get_idealplusrad_temp(rho_cgs,vxyzu(4,i)*unit_ergg,mu,tempi,ierr)
+
+    ! calculate u and xi
+    ugasi = ugas_from_Tgas(tempi,gamma,gmw)
+    vxyzu(4,i) = ugasi
+    rad(iradxi,i) = radiation_and_gas_temperature_equal(rhoi,ugasi,gamma,mu)
+
+    ! calculate opacity
+    call get_kappa_mesa(rho_cgs,tempi,kappa_cgs,kapt,kapr)
+    radprop(ikappa,i) = kappa_cgs/unit_opacity
+    radprop(ithick,i) = 1.
+ enddo
+
+end subroutine modify_dump
+
+end module moddump
+

--- a/src/utils/moddump_rad_to_LTE.f90
+++ b/src/utils/moddump_rad_to_LTE.f90
@@ -37,10 +37,6 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
     vxyzu(4,i) = vxyzu(4,i) + rad(iradxi,i)
  enddo
 
- ieos = 12
- gmw = 0.6   ! CHANGE MU HERE for writing into infile
- print*,'mu has been changed to',gmw  ! mu should not change from what was assumed with radiation
-
 end subroutine modify_dump
 
 end module moddump


### PR DESCRIPTION
Tested that using moddump_LTE_to_rad and moddump_rad_to_LTE in succession recovers the same dump file to within machine precision.