### PR TITLE
increase maxdensits to converge on density even with bad guess for h after splitting

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,18 +18,18 @@ Arnaud Vericel <arnaud.vericel@univ-lyon1.fr>
 Mark Hutchison <markahutch@gmail.com>
 Mats Esseldeurs <mats.esseldeurs@kuleuven.be>
 Rebecca Nealon <rebecca.nealon@warwick.ac.uk>
+Yrisch <yannbernard13@gmail.com>
 Elisabeth Borchert <elisabeth.borchert@monash.edu>
 Ward Homan <ward.homan@kuleuven.be>
 Christophe Pinte <christophe.pinte@univ-grenoble-alpes.fr>
-Yrisch <yannbernard13@gmail.com>
 Terrence Tricco <tstricco@mun.ca>
 Stephane Michoulier <stephane.michoulier@gmail.com>
 Simone Ceppi <simo.ceppi@gmail.com>
 Spencer Magnall <spencermagnall@gmail.com>
 Enrico Ragusa <enr.ragusa@gmail.com>
 Caitlyn Hardiman <caitlyn.hardiman1@monash.edu>
-Sergei Biriukov <svbiriukov@gmail.com>
 Cristiano Longarini <cristiano.longarini@unimi.it>
+Sergei Biriukov <svbiriukov@gmail.com>
 Giovanni Dipierro <giovanni.dipierro@leicester.ac.uk>
 Roberto Iaconi <robertoiaconi1@gmail.com>
 Hauke Worpel <hworpel@aip.de>

--- a/src/main/dens.F90
+++ b/src/main/dens.F90
@@ -99,7 +99,7 @@ module densityforce
  !real, parameter    :: cnormk = 1./pi, wab0 = 1., gradh0 = -3.*wab0, radkern2 = 4F.0
  integer, parameter :: isizecellcache = 1000
  integer, parameter :: isizeneighcache = 0
- integer, parameter :: maxdensits = 50
+ integer, parameter :: maxdensits = 100
 
  !--statistics which can be queried later
  integer, private         :: maxneighact,nrelink

--- a/src/main/inject_keplerian.f90
+++ b/src/main/inject_keplerian.f90
@@ -216,11 +216,11 @@ subroutine write_options_inject(iunit)
  call write_inopt(mdot,'mdot','mass injection rate [msun/yr]',iunit)
  call write_inopt(rinj,'rinj','injection radius',iunit)
  if (maxvxyzu >= 4) then
-   call write_inopt(HonR_inj,'HonR_inj','aspect ratio to give temperature at rinj',iunit)
-endif
-if (nptmass >= 1) then
-   call write_inopt(follow_sink,'follow_sink','injection radius is relative to sink particle 1',iunit)
-endif
+    call write_inopt(HonR_inj,'HonR_inj','aspect ratio to give temperature at rinj',iunit)
+ endif
+ if (nptmass >= 1) then
+    call write_inopt(follow_sink,'follow_sink','injection radius is relative to sink particle 1',iunit)
+ endif
 
 end subroutine write_options_inject
 

--- a/src/main/inject_keplerian.f90
+++ b/src/main/inject_keplerian.f90
@@ -8,7 +8,7 @@ module inject
 !
 ! Injection of material at keplerian speed in an accretion disc
 !
-! :References: 
+! :References:
 !
 ! :Owner: Cristiano Longarini
 !
@@ -116,7 +116,7 @@ subroutine inject_particles(time,dtlast,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
  r2min = huge(r2min)
  do i=1,npart
     if (.not.isdead_or_accreted(xyzh(4,i))) then
-       r2 = (xyzh(1,i)-x0(1))**2 + (xyzh(2,i)-x0(2))**2 
+       r2 = (xyzh(1,i)-x0(1))**2 + (xyzh(2,i)-x0(2))**2
        dr2 = abs(r2 - rinj*rinj)
        if (dr2 < r2min) then
           hguess = xyzh(4,i)
@@ -176,8 +176,8 @@ subroutine inject_particles(time,dtlast,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
 
        vphi = vkep*(1. - (zi/rinj)**2)**(-0.75)  ! see Martire et al. (2024)
 
-       xyzi = (/rinj*cosphi,rinj*sinphi,zi/) 
-       vxyz = (/-vphi*sinphi, vphi*cosphi, 0./) 
+       xyzi = (/rinj*cosphi,rinj*sinphi,zi/)
+       vxyz = (/-vphi*sinphi, vphi*cosphi, 0./)
 
        u = 1.5*cs**2
 
@@ -220,7 +220,7 @@ subroutine write_options_inject(iunit)
 endif
 if (nptmass >= 1) then
    call write_inopt(follow_sink,'follow_sink','injection radius is relative to sink particle 1',iunit)
-endif 
+endif
 
 end subroutine write_options_inject
 

--- a/src/main/inject_keplerian.f90
+++ b/src/main/inject_keplerian.f90
@@ -10,14 +10,16 @@ module inject
 !
 ! :References: 
 !
-! :Owner: Daniel Price
+! :Owner: Cristiano Longarini
 !
 ! :Runtime parameters:
-!   - datafile       : *name of data file for wind injection*
-!   - outer_boundary : *kill gas particles outside this radius*
+!   - HonR_inj    : *aspect ratio to give temperature at rinj*
+!   - follow_sink : *injection radius is relative to sink particle 1*
+!   - mdot        : *mass injection rate [msun/yr]*
+!   - rinj        : *injection radius*
 !
-! :Dependencies: dim, eos, infile_utils, io, part, partinject, physcon,
-!   random, units
+! :Dependencies: eos, externalforces, infile_utils, io, options, part,
+!   partinject, physcon, random, units
 !
  implicit none
  character(len=*), parameter, public :: inject_type = 'keplerian'

--- a/src/setup/set_orbit.f90
+++ b/src/setup/set_orbit.f90
@@ -41,6 +41,21 @@ module setorbit
 !
 ! :Runtime parameters: None
 !
+! :Dependencies: infile_utils, physcon, setbinary, setflyby, units
+!
+
+!  While Campbell elements can be used for unbound orbits, they require
+!  specifying the true anomaly at the start of the simulation. This is
+!  not always easy to determine, so the flyby option is provided as an
+!  alternative. There one specifies the initial separation instead, however
+!  the choice of angles is more restricted
+!
+! :References: None
+!
+! :Owner: Daniel Price
+!
+! :Runtime parameters: None
+!
 ! :Dependencies: physcon
 !
  implicit none

--- a/src/setup/setup_grtde.f90
+++ b/src/setup/setup_grtde.f90
@@ -22,8 +22,9 @@ module setup
 !   - theta         : *inclination of orbit (degrees)*
 !
 ! :Dependencies: eos, externalforces, gravwaveutils, infile_utils, io,
-!   kernel, metric, mpidomain, part, physcon, relaxstar, setbinary,
-!   setstar, setup_params, systemutils, timestep, units, vectorutils
+!   kernel, metric, mpidomain, options, part, physcon, relaxstar,
+!   setbinary, setstar, setup_params, systemutils, timestep, units,
+!   vectorutils
 !
  use setstar, only:star_t
  implicit none

--- a/src/utils/analysis_disc_stresses.f90
+++ b/src/utils/analysis_disc_stresses.f90
@@ -12,10 +12,13 @@ module analysis
 !
 ! :Owner: Daniel Price
 !
-! :Runtime parameters: None
+! :Runtime parameters:
+!   - nbins : *Number of radial bins*
+!   - rin   : *Inner Disc Radius*
+!   - rout  : *Outer Disc Radius*
 !
-! :Dependencies: dim, eos, getneighbours, io, kernel, part, physcon,
-!   prompting, units
+! :Dependencies: dim, eos, getneighbours, infile_utils, io, kernel, part,
+!   physcon, prompting, units
 !
  use getneighbours,    only:generate_neighbour_lists, read_neighbours, write_neighbours, &
                            neighcount,neighb,neighmax

--- a/src/utils/analysis_disc_stresses.f90
+++ b/src/utils/analysis_disc_stresses.f90
@@ -128,7 +128,7 @@ subroutine read_analysis_options
     call read_inopt(rout,'rout',db,errcount=nerr)
     call close_db(db)
     if (nerr > 0) then
-      call fatal(trim(analysistype),'Error in reading '//trim(inputfile))
+       call fatal(trim(analysistype),'Error in reading '//trim(inputfile))
     endif
 
  else

--- a/src/utils/analysis_energies.f90
+++ b/src/utils/analysis_energies.f90
@@ -15,7 +15,7 @@ module analysis
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: None
+! :Dependencies: energies, evwrite, metric_tools, options, part
 !
  implicit none
  character(len=20), parameter, public :: analysistype = 'energies'

--- a/src/utils/analysis_energies.f90
+++ b/src/utils/analysis_energies.f90
@@ -37,7 +37,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
  integer,          intent(in) :: num,npart,iunit
  real,             intent(in) :: xyzh(:,:),vxyzu(:,:)
  real,             intent(in) :: particlemass,time
- 
+
  if (gr) then
     call init_metric(npart,xyzh,metrics,metricderivs)
     iexternalforce = 1

--- a/src/utils/phantomanalysis.f90
+++ b/src/utils/phantomanalysis.f90
@@ -14,8 +14,8 @@ program phantomanalysis
 !
 ! :Usage: phantomanalysis dumpfile(s)
 !
-! :Dependencies: analysis, dim, eos, fileutils, infile_utils, io, kernel,
-!   part, readwrite_dumps
+! :Dependencies: analysis, dim, eos, externalforces, fileutils,
+!   infile_utils, io, kernel, part, readwrite_dumps
 !
  use dim,             only:tagline,do_nucleation,inucleation
  use part,            only:xyzh,hfact,massoftype,vxyzu,npart !,npartoftype


### PR DESCRIPTION
Type of PR: 
Bug fix, fixes #517 

Description:
See #517, increase maximum number of density iterations

Testing:
Tested on dump and .in in #517

Did you run the bots? yes

Did you update relevant documentation in the docs directory? no