### PR TITLE
set isink=1for ieos=6 in case where isink was not set

### DIFF
--- a/src/main/eos.f90
+++ b/src/main/eos.f90
@@ -481,9 +481,8 @@ subroutine init_eos(eos_type,ierr)
     !--Check that if using ieos=6, then isink is set properly
     !
     if (isink==0) then
-       call error('eos','ieos=6, but isink is not set')
-       ierr = ierr_isink_not_set
-       return
+       call error('eos','ieos=6, but isink is not set, setting to 1')
+       isink = 1
     endif
 
  case(8)

--- a/src/setup/setup_disc.f90
+++ b/src/setup/setup_disc.f90
@@ -687,6 +687,7 @@ subroutine equation_of_state(gamma)
              ieos = 6
              print "(/,a)",' setting ieos=6 for locally isothermal disc around sink'
           else
+             isink = 0
              if (discstrat > 0) then
                 ieos = 7
                 print "(/,a)",' setting ieos=7 for locally isothermal disc with stratification'
@@ -695,10 +696,15 @@ subroutine equation_of_state(gamma)
                 polyk2 = (cs*(1./R_ref(onlydisc))**(-qfacdisc2))**2
                 z0 = z0_ref/R_ref(onlydisc)**beta_z
              else
-                ieos = 3
-                print "(/,a)",' setting ieos=3 for locally isothermal disc around origin'
+                if (ieos == 6) then
+                   ! handle the case where ieos=6 is already set in the .in file; do not override this
+                   isink = 1
+                   print "(/,a)",' keeping ieos=6 for locally isothermal disc with bright primary'
+                else
+                   ieos = 3
+                   print "(/,a)",' setting ieos=3 for locally isothermal disc around origin'
+                endif
              endif
-             isink = 0 ! In the case isink==3, to be generalized
           endif
           qfacdisc = qindex(onlydisc)
        endif


### PR DESCRIPTION
Type of PR: 
Bug fix 
Description:
Putting emission source to the primary in circumbinary disc simulation. However, isink was overriten to 0 because for circumbinary disc ieos=3.

Testing:
Running phantom on *.in file succeded.

Did you run the bots? no

Did you update relevant documentation in the docs directory? no