### PR TITLE
(dust_nucleation) fix calculation of gamma

### DIFF
--- a/src/main/dust_formation.f90
+++ b/src/main/dust_formation.f90
@@ -405,7 +405,7 @@ subroutine calc_muGamma(rho_cgs, T, mu, gamma, pH, pH_tot)
        pH2       = KH2*pH**2
        mu        = (1.+4.*eps(iHe))/(.5+eps(iHe)+0.5*pH/pH_tot)
        x         = 2.*(1.+4.*eps(iHe))/mu
-       gamma     = (3.*x+4.-3.*eps(iHe))/(x+4.+eps(iHe))
+       gamma     = (3.*x+4.+4.*eps(iHe))/(x+4.+4.*eps(iHe))
        converged = (abs(T-T_old)/T_old) < tol
        if (i == 1) then
           mu_old = mu


### PR DESCRIPTION
Type of PR: 
Bug fix 

Description:
when using ieos=2 with nucleation,  a discontinuity was present in the profile of gamma (polytropic index) due to an error in its formulation. 

Testing:
the new wind profiles do not show the discontinuity in gamma anymore

Did you run the bots? no

Did you update relevant documentation in the docs directory? no