### PR TITLE
fix windtunnel injection so it works for arbitrary wind parameters

### DIFF
--- a/src/main/inject_windtunnel.f90
+++ b/src/main/inject_windtunnel.f90
@@ -32,27 +32,26 @@ module inject
  character(len=*), parameter, public :: inject_type = 'windtunnel'
 
  public :: init_inject,inject_particles,write_options_inject,read_options_inject,&
-           set_default_options_inject,update_injected_par,windonly
+           set_default_options_inject,update_injected_par
 !
 !--runtime settings for this module
 !
-
- logical :: windonly = .false.
-
  ! Main parameters: model MS6 from Ruffert & Arnett (1994)
  real,    public :: v_inf = 1.
  real,    public :: rho_inf = 1.
- real,    public :: pres_inf = 1.
- real,    public :: Rstar = .1
- integer, public :: nstar  = 0
+ real,    public :: mach = 13.87
 
  ! Particle-related parameters
- integer, public :: hold_star = 0
  integer, public :: lattice_type = 1
  integer, public :: handled_layers = 4
  real,    public :: wind_radius = 30.
  real,    public :: wind_injection_x = -10.
  real,    public :: wind_length = 100.
+
+ ! option to fix the motion of a sphere of particles
+ integer, public :: hold_star = 0
+ real,    public :: Rstar = .1
+ integer, public :: nstar  = 0
 
  private
  real    :: wind_rad,wind_x,psep,distance_between_layers,&
@@ -76,22 +75,18 @@ subroutine init_inject(ierr)
  use dim,        only:maxp
  use io,         only:fatal
  integer, intent(out) :: ierr
- real :: pmass,element_volume,y,z,cs_inf,mach
+ real :: pmass,element_volume,y,z,cs_inf,pres_inf
  integer :: size_y, size_z, pass, i, j
 
  ierr = 0
 
- if (windonly) then
-    nstarpart = 0
- else
-    nstarpart = nstar
- endif
-
+ cs_inf = v_inf/mach
+ pres_inf = cs_inf**2*rho_inf/gamma
+ !mach = v_inf/cs_inf
+ !cs_inf = sqrt(gamma*pres_inf/rho_inf)
  u_inf = pres_inf / (rho_inf*(gamma-1.))
- cs_inf = sqrt(gamma*pres_inf/rho_inf)
- mach = v_inf/cs_inf
- wind_rad = wind_radius * Rstar
- wind_x = wind_injection_x * Rstar
+ wind_rad = wind_radius
+ wind_x = wind_injection_x
  pmass = massoftype(igas)
 
  ! Calculate particle separation between layers given rho_inf, depending on lattice type
@@ -157,7 +152,7 @@ subroutine init_inject(ierr)
     layer_odd(:,:) = layer_even(:,:)
  endif
  h_inf = hfact*(pmass/rho_inf)**(1./3.)
- max_layers = int(wind_length*Rstar/distance_between_layers)
+ max_layers = int(wind_length/distance_between_layers)
  max_particles = int(max_layers*(nodd+neven)/2) + nstarpart
  time_between_layers = distance_between_layers/v_inf
 
@@ -234,7 +229,7 @@ subroutine inject_particles(time,dtlast,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
  irrational_number_close_to_one = 3./pi
  dtinject = (irrational_number_close_to_one*time_between_layers)/utime
 
- if ((hold_star>0) .and. (.not. windonly)) call subtract_star_vcom(nstarpart,xyzh,vxyzu)
+ if (hold_star > 0) call subtract_star_vcom(nstarpart,xyzh,vxyzu)
 
 end subroutine inject_particles
 
@@ -324,13 +319,15 @@ subroutine print_summary(v_inf,cs_inf,rho_inf,pres_inf,mach,pmass,distance_betwe
 
  print*, 'maximum wind layers: ', max_layers
  print*, 'pmass: ',pmass
- print*, 'nstar: ',nstar
- print*, 'nstar + max. wind particles: ', max_particles
  print*, 'distance_between_layers: ',distance_between_layers
  print*, 'time_between_layers: ',time_between_layers
 
- print*, 'planet crossing time: ',2*Rstar/v_inf
- print*, 'wind impact time: ',(abs(wind_injection_x) - Rstar)/v_inf
+ if (hold_star > 0) then
+    print*, 'planet crossing time: ',2*Rstar/v_inf
+    print*, 'wind impact time: ',(abs(wind_injection_x) - Rstar)/v_inf
+    print*, 'nstar: ',nstar
+ endif
+ print*, 'nstar + max. wind particles: ', max_particles
 
 end subroutine print_summary
 
@@ -345,15 +342,17 @@ subroutine write_options_inject(iunit)
  integer, intent(in) :: iunit
 
  call write_inopt(v_inf,'v_inf','wind speed (code units)',iunit)
- call write_inopt(pres_inf,'pres_inf','ambient pressure (code units)',iunit)
+ call write_inopt(mach,'mach','mach number of injected particles',iunit)
  call write_inopt(rho_inf,'rho_inf','ambient density (code units)',iunit)
- call write_inopt(Rstar,'Rstar','sphere radius (code units)',iunit)
- call write_inopt(nstar,'nstar','No. of particles making up sphere',iunit)  ! need to write actual no. of particles, not nstar_in
  call write_inopt(lattice_type,'lattice_type','0: cubic distribution, 1: closepacked distribution',iunit)
  call write_inopt(handled_layers,'handled_layers','(integer) number of handled BHL wind layers',iunit)
  call write_inopt(hold_star,'hold_star','1: subtract CM velocity of star particles at each timestep',iunit)
- call write_inopt(wind_radius,'BHL_radius','radius of the wind cylinder (in star radii)',iunit)
- call write_inopt(wind_injection_x,'wind_injection_x','x position of the wind injection boundary (in star radii)',iunit)
+ if (hold_star > 0) then
+    call write_inopt(Rstar,'Rstar','radius of sphere where velocities are adjusted (code units)',iunit)
+    call write_inopt(nstar,'nstar','No. of particles that should have their velocity adjusted',iunit)  ! need to write actual no. of particles, not nstar_in
+ endif
+ call write_inopt(wind_radius,'BHL_radius','radius of the wind cylinder (in code units)',iunit)
+ call write_inopt(wind_injection_x,'wind_injection_x','x position of the wind injection boundary (in code units)',iunit)
  call write_inopt(wind_length,'wind_length','crude wind length (in star radii)',iunit)
 
 end subroutine write_options_inject
@@ -380,10 +379,10 @@ subroutine read_options_inject(name,valstring,imatch,igotall,ierr)
     read(valstring,*,iostat=ierr) v_inf
     ngot = ngot + 1
     if (v_inf <= 0.)    call fatal(label,'v_inf must be positive')
- case('pres_inf')
-    read(valstring,*,iostat=ierr) pres_inf
+ case('mach')
+    read(valstring,*,iostat=ierr) mach
     ngot = ngot + 1
-    if (pres_inf <= 0.) call fatal(label,'pres_inf must be positive')
+    if (mach <= 0.) call fatal(label,'mach must be positive')
  case('rho_inf')
     read(valstring,*,iostat=ierr) rho_inf
     ngot = ngot + 1
@@ -419,7 +418,7 @@ subroutine read_options_inject(name,valstring,imatch,igotall,ierr)
     ngot = ngot + 1
  end select
 
- igotall = (ngot >= 11)
+ igotall = (ngot >= 9)
 end subroutine read_options_inject
 
 subroutine set_default_options_inject(flag)


### PR DESCRIPTION
Type of PR: 
modification to existing code

Description:
This p-r fixes the wind tunnel injection and setup options so that they are independent of the desire to add a "star" to the simulation.
- add add_star flag to the .setup file instead of a windonly flag in the injection module
- use the hold_star flag in the inject options to decide whether to adjust velocities inside the star. If this option is off, we do not ask for Mstar or Rstar in the injection options
- ask for Mach number rather than pressure in the injection parameters, as much simpler to understand (and dimensionless). 
- default parameters are set to give the same pres_inf as was previously hardwired (i.e. Mach 13.86)
- take particle mass directly as the input parameter for the mass resolution if no star is added to the setup
- wind_length, wind_radius and wind_injection_x parameters are now taken in code units rather than being in units of Rstar (since Rstar is undefined if no star is added)

Testing:
```~/phantom/scripts/writemake.sh windtunnel > Makefile
make setup; make
./phantomsetup wind
./phantom wind
```

Did you run the bots? no

Did you update relevant documentation in the docs directory? no