### PR TITLE
Fix phantom analysis CE recombination energy vs time not working

### DIFF
--- a/src/main/ionization.f90
+++ b/src/main/ionization.f90
@@ -329,7 +329,8 @@ subroutine get_erec_components(logd,T,X,Y,erec)
 
  call get_xion(logd,T,X,Y,xi)
 
- erec = sum(erec(1:4)*xi(1:4))
+ ! [clmu] attempted fix
+ erec = e*xi
 
 end subroutine get_erec_components
 

--- a/src/main/ionization.f90
+++ b/src/main/ionization.f90
@@ -328,8 +328,6 @@ subroutine get_erec_components(logd,T,X,Y,erec)
  e(4) = eion(4)*Y*0.25
 
  call get_xion(logd,T,X,Y,xi)
-
- ! [clmu] attempted fix
  erec = e*xi
 
 end subroutine get_erec_components

--- a/src/utils/analysis_common_envelope.f90
+++ b/src/utils/analysis_common_envelope.f90
@@ -170,7 +170,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
  case(27) ! Analyse disk around companion
     call analyse_disk(num,npart,particlemass,xyzh,vxyzu)
  case(28) ! Recombination energy vs. time
-    call erec_vs_t(time,npart,particlemass,xyzh)
+    call erec_vs_t(time,npart,particlemass,xyzh,vxyzu)
  case(29) ! Binding energy profile
     call create_bindingEnergy_profile(time,num,npart,particlemass,xyzh,vxyzu)
  case(30) ! Planet coordinates and mass
@@ -3682,23 +3682,26 @@ end subroutine analyse_disk
 !  Recombination energy vs. time
 !+
 !----------------------------------------------------------------
-subroutine erec_vs_t(time,npart,particlemass,xyzh)
- use ionization_mod, only:get_erec_components
+subroutine erec_vs_t(time,npart,particlemass,xyzh,vxyzu)
+ use ionization_mod, only:ionization_setup,get_erec_components
  integer, intent(in) :: npart
  real, intent(in)    :: time,particlemass
- real, intent(inout) :: xyzh(:,:)
+ real, intent(inout) :: xyzh(:,:),vxyzu(:,:)
  character(len=17)   :: filename,columns(4)
  integer             :: i
- real                :: ereci(4),erec(4),tempi,rhoi
+ real                :: ereci(4),erec(4),tempi,rhoi,spsoundi,ponrhoi
 
  columns = (/'          H2', &
              '          HI', &
              '         HeI', &
              '        HeII'/)
 
+ call ionization_setup
+
  erec = 0.
  do i = 1,npart
     rhoi = rhoh(xyzh(4,i), particlemass)
+    call equationofstate(ieos,ponrhoi,spsoundi,rhoi,xyzh(1,i),xyzh(2,i),xyzh(3,i),tempi,vxyzu(4,i))
     call get_erec_components( log10(rhoi*unit_density), tempi, X_in, 1.-X_in-Z_in, ereci)
     erec = erec + ereci
  enddo


### PR DESCRIPTION
Type of PR:
Bug fix

Description:
 phantom analysis CE recombination energy vs time not working

Testing:
Describe how you have tested the change

Did you run the bots? yes/no

Did you update relevant documentation in the docs directory? yes/no