### PR TITLE
Read KEPLER AGB star and relax it with a sink. 

### DIFF
--- a/src/main/step_leapfrog.F90
+++ b/src/main/step_leapfrog.F90
@@ -274,6 +274,7 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
                             iexternalforce,timei,merge_ij,merge_n,dsdt_ptmass)
        call get_grforce_all(nptmass,xyzmh_ptmass,metrics_ptmass,metricderivs_ptmass,&
                             vxyz_ptmass,fxyz_ptmass,dtextforce,use_sink=.true.)
+       dtextforce = min(dtextforce, C_force*dtsinksink)
        do i=1,nptmass
           fxyz_ptmass(1:3,i) = fxyz_ptmass(1:3,i) + fxyz_ptmass_sinksink(1:3,i)
        enddo
@@ -281,14 +282,13 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
           call get_accel_sink_gas(nptmass,xyzh(1,i),xyzh(2,i),xyzh(3,i),xyzh(4,i),xyzmh_ptmass, &
                                   fext(1,i),fext(2,i),fext(3,i),poti,pmassi,fxyz_ptmass,&
                                   dsdt_ptmass,fonrmax,dtphi2,bin_info)
+          dtextforce = min(dtextforce,C_force*sqrt(dtphi2),C_force*1./sqrt(fonrmax))
        enddo
     endif
 
     if ((iexternalforce > 0 .and. imetric /= imet_minkowski) .or. idamp > 0 .or. nptmass > 0 .or. &
         (nptmass > 0 .and. imetric == imet_minkowski)) then
-
-       ! for now use the minimum of the two timesteps as dtextforce
-       dtextforce = min(dtextforce, C_force*dtsinksink, C_force*sqrt(dtphi2))
+  
        call substep_gr(npart,nptmass,ntypes,dtsph,dtextforce,xyzh,vxyzu,pxyzu,dens,metrics,metricderivs,fext,t,&
                        xyzmh_ptmass,vxyz_ptmass,pxyzu_ptmass,metrics_ptmass,metricderivs_ptmass,fxyz_ptmass)
     else

--- a/src/main/substepping.F90
+++ b/src/main/substepping.F90
@@ -1542,16 +1542,16 @@ subroutine accrete_gr(xyzh,vxyzu,dens,fext,metrics,metricderivs,nlive,naccreted,
        pri = pondensi*dens(i)
 
        call get_grforce(xyzh(:,i),metrics(:,:,:,i),metricderivs(:,:,:,i),vxyzu(1:3,i),dens(i),vxyzu(4,i),pri,fext(1:3,i),dtf)
+       dtextforce_min = min(dtextforce_min,C_force*dtf)
 
        if (nptmass > 0) then
           !$omp critical
           call get_accel_sink_gas(nptmass,xyzh(1,i),xyzh(2,i),xyzh(3,i),xyzh(4,i),xyzmh_ptmass, &
                                   fext(1,i),fext(2,i),fext(3,i),poti,pmassi,fxyz_ptmass,&
                                   dsdt_ptmass,fonrmax,dtphi2,bin_info) 
+          dtextforce_min = min(dtextforce_min,C_force*sqrt(dtphi2))
           !$omp end critical
        endif
-
-       dtextforce_min = min(dtextforce_min,C_force*dtf,C_force*sqrt(dtphi2))
 
        if (idamp > 0) then
           call apply_damp(fext(1,i), fext(2,i), fext(3,i), vxyzu(1:3,i), xyzh(1:3,i), damp_fac)

--- a/src/setup/readwrite_kepler.f90
+++ b/src/setup/readwrite_kepler.f90
@@ -30,15 +30,16 @@ contains
 !  Read in datafile from the KEPLER stellar evolution code
 !+
 !-----------------------------------------------------------------------
-subroutine read_kepler_file(filepath,ng_max,n_rows,rtab,rhotab,ptab,temperature,&
-                            enitab,totmass,composition,comp_label,columns_compo,ierr,mcut,rcut)
+subroutine read_kepler_file(filepath,ng_max,n_rows,rtab,rhotab,ptab,mtab,temperature,&
+                            enitab,totmass,composition,comp_label,Xfrac,Yfrac,columns_compo,&
+                            ierr,mcut,rcut,cgsunits)
  use units,     only:udist,umass,unit_density,unit_pressure,unit_ergg
  use datafiles, only:find_phantom_datafile
  use fileutils, only:get_ncolumns,get_nlines,skip_header,get_column_labels
 
  integer,intent(in)                       :: ng_max
  integer,intent(out)                      :: ierr,n_rows
- real,allocatable,intent(out)             :: rtab(:),rhotab(:),ptab(:),temperature(:),enitab(:)
+ real,allocatable,intent(out)             :: rtab(:),rhotab(:),ptab(:),temperature(:),enitab(:),mtab(:),Xfrac(:),Yfrac(:)
  real,intent(out),allocatable             :: composition(:,:)
  real,intent(out)                         :: totmass
  real,intent(out),optional                :: rcut
@@ -47,6 +48,7 @@ subroutine read_kepler_file(filepath,ng_max,n_rows,rtab,rhotab,ptab,temperature,
  character(len=20),allocatable            :: all_label(:) !This contains all labels read from KEPLER file.
  character(len=*),intent(in)              :: filepath
  integer,intent(out)                      :: columns_compo
+ logical, intent(in), optional            :: cgsunits
 
  character(len=120)                       :: fullfilepath
  character(len=10000)                     :: line
@@ -54,8 +56,10 @@ subroutine read_kepler_file(filepath,ng_max,n_rows,rtab,rhotab,ptab,temperature,
  integer                                  :: k,aloc,i,column_no,n_cols,n_labels,iu
  integer                                  :: nheaderlines,skip_no
  real,allocatable                         :: stardata(:,:)
- logical                                  :: iexist,n_too_big,composition_available
+ logical                                  :: iexist,n_too_big,composition_available,usecgs
 
+ usecgs = .false.
+ if (present(cgsunits)) usecgs = cgsunits
  !
  !--Get path name
  !
@@ -121,7 +125,8 @@ subroutine read_kepler_file(filepath,ng_max,n_rows,rtab,rhotab,ptab,temperature,
 
  !Allocate memory for saving data
  allocate(stardata(n_rows, n_cols))
- allocate(rtab(n_rows),rhotab(n_rows),ptab(n_rows),temperature(n_rows),enitab(n_rows))
+ allocate(Xfrac(n_rows),Yfrac(n_rows))
+ allocate(rtab(n_rows),rhotab(n_rows),ptab(n_rows),temperature(n_rows),enitab(n_rows),mtab(n_rows))
  !
  !--Read the file again and save the data in stardata tensor.
  !
@@ -136,27 +141,37 @@ subroutine read_kepler_file(filepath,ng_max,n_rows,rtab,rhotab,ptab,temperature,
  !--convert relevant data from CGS to code units
  !
  !radius
- stardata(1:n_rows,4)  = stardata(1:n_rows,4)/udist
+ stardata(1:n_rows,4)  = stardata(1:n_rows,4)
  rtab(1:n_rows)        = stardata(1:n_rows,4)
 
  !density
- stardata(1:n_rows,6)  = stardata(1:n_rows,6)/unit_density
+ stardata(1:n_rows,6)  = stardata(1:n_rows,6)
  rhotab(1:n_rows)      = stardata(1:n_rows,6)
  !mass
- stardata(1:n_rows,3)  = stardata(1:n_rows,3)/umass
+ stardata(1:n_rows,3)  = stardata(1:n_rows,3)
+ mtab(1:n_rows)        = stardata(1:n_rows,3)
  totmass               = stardata(n_rows,3)
  !pressure
- stardata(1:n_rows,8)  = stardata(1:n_rows,8)/unit_pressure
+ stardata(1:n_rows,8)  = stardata(1:n_rows,8)
  ptab(1:n_rows)        = stardata(1:n_rows,8)
 
  !temperature
  temperature(1:n_rows) = stardata(1:n_rows,7)
 
  !specific internal energy
- stardata(1:n_rows,9)  = stardata(1:n_rows,9)/unit_ergg
+ stardata(1:n_rows,9)  = stardata(1:n_rows,9)
  enitab(1:n_rows)      = stardata(1:n_rows,9)
 
- print*, totmass*umass, "Total Mass",rtab(n_rows)*udist,"max radius"
+ if (.not. usecgs) then
+    mtab = mtab / umass
+    rtab = rtab / udist
+    ptab = ptab / unit_pressure
+    rhotab = rhotab / unit_density
+    enitab = enitab / unit_ergg
+    totmass = totmass / umass
+ endif 
+
+ print*, 'Total Mass: ', totmass, 'Max radius: ', rtab(n_rows)
 
  !if elements were found in the file read, save the composition by allocating an array
  !else set it to 0
@@ -178,7 +193,12 @@ subroutine read_kepler_file(filepath,ng_max,n_rows,rtab,rhotab,ptab,temperature,
     allocate(composition(0,0))
     allocate(comp_label(0))
  endif
+
+ Xfrac = composition(:,2) ! save H1 fraction
+ Yfrac = composition(:,4) ! save He4 fraction
+
  print*, shape(composition),'shape of composition array'
+
  if (present(rcut) .and. present(mcut)) then
     aloc = minloc(abs(stardata(1:n_rows,1) - mcut),1)
     rcut = rtab(aloc)

--- a/src/setup/relax_star.f90
+++ b/src/setup/relax_star.f90
@@ -60,7 +60,7 @@ subroutine relax_star(nt,rho,pr,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,ierr,np
  use table_utils,     only:yinterp
  use deriv,           only:get_derivs_global
  use dim,             only:maxp,maxvxyzu,gr,gravity,use_apr
- use part,            only:vxyzu,rad,eos_vars,massoftype,igas,apr_level,fxyzu
+ use part,            only:vxyzu,rad,eos_vars,massoftype,igas,apr_level,fxyzu,nptmass,xyzmh_ptmass
  use step_lf_global,  only:init_step,step
  use initial,         only:initialise
  use memory,          only:allocate_memory
@@ -138,6 +138,7 @@ subroutine relax_star(nt,rho,pr,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,ierr,np
  call set_options_for_relaxation(tdyn)
  call summary_initialise()
  if (gr) call shift_star_origin(i1,npart,xyzh,x0)
+ if (gr) call shift_star_origin(i1,nptmass,xyzmh_ptmass,x0)
  !
  ! check particle setup is sensible
  !
@@ -207,7 +208,12 @@ subroutine relax_star(nt,rho,pr,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,ierr,np
    '       WILL stop when Ekin/Epot < ',tol_ekin,' OR Iter=',maxits
 
  if (write_files) then
+    if (gr) call shift_star_origin(i1,npart,xyzh,-x0)
+    if (gr) call shift_star_origin(i1,nptmass,xyzmh_ptmass,-x0)
     if (.not.restart) call write_fulldump(t,filename)
+    ! move star back to 100,0,0
+    if (gr) call shift_star_origin(i1,npart,xyzh,x0)
+    if (gr) call shift_star_origin(i1,nptmass,xyzmh_ptmass,x0)
     open(newunit=iunit,file='relax'//trim(mylabel)//'.ev',status='replace')
     write(iunit,"(a)") '# nits,rmax,etherm,epot,ekin/epot,L2_{err}'
  endif
@@ -292,10 +298,12 @@ subroutine relax_star(nt,rho,pr,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,ierr,np
           if (write_files) then
              ! move star back to 0,0,0
              if (gr) call shift_star_origin(i1,npart,xyzh,-x0)
+             if (gr) call shift_star_origin(i1,nptmass,xyzmh_ptmass,-x0)
              ! write snapshot
              call write_fulldump(t,filename)
              ! move star back to 100,0,0
              if (gr) call shift_star_origin(i1,npart,xyzh,x0)
+             if (gr) call shift_star_origin(i1,nptmass,xyzmh_ptmass,x0)
           endif
 
           ! flush the relax.ev file
@@ -334,9 +342,11 @@ subroutine relax_star(nt,rho,pr,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,ierr,np
  ! unfake some things
  !
  call restore_original_options(i1,npart)
+ call restore_original_options(i1,nptmass)
 
  ! move star back to 0,0,0
  if (gr) call shift_star_origin(i1,npart,xyzh,-x0)
+ if (gr) call shift_star_origin(i1,nptmass,xyzmh_ptmass,-x0)
 
 end subroutine relax_star
 

--- a/src/setup/set_star.f90
+++ b/src/setup/set_star.f90
@@ -684,7 +684,7 @@ subroutine set_star_interactive(star)
  endif
 
  select case (star%iprofile)
- case(imesa)
+ case(imesa,ikepler)
     print*,'Soften the core density profile and add a sink particle core?'
     print "(3(/,a))",'0: Do not soften profile', &
                      '1: Use cubic softened density profile', &
@@ -812,7 +812,7 @@ subroutine write_options_star(star,iunit,label)
  endif
 
  select case(star%iprofile)
- case(imesa)
+ case(imesa,ikepler)
     call write_inopt(star%isoftcore,'isoftcore'//trim(c),&
                      '0=no core softening, 1=cubic, 2=const. entropy',iunit)
 
@@ -820,7 +820,7 @@ subroutine write_options_star(star,iunit,label)
        call write_inopt(star%input_profile,'input_profile'//trim(c),&
                         'Path to input profile',iunit)
        call write_inopt(star%outputfilename,'outputfilename'//trim(c),&
-                        'Output path for softened MESA profile',iunit)
+                        'Output path for softened star profile',iunit)
 
        if (star%isoftcore == 1) then
           call write_inopt(star%isofteningopt,'isofteningopt'//trim(c),&
@@ -901,7 +901,7 @@ subroutine read_options_star(star,db,nerr,label)
  endif
 
  select case(star%iprofile)
- case(imesa)
+ case(imesa,ikepler)
     call read_inopt(star%isoftcore,'isoftcore'//trim(c),db,errcount=nerr,min=0)
 
     if (star%isoftcore <= 0) then ! sink particle core without softening

--- a/src/setup/set_star_utils.f90
+++ b/src/setup/set_star_utils.f90
@@ -79,6 +79,8 @@ subroutine read_star_profile(iprofile,ieos,input_profile,gamma,polyk,ui_coef,&
  use readwrite_kepler,   only:read_kepler_file
  use setsoftenedcore,    only:set_softened_core
  use io,                 only:fatal
+ use units,              only:udist,umass
+ use physcon,            only:solarr,solarm
  integer,           intent(in)    :: iprofile,ieos
  character(len=*),  intent(in)    :: input_profile,outputfilename
  real,              intent(in)    :: ui_coef
@@ -123,10 +125,15 @@ subroutine read_star_profile(iprofile,ieos,input_profile,gamma,polyk,ui_coef,&
     rmin  = r(1)
     Rstar = r(npts)
     pres = polyk*den**gamma
- case(imesa)
+ case(imesa,ikepler)
     deallocate(r,den,pres,temp,en,mtab)
     if (isoftcore > 0) then
-       call read_mesa(input_profile,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,Mstar,ierr,cgsunits=.true.)
+       if (iprofile == imesa) then
+          call read_mesa(input_profile,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,Mstar,ierr,cgsunits=.true.)
+       else 
+          call read_kepler_file(trim(input_profile),ng_max,npts,r,den,pres,mtab,temp,en,&
+                           Mstar,composition,comp_label,Xfrac,Yfrac,columns_compo,ierr,cgsunits=.true.)
+       endif
        allocate(mu(size(den)))
        mu = 0.
        if (ierr /= 0) call fatal('setup','error in reading stellar profile from'//trim(input_profile))
@@ -136,7 +143,11 @@ subroutine read_star_profile(iprofile,ieos,input_profile,gamma,polyk,ui_coef,&
           eos_type = ieos
        endif
        regrid_core = .false.  ! hardwired to be false for now
+       mcore = mcore * umass / solarm ! mcore and rcore needed in solar units for set softened star
+       rcore = rcore * udist / solarr
        call set_softened_core(eos_type,isoftcore,isofteningopt,regrid_core,rcore,mcore,r,den,pres,mtab,Xfrac,Yfrac,ierr)
+       mcore = mcore * solarm / umass
+       rcore = rcore * solarr / udist
        hsoft = rcore/radkern
 
        call solve_uT_profiles(eos_type,r,den,pres,Xfrac,Yfrac,regrid_core,temp,en,mu)
@@ -144,21 +155,18 @@ subroutine read_star_profile(iprofile,ieos,input_profile,gamma,polyk,ui_coef,&
        ! now read the softened profile instead
        call read_mesa(outputfilename,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,Mstar,ierr)
     else
-       call read_mesa(input_profile,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,Mstar,ierr)
+       if (iprofile == imesa) then
+          call read_mesa(input_profile,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,Mstar,ierr)
+       else 
+          call read_kepler_file(trim(input_profile),ng_max,npts,r,den,pres,mtab,temp,en,&
+                Mstar,composition,comp_label,Xfrac,Yfrac,columns_compo,ierr)
+       endif
     endif
     if (ierr==1) call fatal('set_star',trim(input_profile)//' does not exist')
     if (ierr==2) call fatal('set_star','insufficient data points read from file')
     if (ierr==3) call fatal('set_star','too many data points; increase ng')
     if (ierr /= 0) call fatal('set_star','error in reading stellar profile from'//trim(input_profile))
     npts = size(den)
-    rmin  = r(1)
-    Rstar = r(npts)
- case(ikepler)
-    call read_kepler_file(trim(input_profile),ng_max,npts,r,den,pres,temp,en,&
-                          Mstar,composition,comp_label,columns_compo,ierr)
-    if (ierr==1) call fatal('set_star',trim(input_profile)//' does not exist')
-    if (ierr==2) call fatal('set_star','insufficient data points read from file')
-    if (ierr==3) call fatal('set_star','too many data points; increase ng')
     rmin  = r(1)
     Rstar = r(npts)
  case(ievrard)

--- a/src/setup/setup_grtde.f90
+++ b/src/setup/setup_grtde.f90
@@ -338,6 +338,8 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
     do i=1,nstar
        xyzmh_ptmass_in(1:3,i) = xyzmh_ptmass_in(1:3,i) + xyzstar(:)
        vxyz_ptmass_in(1:3,i)  = vxyz_ptmass_in(1:3,i) + vxyzstar(:)
+       xyzmh_ptmass(1:3,i) = xyzmh_ptmass(1:3,i) + xyzstar(:)
+       vxyz_ptmass(1:3,i)  = vxyz_ptmass(1:3,i) + vxyzstar(:)
     enddo
  endif
 


### PR DESCRIPTION
Type of PR: 
modification to existing code + bug fix

Description:
We can now read KEPLER AGB stars and relax them with a sink particle. 
There was a bug inside the substepping.f90 file for sink-gas force in GR which was fixed by using omp critical statement. 
Inside setup_grtde.f90 we displace the sink particle as well. 

Testing:
a sink + gas particles star orbit around each other
two sinks orbit around each other. 
KEPLER AGB star setup around a BH in GR

Did you run the bots? no

Did you update relevant documentation in the docs directory? no