### PR TITLE
Relax asteroids

### DIFF
--- a/src/main/cons2prim.f90
+++ b/src/main/cons2prim.f90
@@ -368,7 +368,7 @@ subroutine cons2prim_everything(npart,xyzh,vxyzu,dvdx,rad,eos_vars,radprop,&
        if (use_krome) gammai = eos_vars(igamma,i)
        if (maxvxyzu >= 4) then
           uui = vxyzu(4,i)
-          if (uui < 0.) then
+          if (uui < 0. .and. .not. ieos==23) then
              call warning('cons2prim','Internal energy < 0',i,'u',uui)
           endif
           call equationofstate(ieos,p_on_rhogas,spsound,rhogas,xi,yi,zi,temperaturei,eni=uui,&

--- a/src/main/eos.f90
+++ b/src/main/eos.f90
@@ -66,7 +66,7 @@ module eos
  public  :: init_eos,finish_eos,write_options_eos,read_options_eos
  public  :: write_headeropts_eos,read_headeropts_eos
  public  :: eos_requires_isothermal,eos_requires_polyk
- public  :: eos_is_not_implemented
+ public  :: eos_is_not_implemented,eos_has_pressure_without_u
 
  public :: irecomb  ! propagated from eos_gasradrec
 
@@ -1385,6 +1385,20 @@ end function eos_requires_polyk
 
 !-----------------------------------------------------------------------
 !+
+!  Query function for whether the equation of state can get
+!  a non-zero pressure even if no thermal energy is set
+!+
+!-----------------------------------------------------------------------
+logical function eos_has_pressure_without_u(ieos)
+ integer, intent(in) :: ieos
+
+ eos_has_pressure_without_u = eos_requires_isothermal(ieos) .or. &
+                              ieos==9 .or. ieos==16 .or. ieos == 23
+
+end function eos_has_pressure_without_u
+
+!-----------------------------------------------------------------------
+!+
 !  function to skip unimplemented eos choices
 !+
 !-----------------------------------------------------------------------
@@ -1412,6 +1426,7 @@ subroutine eosinfo(eos_type,iprint)
  use eos_barotropic, only:eos_info_barotropic
  use eos_piecewise,  only:eos_info_piecewise
  use eos_gasradrec,  only:eos_info_gasradrec
+ use eos_tillotson,  only:eos_info_tillotson
  integer, intent(in) :: eos_type,iprint
 
  if (id/=master) return
@@ -1459,6 +1474,8 @@ subroutine eosinfo(eos_type,iprint)
     else
        write(*,'(1x,a,f10.6,a,f10.6)') 'Using fixed composition X = ',X_in,", Z = ",Z_in
     endif
+ case(23)
+    call eos_info_tillotson(iprint)
  end select
  write(iprint,*)
 
@@ -1659,8 +1676,5 @@ subroutine read_options_eos(name,valstring,imatch,igotall,ierr)
                        .and. igotall_tillotson
 
 end subroutine read_options_eos
-
-
-!-----------------------------------------------------------------------
 
 end module eos

--- a/src/main/eos_tillotson.f90
+++ b/src/main/eos_tillotson.f90
@@ -153,6 +153,10 @@ subroutine eos_info_tillotson(iprint)
  integer, intent(in) :: iprint
 
  write(iprint,"(/,a)") ' Tillotson EoS'
+ write(iprint,"(a,1pg10.3,a)") '  rho_0 = ',rho_0,' g/cm^3 [density at which P=0]'
+ write(iprint,"(a,1pg10.3,a)") '    u_0 = ',u_0, ' erg/g  [reference specific energy]'
+ write(iprint,"(a,1pg10.3,a)") '   u_iv = ',u_iv,' erg/g  [energy of incipient vaporisation]'
+ write(iprint,"(a,1pg10.3,a)") '   u_cv = ',u_cv,' erg/g  [energy of complete vaporisation]'
 
 end subroutine eos_info_tillotson
 

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -3016,7 +3016,7 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
        endif
 
        ! cooling timestep dt < fac*u/(du/dt)
-       if (maxvxyzu >= 4 .and. .not. gr) then ! not with gr which uses entropy
+       if (maxvxyzu >= 4 .and. .not. gr .and. .not. (ieos==23)) then ! not with gr which uses entropy
           if (eni + dtc*fxyzu(4,i) < epsilon(0.) .and. eni > epsilon(0.)) dtcool = C_cool*abs(eni/fxyzu(4,i))
        endif
 

--- a/src/main/physcon.f90
+++ b/src/main/physcon.f90
@@ -69,6 +69,7 @@ module physcon
  real(kind=8), parameter :: jupiterm = 1.89813d30               !Mass of Jupiter           g
  real(kind=8), parameter :: jupiterr = 7.1492e9                 !Equatorial radius Jupiter cm
  real(kind=8), parameter :: ceresm = 8.958d23                   !Mass of Ceres             g
+ real(kind=8), parameter :: kg = 1.d3
  real(kind=8), parameter :: gram = 1.d0
 !
 !--Distance scale
@@ -79,6 +80,7 @@ module physcon
  real(kind=8), parameter :: kpc = 3.086d21                      !Kiloparsec                cm
  real(kind=8), parameter :: Mpc = 3.086d24                      !Megaparsec                cm
  real(kind=8), parameter :: km = 1.d5                           !Kilometer                 cm
+ real(kind=8), parameter :: metre = 1.d2                        !Metre                     cm
  real(kind=8), parameter :: cm = 1.d0                           !Centimetre                cm
  real(kind=8), parameter :: mm = 0.1d0                          !Millimetre                cm
  real(kind=8), parameter :: micron = 1.d-4                      !Micron                    cm

--- a/src/main/units.f90
+++ b/src/main/units.f90
@@ -34,7 +34,7 @@ module units
  public :: set_units, set_units_extra, print_units, select_unit
  public :: get_G_code, get_c_code, get_radconst_code, get_kbmh_code
  public :: c_is_unity, G_is_unity, in_geometric_units, in_code_units, in_units
- public :: is_time_unit, is_length_unit, is_mdot_unit
+ public :: is_time_unit, is_length_unit, is_mdot_unit, is_density_unit
  public :: in_solarr, in_solarm, in_solarl
 
  integer, parameter :: len_utype = 10
@@ -291,6 +291,12 @@ subroutine select_unit(string,unit,ierr,unit_type)
  case('c')
     unit = c
     utype = 'velocity'
+ case('g/cm^3','g/cm3','g/cc','g_per_cc','g_per_cm3','g cm^-3')
+    unit = gram/cm**3
+    utype = 'density'
+ case('kg/m^3','kg/m3','kg_per_m3','kg m^-3')
+    unit = kg/metre**3
+    utype = 'density'
  case default
     if (len_trim(unitstr) > 0) ierr = 1
     unit = 1.d0
@@ -358,6 +364,24 @@ end function is_mdot_unit
 
 !------------------------------------------------------------------------------------
 !+
+!  check if string is a unit of mdot
+!+
+!------------------------------------------------------------------------------------
+logical function is_density_unit(string)
+ character(len=*), intent(in) :: string
+ character(len=len_utype) :: unit_type
+ real(kind=8) :: val
+ integer :: ierr
+
+ ierr = 0
+ call select_unit(string,val,ierr,unit_type)
+
+ is_density_unit = (trim(unit_type) == 'density')
+
+end function is_density_unit
+
+!------------------------------------------------------------------------------------
+!+
 !  parse a string like '10.*days' or '10*au' and return the value in code units
 !  if there is no recognisable units, the value is returned unscaled
 !+
@@ -395,6 +419,8 @@ real function in_code_units(string,ierr,unit_type) result(rval)
        rval = real(val/(umass/utime))
     case('luminosity')
        rval = real(val/unit_luminosity)
+    case('density')
+       rval = real(val/unit_density)
     case default
        rval = real(val)  ! no unit conversion
     end select

--- a/src/setup/set_star.f90
+++ b/src/setup/set_star.f90
@@ -156,12 +156,20 @@ end subroutine check_and_convert
 !+
 !--------------------------------------------------------------------------
 subroutine get_star_properties_in_code_units(star,rstar,mstar,rcore,mcore,hsoft,lcore,hacc,nerr)
+ use units,   only:is_density_unit
+ use physcon, only:pi
  type(star_t), intent(in)    :: star
  real,         intent(out)   :: rstar,mstar,rcore,mcore,hsoft,lcore,hacc
  integer,      intent(inout) :: nerr
+ real :: rho0
 
- call check_and_convert(star%r,'stellar radius','length',rstar,nerr)
- call check_and_convert(star%m,'stellar mass','mass',mstar,nerr)
+ call check_and_convert(star%r,'radius','length',rstar,nerr)
+ if (is_density_unit(star%m)) then
+    call check_and_convert(star%m,'density','density',rho0,nerr)
+    mstar = rho0*4./3.*pi*rstar**3
+ else
+    call check_and_convert(star%m,'mass','mass',mstar,nerr)
+ endif
  call check_and_convert(star%rcore,'rcore','length',rcore,nerr)
  call check_and_convert(star%mcore,'mcore','mass',mcore,nerr)
  call check_and_convert(star%hsoft,'core softening','length',hsoft,nerr)
@@ -348,7 +356,7 @@ subroutine set_star(id,master,star,xyzh,vxyzu,eos_vars,rad,&
  !
  if (maxvxyzu==4) call set_star_thermalenergy(ieos,den,pres,r,npts,npart,&
                        xyzh,vxyzu,rad,eos_vars,relax,use_var_comp,star%initialtemp,&
-                       npin=npart_old)
+                       star%polyk,npin=npart_old)
 
  if (do_radiation) then
     if (eos_outputs_mu(ieos)) then
@@ -669,10 +677,10 @@ subroutine set_star_interactive(star)
  if (need_inputprofile(star%iprofile)) then
     call prompt('Enter file name containing input profile',star%input_profile)
  else
-    call prompt('Enter the mass of the star (e.g. 1*msun)',star%m,noblank=.true.)
-    if (need_rstar(star%iprofile)) then
-       call prompt('Enter the radius of the star (e.g. 1*rsun)',star%r,noblank=.true.)
-    endif
+   if (need_rstar(star%iprofile)) then
+      call prompt('Enter the radius of the body (e.g. 1*rsun)',star%r,noblank=.true.)
+   endif
+   call prompt('Enter the mass of the body (e.g. 1*msun)',star%m,noblank=.true.)
  endif
 
  select case (star%iprofile)
@@ -745,14 +753,14 @@ subroutine set_stars_interactive(star,ieos,relax,nstar)
  ! optionally ask for number of stars, otherwise fix nstars to the input array size
  if (present(nstar) .and. size(star) > 1) then
     nstar = 1
-    call prompt('how many stars to set up (0-'//int_to_string(size(star))//')',nstar,0,size(star))
+    call prompt('how many bodies to set up (0-'//int_to_string(size(star))//')',nstar,0,size(star))
     nstars = nstar
  else
     nstars = size(star)
  endif
 
  do i=1,nstars
-    print "(/,'------------- STAR ',i0,'-------------')",i
+    print "(/,'------------- BODY ',i0,'-------------')",i
     call set_star_interactive(star(i))
  enddo
 
@@ -763,7 +771,7 @@ subroutine set_stars_interactive(star,ieos,relax,nstar)
        call set_star_eos_interactive(ieos,star)
 
        relax = .false.
-       call prompt('Relax stars automatically during setup?',relax)
+       call prompt('Relax bodies automatically during setup?',relax)
     endif
  endif
 
@@ -787,7 +795,7 @@ subroutine write_options_star(star,iunit,label)
  c = ''
  if (present(label)) c = trim(adjustl(label))
 
- write(iunit,"(/,a)") '# options for star '//trim(c)
+ write(iunit,"(/,a)") '# options for body '//trim(c)
  call get_optstring(nprofile_opts+1,profile_opt,string,4,from_zero=.true.)
  call write_inopt(star%iprofile,'iprofile'//trim(c),trim(string(1:48)),iunit)
 
@@ -796,9 +804,10 @@ subroutine write_options_star(star,iunit,label)
        call write_inopt(star%input_profile,'input_profile'//trim(c),&
             'Path to input profile',iunit)
     else
-       call write_inopt(star%m,'Mstar'//trim(c),'mass of star '//trim(c)//' (code units or e.g. 1*msun)',iunit)
        if (need_rstar(star%iprofile)) &
-          call write_inopt(star%r,'Rstar'//trim(c),'radius of star'//trim(c)//' (code units or e.g. 1*rsun)',iunit)
+          call write_inopt(star%r,'Rstar'//trim(c),'radius of body '//trim(c)//' (code units or e.g. 1*rsun)',iunit)
+       call write_inopt(star%m,'Mstar'//trim(c),'mass of body '//trim(c)//&
+                        ' (code units or e.g. 1*msun or mean density 2 g/cc)',iunit)
     endif
  endif
 
@@ -935,10 +944,10 @@ subroutine read_options_star(star,db,nerr,label)
     if (need_inputprofile(star%iprofile)) then
        call read_inopt(star%input_profile,'input_profile'//trim(c),db,errcount=nerr)
     else
-       call read_inopt(star%m,'Mstar'//trim(c),db,errcount=nerr,err=ierr)
        if (need_rstar(star%iprofile)) then
           call read_inopt(star%r,'Rstar'//trim(c),db,errcount=nerr,err=ierr)
        endif
+       call read_inopt(star%m,'Mstar'//trim(c),db,errcount=nerr,err=ierr)
     endif
  endif
 
@@ -965,7 +974,7 @@ subroutine write_options_stars(star,relax,write_rho_to_file,ieos,iunit,nstar)
 
  ! optionally ask for number of stars, otherwise fix nstars to the input array size
  if (present(nstar)) then
-    call write_inopt(nstar,'nstars','number of stars to add (0-'//trim(int_to_string(size(star)))//')',iunit)
+    call write_inopt(nstar,'nstars','number of bodies to add (0-'//trim(int_to_string(size(star)))//')',iunit)
     nstars = nstar
  else
     nstars = size(star)
@@ -983,7 +992,7 @@ subroutine write_options_stars(star,relax,write_rho_to_file,ieos,iunit,nstar)
        call write_options_stars_eos(nstars,star(1:nstars),label(1:nstars),ieos,iunit)
 
        write(iunit,"(/,a)") '# relaxation options'
-       call write_inopt(relax,'relax','relax stars into equilibrium',iunit)
+       call write_inopt(relax,'relax','relax bodies into equilibrium',iunit)
        call write_options_relax(iunit)
        call write_inopt(write_rho_to_file,'write_rho_to_file','write density profile(s) to file',iunit)
     endif
@@ -1063,7 +1072,7 @@ subroutine write_options_stars_eos(nstars,star,label,ieos,iunit)
  integer :: i
 
  write(iunit,"(/,a)") '# equation of state used to set the thermal energy profile'
- call write_inopt(ieos,'ieos','1=isothermal,2=adiabatic,10=MESA,12=idealplusrad',iunit)
+ call write_inopt(ieos,'ieos','1=isothermal,2=adiabatic,10=MESA,12=idealplusrad,23=Tillotson',iunit)
 
  if (any(star(:)%iprofile==imesa)) then
     call write_inopt(use_var_comp,'use_var_comp','Use variable composition (X, Z, mu)',iunit)

--- a/src/setup/set_star_utils.f90
+++ b/src/setup/set_star_utils.f90
@@ -454,7 +454,7 @@ end subroutine set_star_composition
 !+
 !-----------------------------------------------------------------------
 subroutine set_star_thermalenergy(ieos,den,pres,r,npts,npart,xyzh,vxyzu,rad,eos_vars,&
-                                  relaxed,use_var_comp,initialtemp,npin,x0)
+                                  relaxed,use_var_comp,initialtemp,polyk_in,npin,x0)
  use part,            only:do_radiation,rhoh,massoftype,igas,itemp,igasP,iX,iZ,imu,iradxi
  use eos,             only:equationofstate,calc_temp_and_ene,gamma,gmw
  use radiation_utils, only:ugas_from_Tgas,radxi_from_Trad
@@ -465,7 +465,7 @@ subroutine set_star_thermalenergy(ieos,den,pres,r,npts,npart,xyzh,vxyzu,rad,eos_
  real,    intent(in)    :: xyzh(:,:)
  real,    intent(inout) :: vxyzu(:,:),eos_vars(:,:),rad(:,:)
  logical, intent(in)    :: relaxed,use_var_comp
- real,    intent(in)    :: initialtemp
+ real,    intent(in)    :: initialtemp,polyk_in
  integer, intent(in), optional :: npin
  real,    intent(in), optional :: x0(3)
  integer :: eos_type,i,ierr
@@ -499,7 +499,7 @@ subroutine set_star_thermalenergy(ieos,den,pres,r,npts,npart,xyzh,vxyzu,rad,eos_
 
     select case(ieos)
     case(23) ! Tillotson
-       vxyzu(4,i) = initialtemp
+       vxyzu(4,i) = 1.5*polyk_in
     case(16) ! Shen EoS
        vxyzu(4,i) = initialtemp
     case(15) ! Helmholtz EoS

--- a/src/setup/setup_solarsystem.f90
+++ b/src/setup/setup_solarsystem.f90
@@ -154,7 +154,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
 
     print "(a,2(es10.3,a))",' mass of apophis is ',m_apophis*umass,&
                             ' g or ',m_apophis*umass/ceresm,' ceres masses'
-    print "(a,1pg10.3,a)",' density is ',m_apophis/(4./3.*pi*r_apophis)*unit_density,' g/cm^3'
+    print "(a,1pg10.3,a)",' density is ',m_apophis/(4./3.*pi*r_apophis**3)*unit_density,' g/cm^3'
 
     rtidal = r_apophis*(earthm/umass/m_apophis)**(1./3.)
     print "(3(a,1pg10.3),a)",' r_tidal is ',rtidal,' au,',rtidal*udist/km,' km, or ',rtidal*udist/earthr,' earth radii'


### PR DESCRIPTION
Type of PR: 
Bug fix / new physics

Description:
- relax_star routine now works when setting up uniform density solar system bodies
- can specify density instead of total mass when setting up stars/bodies by giving appropriate units (e.g. "2 g/cc"). Currently there is an issue parsing units with ^ in the string, so currently must use "g/cc" rather than "g/cm^3" as the density unit.
- also silenced warnings about u < 0 when using Tillotson eos
- issue with initial value of u being hard wired for Tillotson eos fixed

Testing:
Successfully relax uniform density body with ieos=23 via SETUP=star

Did you run the bots? no

Did you update relevant documentation in the docs directory? no