### PR TITLE
(substepping) reverse 0e0cc6d patch on the particle type sent to ptmass_accrete

### DIFF
--- a/src/main/substepping.F90
+++ b/src/main/substepping.F90
@@ -773,10 +773,7 @@ subroutine kick(dki,dt,npart,nptmass,ntypes,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,
              fxi = fext(1,i)
              fyi = fext(2,i)
              fzi = fext(3,i)
-             if (ind_timesteps) then
-                ibin_wakei = ibin_wake(i)
-                itype = iphase(i)
-             endif
+             if (ind_timesteps) ibin_wakei = ibin_wake(i)
 
              call ptmass_accrete(1,nptmass,xyzh(1,i),xyzh(2,i),xyzh(3,i),xyzh(4,i),&
                               vxyzu(1,i),vxyzu(2,i),vxyzu(3,i),fxi,fyi,fzi,&


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
As noted in #588. There was an issue on the type of particle sent to `ptmass_accrete` when `ntypes<=1`. Only particles on the same `iphase` value  of the first particle in arrays were able to accrete. I proposed a patch 1 month ago to allow only active particles to enter in accretion loop which revealed to be a mistake. Inactive particles are meant to be awakened in the accretion loop if close enough to a sink particle. Then this feature is broken if only active particles are sent in this loop. 

The solution proposed in #588 is then the right one. 


Testing:
One line fix to reverse a mistake... No testing needed

Did you run the bots? no

Did you update relevant documentation in the docs directory? no