### PR TITLE
(dust) make drag_implicit option visible 

### DIFF
--- a/src/main/checksetup.f90
+++ b/src/main/checksetup.f90
@@ -38,7 +38,7 @@ contains
 !------------------------------------------------------------------
 subroutine check_setup(nerror,nwarn,restart)
  use dim,  only:maxp,maxvxyzu,periodic,use_dust,ndim,mhd,use_dustgrowth,h2chemistry, &
-                do_radiation,n_nden_phantom,mhd_nonideal,do_nucleation,use_krome
+                do_radiation,n_nden_phantom,mhd_nonideal,do_nucleation,use_krome,ind_timesteps
  use part, only:xyzh,massoftype,hfact,vxyzu,npart,npartoftype,nptmass,gravity, &
                 iphase,maxphase,isetphase,labeltype,igas,maxtypes,&
                 idust,xyzmh_ptmass,vxyz_ptmass,iboundary,isdeadh,ll,ideadhead,&
@@ -56,6 +56,7 @@ subroutine check_setup(nerror,nwarn,restart)
  use nicil,           only:n_nden
  use metric_tools,    only:imetric,imet_minkowski
  use physcon,         only:au,solarm
+ use dust,            only:drag_implicit
  integer, intent(out) :: nerror,nwarn
  logical, intent(in), optional :: restart
  integer      :: i,nbad,itype,iu,ndead
@@ -372,6 +373,10 @@ subroutine check_setup(nerror,nwarn,restart)
  if (npartoftype(idust) > 0) then
     if (.not. use_dust) then
        if (id==master) print*,'ERROR: dust particles present but -DDUST is not set'
+       nerror = nerror + 1
+    endif
+    if (use_dust .and. drag_implicit .and. ind_timesteps) then
+       if (id==master) print*,'ERROR: implicit drag does not work with individual timesteps, please recompile with IND_TIMESTEPS=no'
        nerror = nerror + 1
     endif
     if (use_dustfrac) then

--- a/src/main/dust.f90
+++ b/src/main/dust.f90
@@ -323,7 +323,7 @@ subroutine write_options_dust(iunit)
     call write_inopt(ilimitdustflux,'ilimitdustflux','limit the dust flux using Ballabio et al. (2018)',iunit)
  else
     call write_inopt(irecon,'irecon','use reconstruction in gas/dust drag (-1=off,0=no slope limiter,1=van leer MC)',iunit)
-    !call write_inopt(drag_implicit,'drag_implicit','gas/dust drag implicit scheme (!!! Works only with IND_TIMESTEPS=no !!!)',iunit)
+    call write_inopt(drag_implicit,'drag_implicit','gas/dust drag implicit scheme (works only with IND_TIMESTEPS=no)',iunit)
  endif
 
  call write_inopt(icut_backreaction,'icut_backreaction','cut the drag on the gas phase (0=no, 1=yes)',iunit)
@@ -378,8 +378,8 @@ subroutine read_options_dust(name,valstring,imatch,igotall,ierr)
     !--no longer a compulsory parameter
  case('irecon')
     read(valstring,*,iostat=ierr) irecon
-    !case('drag_implicit')
-    !   read(valstring,*,iostat=ierr) drag_implicit
+ case('drag_implicit')
+    read(valstring,*,iostat=ierr) drag_implicit
  case default
     imatch = .false.
  end select


### PR DESCRIPTION
make drag_implicit option visible  in the .in file; give error if IND_TIMESTEPS=yes

Type of PR: 
other

Description:
The option for the Loren-Bate implicit dust scheme was hidden in the code, it is now visible to the user and makes clear that it can only be used if ind_timesteps=no

Testing:
check that code runs (dustydisc) with IND_TIMESTEPS=no, and gives error if IND_TIMESTEPS=yes

Did you run the bots? no

Did you update relevant documentation in the docs directory? no