### PR TITLE
(gr) can use tabulated metric independently of einstein toolkit

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -488,7 +488,7 @@ ifdef METRIC
 else
     SRCMETRIC= metric_minkowski.f90
 endif
-SRCGR=inverse4x4.f90 einsteintk_utils.f90 $(SRCMETRIC) metric_tools.f90 utils_gr.f90 interpolate3D.f90 tmunu2grid.f90
+SRCGR=inverse4x4.f90 metric_et_utils.f90 einsteintk_utils.f90 $(SRCMETRIC) metric_tools.f90 utils_gr.f90 interpolate3D.f90 tmunu2grid.f90
 #
 # chemistry and cooling
 #
@@ -1229,6 +1229,24 @@ combinedustdumps: checksys checkparams $(OBJCDD)
 
 cleancombinedustdumps:
 	rm -f $(BINDIR)/combinedustdumps
+
+#----------------------------------------------------
+# these are the sources for the tabulate_metric tility
+.PHONY: tabulate_metric
+SRCTAB= io.F90 utils_infiles.f90 metric_${METRIC}.f90 metric_et_utils.f90 tabulate_metric.f90 #metric_tools.F90
+OBJTAB1= $(SRCTAB:.F90=.o)
+OBJTAB= $(OBJTAB1:.f90=.o)
+
+tabulate_metric: checksys $(OBJTAB)
+	@echo ""
+	@echo "tabulate_metric: Because grids are great"
+	@echo ""
+	$(FC) $(FFLAGS) -o $(BINDIR)/$@ $(OBJTAB)
+
+cleantabulatemetric:
+	rm -f $(BINDIR)/tabulate_metric
+
+
 
 
 include Makefile_qscripts

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -41,7 +41,7 @@ contains
 !+
 !----------------------------------------------------------------
 subroutine initialise()
- use dim,              only:mpi
+ use dim,              only:mpi,gr
  use io,               only:fatal,die,id,master,nprocs,ievfile
 #ifdef FINVSQRT
  use fastmath,         only:testsqrt
@@ -56,6 +56,8 @@ subroutine initialise()
  use cpuinfo,          only:print_cpuinfo
  use checkoptions,     only:check_compile_time_settings
  use readwrite_dumps,  only:init_readwrite_dumps
+ use metric,           only:metric_type
+ use metric_et_utils,  only:read_tabulated_metric,gridinit
  integer :: ierr
 !
 !--write 'PHANTOM' and code version
@@ -99,6 +101,13 @@ subroutine initialise()
 !--initialise MPI domains
 !
  call init_domains(nprocs)
+!
+!--initialise metric if tabulated
+!
+ if (gr  .and. metric_type=='et') then
+    call read_tabulated_metric('tabuled_metric.dat',ierr)
+    gridinit = .true.
+ endif
 
  call init_readwrite_dumps()
 

--- a/src/main/metric_et_utils.f90
+++ b/src/main/metric_et_utils.f90
@@ -1,0 +1,150 @@
+module metric_et_utils
+  implicit none
+
+  real, allocatable :: gcovgrid(:,:,:,:,:)
+  real, allocatable :: gcongrid(:,:,:,:,:)
+  real, allocatable :: sqrtggrid(:,:,:)
+  real, allocatable :: metricderivsgrid(:,:,:,:,:,:)
+  real              :: dxgrid(3), gridorigin(3)
+  integer           :: gridsize(3)
+  logical           :: gridinit = .false.
+
+  ! Declaration of grid limits and dimensions
+  integer, public :: nx,ny,nz
+  real, parameter :: xmin = -10.0, xmax = 10.0
+  real, parameter :: ymin = -10.0, ymax = 10.0
+  real, parameter :: zmin = -10.0, zmax = 10.0
+  real, parameter :: mass = 1.0  ! Mass of the central object
+  
+  contains
+  
+  subroutine allocate_grid(nxin,nyin,nzin,dx,dy,dz,originx,originy,originz)
+    integer, intent(in) :: nxin,nyin,nzin
+    real, intent(in) :: dx,dy,dz,originx,originy,originz
+
+    nx = nxin
+    ny = nyin
+    nz = nzin
+    gridsize(1) = nx
+    gridsize(2) = ny
+    gridsize(3) = nz
+   
+    dxgrid(1) = dx
+    dxgrid(2) = dy
+    dxgrid(3) = dz
+   
+    gridorigin(1) = originx
+    gridorigin(2) = originy
+    gridorigin(3) = originz
+
+   allocate(gcovgrid(0:3,0:3,nx,ny,nz))
+   allocate(gcongrid(0:3,0:3,nx,ny,nz))
+   allocate(sqrtggrid(nx,ny,nz))
+  
+   !metric derivs are stored in the form
+   ! mu comp, nu comp, deriv, gridx,gridy,gridz
+   ! Note that this is only the spatial derivs of
+   ! the metric and we will need an additional array
+   ! for time derivs
+   allocate(metricderivsgrid(0:3,0:3,3,nx,ny,nz))
+  
+  end subroutine allocate_grid
+
+  subroutine initialize_grid()
+    ! Local variable declarations
+    real :: dx, dy, dz, x0(3)
+
+    nx = 100
+    ny = 100
+    nz = 100
+
+    ! Calculate the step size in each direction
+    dx = (xmax - xmin) / (nx - 1)
+    dy = (ymax - ymin) / (ny - 1)
+    dz = (zmax - zmin) / (nz - 1)
+
+    x0 = [0.,0.,0.]
+    call allocate_grid(nx,ny,nz,dx,dy,dz,x0(1),x0(2),x0(3))
+
+    gridinit = .true.
+
+  end subroutine initialize_grid
+
+  subroutine print_metric_grid()
+    ! Subroutine for printing quantities of the ET grid
+   
+    print*, "Grid spacing (x,y,z) is : ", dxgrid
+    print*, "Grid origin (x,y,z) is: ", gridorigin
+    print*, "Covariant metric tensor of the grid is: ", gcovgrid(:,:,1,1,1)
+   
+  end subroutine print_metric_grid
+
+  subroutine write_tabulated_metric(metric_file, ierr)
+    character(len=*), intent(in) :: metric_file
+    integer, intent(out) :: ierr
+    integer :: iunit
+
+    ! Open the file for writing
+    open(newunit=iunit, file=metric_file, status='replace', form='unformatted',action='write', iostat=ierr)
+    if (ierr /= 0) then
+        ierr = 1
+        return
+    endif
+
+    ! Write the dimensions of the grid
+    write(iunit) gridsize
+
+    ! Write the grid origin and spacing
+    write(iunit) gridorigin
+    write(iunit) dxgrid
+
+    ! Write the metric values to the file
+    write(iunit) gcovgrid
+    write(iunit) gcongrid
+    write(iunit) sqrtggrid
+    write(iunit) metricderivsgrid
+
+    ! Close the file
+    close(iunit)
+    ierr = 0
+  end subroutine write_tabulated_metric
+
+  subroutine read_tabulated_metric(metric_file, ierr)
+    character(len=*), intent(in) :: metric_file
+    integer, intent(out) :: ierr
+    integer :: iunit
+  
+
+    ! Open the file for reading
+    open(newunit=iunit, file=metric_file, status='old',  form='unformatted', action='read', iostat=ierr)
+    if (ierr /= 0) return
+
+    ! Read the dimensions of the grid
+    read(iunit) gridsize
+
+    ! Read the grid origin and spacing
+    read(iunit) gridorigin
+    read(iunit) dxgrid
+
+    nx = gridsize(1)
+    ny = gridsize(2)
+    nz = gridsize(3)
+
+    call allocate_grid(nx,ny,nz,&
+        dxgrid(1),dxgrid(2),dxgrid(3),&
+        gridorigin(1),gridorigin(2),gridorigin(3))
+
+    ! Read the metric values from the file
+    read(iunit) gcovgrid
+    read(iunit) gcongrid
+    read(iunit) sqrtggrid
+    read(iunit) metricderivsgrid
+
+    gridinit = .true.
+
+    ! Close the file
+    close(iunit)
+    ierr = 0
+  end subroutine read_tabulated_metric
+
+end module metric_et_utils

--- a/src/utils/einsteintk_utils.f90
+++ b/src/utils/einsteintk_utils.f90
@@ -16,22 +16,18 @@ module einsteintk_utils
 !
 ! :Dependencies: part
 !
+ use metric_et_utils, only:gridorigin,dxgrid,gridsize
  implicit none
- real, allocatable :: gcovgrid(:,:,:,:,:)
- real, allocatable :: gcongrid(:,:,:,:,:)
- real, allocatable :: sqrtggrid(:,:,:)
  real, allocatable :: tmunugrid(:,:,:,:,:)
  real, allocatable :: rhostargrid(:,:,:)
  real, allocatable :: pxgrid(:,:,:,:)
  real, allocatable :: entropygrid(:,:,:)
- real, allocatable :: metricderivsgrid(:,:,:,:,:,:)
- real              :: dxgrid(3), gridorigin(3), boundsize(3)
- integer           :: gridsize(3)
- logical           :: gridinit = .false.
+ real              :: boundsize(3)
  logical           :: exact_rendering
  character(len=128)  :: logfilestor,evfilestor,dumpfilestor,infilestor
 contains
 subroutine init_etgrid(nx,ny,nz,dx,dy,dz,originx,originy,originz)
+ use metric_et_utils, only:allocate_grid,gridsize,dxgrid,gridorigin
  integer, intent(in) :: nx,ny,nz
  real,    intent(in) :: dx,dy,dz,originx,originy,originz
 
@@ -47,40 +43,24 @@ subroutine init_etgrid(nx,ny,nz,dx,dy,dz,originx,originy,originz)
  gridorigin(2) = originy
  gridorigin(3) = originz
 
-
- allocate(gcovgrid(0:3,0:3,nx,ny,nz))
- allocate(gcongrid(0:3,0:3,nx,ny,nz))
- allocate(sqrtggrid(nx,ny,nz))
+ call allocate_grid(nx,ny,nz,dx,dy,dz,originx,originy,originz)
 
  ! Will need to delete this at somepoint
  ! For now it is the simplest way
  allocate(tmunugrid(0:3,0:3,nx,ny,nz))
-
  allocate(pxgrid(3,nx,ny,nz))
-
  allocate(rhostargrid(nx,ny,nz))
-
  allocate(entropygrid(nx,ny,nz))
 
- ! metric derivs are stored in the form
- ! mu comp, nu comp, deriv, gridx,gridy,gridz
- ! Note that this is only the spatial derivs of
- ! the metric and we will need an additional array
- ! for time derivs
- allocate(metricderivsgrid(0:3,0:3,3,nx,ny,nz))
-
- gridinit = .true.
  !exact_rendering = exact
 
 end subroutine init_etgrid
 
 subroutine print_etgrid()
- ! Subroutine for printing quantities of the ET grid
-
- print*, "Grid spacing (x,y,z) is : ", dxgrid
- print*, "Grid origin (x,y,z) is: ", gridorigin
- print*, "Covariant metric tensor of the grid is: ", gcovgrid(:,:,1,1,1)
-
+ use metric_et_utils, only:print_metric_grid
+ 
+ call print_metric_grid()
+ 
 end subroutine print_etgrid
 
 subroutine get_particle_rhs(i,vx,vy,vz,fx,fy,fz,e_rhs)

--- a/src/utils/tabulate_metric.f90
+++ b/src/utils/tabulate_metric.f90
@@ -1,0 +1,67 @@
+program tabulate_metric
+    use metric_et_utils
+    !use metric
+
+    implicit none
+  
+    integer :: ierr 
+    character(len=64) :: metric_file = 'tabuled_metric.dat'
+
+
+    ! Init grid and tabulated metric
+    call initialize_grid()
+    
+    ! Fill and interpolate metric in the grid
+    call fill_grid()
+
+    ! Write Data in file
+    call write_tabulated_metric(metric_file, ierr)
+
+    if (ierr /= 0) then
+        print *, 'Error writing metric data to file'
+      else
+        print *, 'Metric data successfully written to file'
+    endif
+
+contains
+
+subroutine fill_grid()
+    use metric
+    integer :: i, j, k
+    real :: dx, dy, dz
+    real :: position(3)
+    real :: gcov(0:3,0:3)
+    real :: gcon(0:3,0:3)
+    real :: sqrtg
+    real :: dgcovdx(0:3,0:3)
+    real :: dgcovdy(0:3,0:3)
+    real :: dgcovdz(0:3,0:3)
+    ! Triple loop to fill the grid
+    dx = (xmax - xmin) / (nx - 1)
+    dy = (ymax - ymin) / (ny - 1)
+    dz = (zmax - zmin) / (nz - 1)
+
+    do i = 1, nx
+        do j = 1, ny
+          do k = 1, nz
+            ! Calculate the current position in the grid
+            position(1) = xmin + (i - 1) * dx
+            position(2) = ymin + (j - 1) * dy
+            position(3) = zmin + (k - 1) * dz
+            ! Store the calculated values in the grid arrays
+            call get_metric_cartesian(position,gcov,gcon,sqrtg)
+            !call get_metric_derivs(position,dgcovdx, dgcovdy, dgcovdz)
+            call metric_cartesian_derivatives(position,dgcovdx, dgcovdy, dgcovdz)
+            gcovgrid(:,:,i,j,k) = gcov
+            gcongrid(:,:,i,j,k) = gcon
+            sqrtggrid(i,j,k) = sqrtg
+            metricderivsgrid(:,:,1,i,j,k) = dgcovdx
+            metricderivsgrid(:,:,2,i,j,k) = dgcovdy
+            metricderivsgrid(:,:,3,i,j,k) = dgcovdz
+          end do
+        end do
+      end do
+end subroutine fill_grid
+
+end program tabulate_metric
+


### PR DESCRIPTION
Type of PR: 
other

Description:
(gr) can use tabulated metric independently of einstein toolkit

Testing:
```
~/phantom/scripts/writemake.sh gr_testparticles > Makefile
make tabulate_metric
./tabulate_metric
make METRIC=et
make METRIC=et setup
./phantomsetup grtest
./phantom grtest.in
```
Did you run the bots? no

Did you update relevant documentation in the docs directory? no