### PR TITLE
(#580) fix failing github actions tests by moving data files to Zenodo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ build/phantom-version.h
 *~
 */*~
 */*/*~
+eos_binary_table.dat
+helm_data.tab
+forcing.dat
 *.bindata
 *.pyc
 #*

--- a/docs/developer-guide/datafiles.rst
+++ b/docs/developer-guide/datafiles.rst
@@ -57,10 +57,29 @@ For large data files, the procedure is as follows:
 
 2. Add the name of the file to the **.gitignore** file in the root-level
    phantom directory
-3. Then, send your file to daniel.price@monash.edu (e.g. via Dropbox) to
-   store on the phantom website
-4. Implement the call in the code as previously using the
+3. Then, upload your file(s) to a repository on zenodo.org, obtain
+   the DOI for the repository, and submit it in the phantom zenodo community
+
+   https://zenodo.org/communities/phantom/
+
+   This will allow the file to be downloaded
+   by Phantom users at runtime
+4. Edit the datafiles.f90 module to include the URL for the file in the
+   **map_dir_to_web** routine. This routine maps the directory where the
+   file should be located to the URL where the file can be downloaded
+   from. For example, if the file is in the
+   **star_data_files/red_giant** directory, you would add a case to the
+   routine like so:
+
+::
+
+    case('data/star_data_files/red_giant')
+         url = 'https://zenodo.org/records/12345678/files/'
+
+    where the URL is the URL of the repository on zenodo.org
+
+5. Implement the call in the code as previously using the
    find_phantom_datafile routine. This will automatically retrieve the
-   file from the web into your phantom/data directory at runtime (using
-   wget). Alternatively you can manually place the file in the
+   file from the web into your phantom/data directory at runtime.
+   Alternatively you can manually download the file to the
    appropriate folder

--- a/scripts/test_analysis_ce.sh
+++ b/scripts/test_analysis_ce.sh
@@ -12,7 +12,7 @@ rm -f *.ev *txt
 # grab the data file from the server if it doesn't already exist
 file=binary_01000
 if [ ! -f $file ]; then
-   curl -k https://users.monash.edu.au/~dprice/phantom/data/tests/test_analysis_ce/binary_01000 -o binary_01000; err=$?;
+   curl -k https://zenodo.org/records/13163487/files/binary_01000 -o binary_01000; err=$?;
    if [ $err -gt 0 ]; then
       exit $err;
    fi

--- a/src/main/datafiles.f90
+++ b/src/main/datafiles.f90
@@ -7,8 +7,8 @@
 module datafiles
 !
 ! Interface to routine to search for external data files
-!   This module just provides the url and environment variable
-!   settings that are specific to Phantom
+! This module just provides the url and environment variable
+! settings that are specific to Phantom
 !
 ! :References: None
 !
@@ -19,11 +19,14 @@ module datafiles
 ! :Dependencies: datautils, io, mpiutils
 !
  implicit none
- character(len=*), parameter :: data_url = &
-  'https://users.monash.edu.au/~dprice/phantom/'
 
 contains
 
+!----------------------------------------------------------------
+!+
+!  Find a datafile in the Phantom data directory
+!+
+!----------------------------------------------------------------
 function find_phantom_datafile(filename,loc)
  use datautils, only:find_datafile
  use io,        only:id,master
@@ -34,7 +37,8 @@ function find_phantom_datafile(filename,loc)
 
  search_dir = 'data/'//trim(adjustl(loc))
  if (id == master) then ! search for and download datafile if necessary
-    find_phantom_datafile = find_datafile(filename,dir=search_dir,env_var='PHANTOM_DIR',url=data_url)
+    find_phantom_datafile = find_datafile(filename,dir=search_dir,env_var='PHANTOM_DIR',&
+                            url=map_dir_to_web(trim(search_dir)))
  endif
  call barrier_mpi()
  if (id /= master) then ! find datafile location, do not attempt to download it
@@ -43,5 +47,37 @@ function find_phantom_datafile(filename,loc)
  endif
 
 end function find_phantom_datafile
+
+!----------------------------------------------------------------
+!+
+!  Find the web location for files that are not in the Phantom
+!  git repo, which need to be downloaded into the data directory
+!  at runtime
+!+
+!----------------------------------------------------------------
+function map_dir_to_web(search_dir) result(url)
+ character(len=*), intent(in) :: search_dir
+ character(len=120) :: url
+
+ !print*,' search_dir=',trim(search_dir)
+ select case(search_dir)
+ case('data/eos/mesa')
+    url = 'https://zenodo.org/records/13148447/files/'
+ case('data/eos/shen')
+    url = 'https://zenodo.org/records/13163155/files/'
+ case('data/eos/helmholtz')
+    url = 'https://zenodo.org/records/13163286/files/'
+ case('data/forcing')
+    url = 'https://zenodo.org/records/13162225/files/'
+ case('data/velfield')
+    url = 'https://zenodo.org/records/13162515/files/'
+ case('data/galaxy_merger')
+    url = 'https://zenodo.org/records/13162815/files/'
+ case default
+    url = 'https://users.monash.edu.au/~dprice/'//trim(search_dir)
+ end select
+ !print*,'url=',trim(new_url)
+
+end function map_dir_to_web
 
 end module datafiles

--- a/src/main/datafiles.f90
+++ b/src/main/datafiles.f90
@@ -73,6 +73,8 @@ function map_dir_to_web(search_dir) result(url)
     url = 'https://zenodo.org/records/13162515/files/'
  case('data/galaxy_merger')
     url = 'https://zenodo.org/records/13162815/files/'
+ case('data/starcluster')
+    url = 'https://zenodo.org/records/13164858/files/'
  case default
     url = 'https://users.monash.edu.au/~dprice/'//trim(search_dir)
  end select

--- a/src/main/utils_datafiles.f90
+++ b/src/main/utils_datafiles.f90
@@ -79,11 +79,6 @@ function find_datafile(filename,dir,env_var,url,verbose) result(filepath)
              ! try to download the file from a remote url
              !
              my_url = url
-             if (present(dir)) then
-                if (len_trim(dir) > 0) my_url = trim(url)//'/'//trim(dir)//'/'
-             else
-                my_url = url
-             endif
              call download_datafile(trim(my_url),trim(mydir),trim(filename),filepath,ierr)
              if (ierr == 0) then
                 inquire(file=trim(filepath),exist=iexist)


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
Fixes #580, this should fix failures occurring in all pull requests due to failures to download files from my webpage

Testing:
make SETUP=test phantomtest && ./bin/phantomtest eos

Did you run the bots? no

Did you update relevant documentation in the docs directory? yes