### PR TITLE
tighter tolerances for ieos=12,20 testing

### DIFF
--- a/src/main/eos.f90
+++ b/src/main/eos.f90
@@ -106,7 +106,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,tempi,eni,gam
  use io,            only:fatal,error,warning
  use part,          only:xyzmh_ptmass, nptmass
  use units,         only:unit_density,unit_pressure,unit_ergg,unit_velocity
- use physcon,       only:kb_on_mh,radconst
+ use physcon,       only:Rg,radconst
  use eos_mesa,      only:get_eos_pressure_temp_gamma1_mesa,get_eos_1overmu_mesa
  use eos_helmholtz, only:eos_helmholtz_pres_sound
  use eos_shen,      only:eos_shen_NL3
@@ -414,7 +414,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,tempi,eni,gam
     if (tempi > 0.) then
        temperaturei = tempi
     else
-       temperaturei = min(0.67 * cgseni * mui / kb_on_mh, (cgseni*cgsrhoi/radconst)**0.25)
+       temperaturei = min(0.67 * cgseni * mui / Rg, (cgseni*cgsrhoi/radconst)**0.25)
     endif
     call equationofstate_gasradrec(cgsrhoi,cgseni*cgsrhoi,temperaturei,imui,X_i,1.-X_i-Z_i,cgspresi,cgsspsoundi,gammai)
     ponrhoi  = real(cgspresi / (unit_pressure * rhoi))

--- a/src/main/eos_gasradrec.f90
+++ b/src/main/eos_gasradrec.f90
@@ -23,6 +23,7 @@ module eos_gasradrec
  public :: equationofstate_gasradrec,calc_uT_from_rhoP_gasradrec,read_options_eos_gasradrec,&
            write_options_eos_gasradrec,eos_info_gasradrec,init_eos_gasradrec
  private
+ real, parameter :: eoserr=1.e-15,W4err=1.e-2
 
 contains
 !-----------------------------------------------------------------------
@@ -39,7 +40,6 @@ subroutine equationofstate_gasradrec(d,eint,T,imu,X,Y,p,cf,gamma_eff)
  real, intent(in)    :: X,Y
  real, intent(out)   :: p,cf,gamma_eff
  real                :: corr,erec,derecdT,dimurecdT,Tdot,logd,dt,Tguess
- real, parameter     :: W4err=1.e-2,eoserr=1.e-13
  integer, parameter  :: nmax = 500
  integer n
 
@@ -69,6 +69,7 @@ subroutine equationofstate_gasradrec(d,eint,T,imu,X,Y,p,cf,gamma_eff)
     print*,'d=',d,'eint=',eint/d,'Tguess=',Tguess,'mu=',1./imu,'T=',T,'erec=',erec
     call fatal('eos_gasradrec','Failed to converge on temperature in equationofstate_gasradrec')
  endif
+ call get_erec_imurec(logd,T,X,Y,erec,imu)
  p = ( Rg*imu*d + radconst*T**3/3. )*T
  gamma_eff = 1.+p/(eint-d*erec)
  cf = sqrt(gamma_eff*p/d)
@@ -92,7 +93,6 @@ subroutine calc_uT_from_rhoP_gasradrec(rhoi,presi,X,Y,T,eni,mui,ierr)
  integer, intent(out)        :: ierr
  integer                     :: n
  real                        :: logrhoi,imu,dimurecdT,dT,Tdot,corr
- real, parameter             :: W4err=1.e-2,eoserr=1.e-13
 
  if (T <= 0.) T = min((3.*presi/radconst)**0.25, presi/(rhoi*Rg))  ! initial guess for temperature
  ierr = 0

--- a/src/main/eos_idealplusrad.f90
+++ b/src/main/eos_idealplusrad.f90
@@ -20,7 +20,7 @@ module eos_idealplusrad
 !
  use physcon,  only:Rg,radconst
  implicit none
- real, parameter :: tolerance = 1e-15
+ real, parameter :: tolerance = 1.e-15
 
  public :: get_idealplusrad_temp,get_idealplusrad_pres,get_idealplusrad_spsoundi,&
            get_idealgasplusrad_tempfrompres,get_idealplusrad_enfromtemp,&
@@ -64,19 +64,17 @@ end subroutine get_idealplusrad_temp
 
 
 subroutine get_idealplusrad_pres(rhoi,tempi,mu,presi)
- real, intent(in)    :: rhoi,mu
- real, intent(in)    :: tempi
+ real, intent(in)    :: rhoi,tempi,mu
  real, intent(out)   :: presi
 
- presi = Rg*rhoi*tempi/mu + 1./3.*radconst*tempi**4 ! Eq 13.2 (Kippenhahn et al.)
+ presi = (Rg*rhoi/mu + radconst*tempi**3/3.)*tempi ! Eq 13.2 (Kippenhahn et al.)
 
 end subroutine get_idealplusrad_pres
 
 
 subroutine get_idealplusrad_spsoundi(rhoi,presi,eni,spsoundi,gammai)
  real, intent(in)  :: rhoi,presi,eni
- real, intent(out) :: spsoundi
- real, intent(out) :: gammai
+ real, intent(out) :: spsoundi,gammai
 
  gammai = 1. + presi/(eni*rhoi)
  spsoundi = sqrt(gammai*presi/rhoi)
@@ -127,7 +125,7 @@ subroutine get_idealplusrad_enfromtemp(densi,tempi,mu,eni)
  real, intent(in)  :: densi,tempi,mu
  real, intent(out) :: eni
 
- eni = 3./2.*Rg*tempi/mu + radconst*tempi**4/densi
+ eni = 1.5*Rg*tempi/mu + radconst*tempi**4/densi
 
 end subroutine get_idealplusrad_enfromtemp
 

--- a/src/tests/test_eos.f90
+++ b/src/tests/test_eos.f90
@@ -23,6 +23,7 @@ module testeos
  public :: test_helmholtz ! to avoid compiler warning for unused routine
 
  private
+ logical :: use_rel_tol = .true.
 
 contains
 !----------------------------------------------------------
@@ -116,7 +117,7 @@ subroutine test_idealplusrad(ntests, npass)
  use eos_idealplusrad, only:get_idealplusrad_enfromtemp,get_idealplusrad_pres
  use testutils,        only:checkval,checkvalbuf_start,checkvalbuf,checkvalbuf_end,update_test_scores
  use units,            only:unit_density,unit_pressure,unit_ergg
- use physcon,          only:kb_on_mh
+ use physcon,          only:Rg
  integer, intent(inout) :: ntests,npass
  integer                :: npts,ieos,ierr,i,j,nfail(2),ncheck(2)
  real                   :: rhocodei,gamma,presi,dum,csound,eni,temp,ponrhoi,mu,tol,errmax(2),pres2,code_eni
@@ -129,7 +130,7 @@ subroutine test_idealplusrad(ntests, npass)
 
  call get_rhoT_grid(npts,rhogrid,Tgrid)
  dum = 0.
- tol = 1.e-12
+ tol = 1.e-15
  nfail = 0; ncheck = 0; errmax = 0.
  call init_eos(ieos,ierr)
  do i=1,npts
@@ -140,13 +141,13 @@ subroutine test_idealplusrad(ntests, npass)
 
        ! Recalculate T, P, from rho, u
        code_eni = eni/unit_ergg
-       temp = eni*mu/kb_on_mh
+       temp = eni*mu/Rg ! guess
        rhocodei = rhogrid(i)/unit_density
        call equationofstate(ieos,ponrhoi,csound,rhocodei,dum,dum,dum,temp,code_eni,mu_local=mu,gamma_local=gamma)
        pres2 = ponrhoi * rhocodei * unit_pressure
 
-       call checkvalbuf(temp,Tgrid(j),tol,'Check recovery of T from rho, u',nfail(1),ncheck(1),errmax(1))
-       call checkvalbuf(pres2,presi,tol,'Check recovery of P from rho, u',nfail(2),ncheck(2),errmax(2))
+       call checkvalbuf(temp,Tgrid(j),tol,'Check recovery of T from rho, u',nfail(1),ncheck(1),errmax(1),use_rel_tol)
+       call checkvalbuf(pres2,presi,tol,'Check recovery of P from rho, u',nfail(2),ncheck(2),errmax(2),use_rel_tol)
     enddo
  enddo
  call checkvalbuf_end('Check recovery of T from rho, u',ncheck(1),nfail(1),errmax(1),tol)
@@ -170,9 +171,9 @@ subroutine test_hormone(ntests, npass)
  use testutils, only:checkval,checkvalbuf_start,checkvalbuf,checkvalbuf_end,update_test_scores
  use units,     only:unit_density,unit_pressure,unit_ergg
  integer, intent(inout) :: ntests,npass
- integer                :: npts,ieos,ierr,i,j,nfail(4),ncheck(4)
- real                   :: imurec,mu,eni_code,presi,pres2,dum,csound,eni,tempi
- real                   :: ponrhoi,X,Z,tol,errmax(4),gasrad_eni,eni2,rhocodei,gamma
+ integer                :: npts,ieos,ierr,i,j,nfail(6),ncheck(6)
+ real                   :: imurec,mu,eni_code,presi,pres2,dum,csound,eni,tempi,gamma_eff
+ real                   :: ponrhoi,X,Z,tol,errmax(6),gasrad_eni,eni2,rhocodei,gamma,mu2
  real, allocatable      :: rhogrid(:),Tgrid(:)
 
  if (id==master) write(*,"(/,a)") '--> testing HORMONE equation of states'
@@ -185,45 +186,44 @@ subroutine test_hormone(ntests, npass)
 
  ! Testing
  dum = 0.
- tol = 1.e-12
+ tol = 1.e-14
  tempi = -1.
  nfail = 0; ncheck = 0; errmax = 0.
  call init_eos(ieos,ierr)
- tempi = 1.
- eni_code =  764437650.64783347/unit_ergg
- rhocodei = 3.2276168501594796E-015/unit_density
- call equationofstate(ieos,ponrhoi,csound,rhocodei,0.,0.,0.,tempi,eni_code,mu_local=mu,Xlocal=X,Zlocal=Z,gamma_local=gamma)
  do i=1,npts
     do j=1,npts
        gamma = 5./3.
-       ! Get mu from rho, T
+       ! Get mu, u, P from rho, T
        call get_imurec(log10(rhogrid(i)),Tgrid(j),X,1.-X-Z,imurec)
        mu = 1./imurec
-
-       ! Get u, P from rho, T, mu
        call get_idealplusrad_enfromtemp(rhogrid(i),Tgrid(j),mu,gasrad_eni)
        eni = gasrad_eni + get_erec(log10(rhogrid(i)),Tgrid(j),X,1.-X-Z)
        call get_idealplusrad_pres(rhogrid(i),Tgrid(j),mu,presi)
 
-       ! Recalculate P, T from rho, u, mu
+       ! Recalculate P, T from rho, u
        tempi = 1.
        eni_code = eni/unit_ergg
        rhocodei = rhogrid(i)/unit_density
-       call equationofstate(ieos,ponrhoi,csound,rhocodei,0.,0.,0.,tempi,eni_code,mu_local=mu,Xlocal=X,Zlocal=Z,gamma_local=gamma)
+       call equationofstate(ieos,ponrhoi,csound,rhocodei,0.,0.,0.,tempi,eni_code,&
+                            mu_local=mu2,Xlocal=X,Zlocal=Z,gamma_local=gamma_eff)  ! mu and gamma_eff are outputs
        pres2 = ponrhoi * rhocodei * unit_pressure
-       call checkvalbuf(tempi,Tgrid(j),tol,'Check recovery of T from rho, u',nfail(1),ncheck(1),errmax(1))
-       call checkvalbuf(pres2,presi,tol,'Check recovery of P from rho, u',nfail(2),ncheck(2),errmax(2))
+       call checkvalbuf(mu2,mu,tol,'Check recovery of mu from rho, u',nfail(1),ncheck(1),errmax(1),use_rel_tol)
+       call checkvalbuf(tempi,Tgrid(j),tol,'Check recovery of T from rho, u',nfail(2),ncheck(2),errmax(2),use_rel_tol)
+       call checkvalbuf(pres2,presi,tol,'Check recovery of P from rho, u',nfail(3),ncheck(3),errmax(3),use_rel_tol)
 
        ! Recalculate u, T, mu from rho, P
-       call calc_uT_from_rhoP_gasradrec(rhogrid(i),presi,X,1.-X-Z,tempi,eni2,mu,ierr)
-       call checkvalbuf(tempi,Tgrid(j),tol,'Check recovery of T from rho, P',nfail(3),ncheck(3),errmax(3))
-       call checkvalbuf(eni2,eni,tol,'Check recovery of u from rho, P',nfail(4),ncheck(4),errmax(4))
+       call calc_uT_from_rhoP_gasradrec(rhogrid(i),presi,X,1.-X-Z,tempi,eni2,mu2,ierr)
+       call checkvalbuf(mu2,mu,tol,'Check recovery of mu from rho, P',nfail(4),ncheck(4),errmax(4),use_rel_tol)
+       call checkvalbuf(tempi,Tgrid(j),tol,'Check recovery of T from rho, P',nfail(5),ncheck(5),errmax(5),use_rel_tol)
+       call checkvalbuf(eni2,eni,tol,'Check recovery of u from rho, P',nfail(6),ncheck(6),errmax(6),use_rel_tol)
     enddo
  enddo
- call checkvalbuf_end('Check recovery of T from rho, u',ncheck(1),nfail(1),errmax(1),tol)
- call checkvalbuf_end('Check recovery of P from rho, u',ncheck(2),nfail(2),errmax(2),tol)
- call checkvalbuf_end('Check recovery of T from rho, P',ncheck(3),nfail(3),errmax(3),tol)
- call checkvalbuf_end('Check recovery of u from rho, P',ncheck(4),nfail(4),errmax(4),tol)
+ call checkvalbuf_end('Check recovery of mu from rho, u',ncheck(1),nfail(1),errmax(1),tol)
+ call checkvalbuf_end('Check recovery of T from rho, u',ncheck(2),nfail(2),errmax(2),tol)
+ call checkvalbuf_end('Check recovery of P from rho, u',ncheck(3),nfail(3),errmax(3),tol)
+ call checkvalbuf_end('Check recovery of mu from rho, P',ncheck(4),nfail(4),errmax(4),tol)
+ call checkvalbuf_end('Check recovery of T from rho, P',ncheck(5),nfail(5),errmax(5),tol)
+ call checkvalbuf_end('Check recovery of u from rho, P',ncheck(6),nfail(6),errmax(6),tol)
  call update_test_scores(ntests,nfail,npass)
 
 end subroutine test_hormone

--- a/src/tests/utils_testsuite.f90
+++ b/src/tests/utils_testsuite.f90
@@ -629,16 +629,21 @@ end subroutine checkvalbuf_int
 !  (buffered: reports on errors only and ndiff is a running total)
 !+
 !----------------------------------------------------------------
-subroutine checkvalbuf_real(xi,val,tol,label,ndiff,ncheck,errmax)
+subroutine checkvalbuf_real(xi,val,tol,label,ndiff,ncheck,errmax,use_rel_tol)
  real,             intent(in)    :: xi
  real,             intent(in)    :: val,tol
  character(len=*), intent(in)    :: label
  integer,          intent(inout) :: ndiff,ncheck
  real,             intent(inout) :: errmax
+ logical, intent(in), optional   :: use_rel_tol
  real :: erri
+ logical :: rel_tol
+
+ rel_tol = .false.
+ if (present(use_rel_tol)) rel_tol = use_rel_tol
 
  erri = abs(xi-val)
- if (abs(val) > smallval .and. erri > tol) erri = erri/abs(val)
+ if (rel_tol .or. (abs(val) > smallval .and. erri > tol)) erri = erri/abs(val)
 
  ncheck = ncheck + 1
  if (erri > tol .or. erri /= erri) then


### PR DESCRIPTION
- Add optional flag to force checkvalbuf_real to use relative instead of absolute tolerances.
- Require tolerance of 1e-15 for ieos=12 (ideal gas+rad) forward-backward test. Previous tolerance was 1e-12.
- Tighter tolerance of ieos=20 (gas+rad+rec) temperature solving from 1e-13 to 1e-15. Adjust tolerance for forward-backward test for ieos=20 from 1e-12 to 1e-14 (it does not have an error < 1e-15 and I don't know why).