### PR TITLE
Issue with omp reduction

### DIFF
--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -233,7 +233,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
  character(len=*), intent(out) :: logfile,evfile,dumpfile
  logical,          intent(in), optional :: noread
  integer         :: ierr,i,j,nerr,nwarn,ialphaloc,irestart,merge_n,merge_ij(maxptmass),boundi,boundf
- real            :: poti,hfactfile
+ real            :: poti,hfactfile,ponsubg(nptmass)
  real            :: hi,pmassi,rhoi1
  real            :: dtsinkgas,dtsinksink,fonrmax,dtphi2,dtnew_first,dtinject
  real            :: stressmax,xmin,ymin,zmin,xmax,ymax,zmax,dx,dy,dz,tolu,toll
@@ -587,7 +587,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
           if (.not.use_sinktree) then
              call get_accel_sink_gas(nptmass,xyzh(1,i),xyzh(2,i),xyzh(3,i),xyzh(4,i),xyzmh_ptmass, &
                                      fext(1,i),fext(2,i),fext(3,i),poti,pmassi,fxyz_ptmass,&
-                                     dsdt_ptmass,fonrmax,dtphi2,bin_info)
+                                     dsdt_ptmass,fonrmax,dtphi2,bin_info,ponsubg)
              dtsinkgas = min(dtsinkgas,C_force*1./sqrt(fonrmax),C_force*sqrt(dtphi2))
           endif
        endif

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -144,7 +144,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
                             nden_nimhd,dustevol,rhoh,gradh,apr_level,aprmassoftype,&
                             Bevol,Bxyz,dustprop,filfac,ddustprop,ndustsmall,iboundary,eos_vars,dvdx, &
                             n_group,n_ingroup,n_sing,nmatrix,group_info,bin_info,isionised,shortsinktree,&
-                            fxyz_ptmass_tree,isink
+                            fxyz_ptmass_tree,isink,ipert
  use part,             only:pxyzu,dens,metrics,rad,radprop,drad,ithick
  use densityforce,     only:densityiterate
  use linklist,         only:set_linklist
@@ -232,20 +232,21 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
  character(len=*), intent(in)  :: infile
  character(len=*), intent(out) :: logfile,evfile,dumpfile
  logical,          intent(in), optional :: noread
- integer         :: ierr,i,j,nerr,nwarn,ialphaloc,irestart,merge_n,merge_ij(maxptmass),boundi,boundf
- real            :: poti,hfactfile,ponsubg(nptmass)
- real            :: hi,pmassi,rhoi1
- real            :: dtsinkgas,dtsinksink,fonrmax,dtphi2,dtnew_first,dtinject
- real            :: stressmax,xmin,ymin,zmin,xmax,ymax,zmax,dx,dy,dz,tolu,toll
- real            :: dummy(3)
- real            :: gmw_nicil
+ integer           :: ierr,i,j,nerr,nwarn,ialphaloc,irestart,merge_n,merge_ij(maxptmass),boundi,boundf
+ real, allocatable :: ponsubg(:)
+ real              :: poti,hfactfile
+ real              :: hi,pmassi,rhoi1
+ real              :: dtsinkgas,dtsinksink,fonrmax,dtphi2,dtnew_first,dtinject
+ real              :: stressmax,xmin,ymin,zmin,xmax,ymax,zmax,dx,dy,dz,tolu,toll
+ real              :: dummy(3)
+ real              :: gmw_nicil
 #ifndef GR
- real            :: dtf,fextv(3)
+ real              :: dtf,fextv(3)
 #endif
- integer         :: itype,iposinit,ipostmp,ntypes,nderivinit
- logical         :: iexist,read_input_files
+ integer           :: itype,iposinit,ipostmp,ntypes,nderivinit
+ logical           :: iexist,read_input_files
  character(len=len(dumpfile)) :: dumpfileold
- character(len=7) :: dust_label(maxdusttypes)
+ character(len=7)  :: dust_label(maxdusttypes)
 #ifdef INJECT_PARTICLES
  character(len=len(dumpfile)) :: file1D
  integer :: npart_old
@@ -293,11 +294,11 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
 !
 !--initialise apr if it is being used
 !
- if (use_apr) then
-    call init_apr(apr_level,ierr)
- else
-    apr_level(:) = 1
- endif
+    if (use_apr) then
+       call init_apr(apr_level,ierr)
+    else
+       apr_level(:) = 1
+    endif
 
 !
 !--if starting from a restart dump, rename the dumpefile to that of the previous non-restart dump
@@ -573,6 +574,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
     ! compute initial sink-gas forces and get timestep
     pmassi = massoftype(igas)
     ntypes = get_ntypes(npartoftype)
+    allocate(ponsubg(nptmass))
     do i=1,npart
        if (.not.isdead_or_accreted(xyzh(4,i))) then
           if (ntypes > 1 .and. maxphase==maxp) then
@@ -592,6 +594,8 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
           endif
        endif
     enddo
+    if (use_regnbody) bin_info(ipert,1:nptmass) = bin_info(ipert,1:nptmass) + ponsubg(1:nptmass)
+    deallocate(ponsubg)
     !
     ! reduction of sink-gas forces from each MPI thread
     !

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -155,14 +155,15 @@ contains
 !+
 !----------------------------------------------------------------
 subroutine get_accel_sink_gas(nptmass,xi,yi,zi,hi,xyzmh_ptmass,fxi,fyi,fzi,phi, &
-                              pmassi,fxyz_ptmass,dsdt_ptmass,fonrmax,dtphi2,bin_info,extrapfac,fsink_old)
+                              pmassi,fxyz_ptmass,dsdt_ptmass,fonrmax,dtphi2,bin_info,&
+                              ponsubg,extrapfac,fsink_old)
 #ifdef FINVSQRT
  use fastmath,      only:finvsqrt
 #endif
  use kernel,        only:kernel_softening,radkern
  use vectorutils,   only:unitvec
  use extern_geopot, only:get_geopot_force
- use part,          only:ipert,isemi
+ use part,          only:isemi
  integer,           intent(in)    :: nptmass
  real,              intent(in)    :: xi,yi,zi,hi
  real,              intent(inout) :: fxi,fyi,fzi,phi
@@ -172,12 +173,13 @@ subroutine get_accel_sink_gas(nptmass,xi,yi,zi,hi,xyzmh_ptmass,fxi,fyi,fzi,phi, 
  real,    optional, intent(in)    :: fsink_old(4,nptmass)
  real,    optional, intent(out)   :: fonrmax,dtphi2
  real,    optional, intent(inout) :: bin_info(7,nptmass)
+ real,    optional, intent(out)   :: ponsubg(nptmass)
  real                             :: ftmpxi,ftmpyi,ftmpzi
  real                             :: dx,dy,dz,rr2,ddr,dr3,f1,f2,pmassj,J2,shat(3),Rsink
  real                             :: hsoft,hsoft1,hsoft21,q2i,qi,psoft,fsoft
  real                             :: fxj,fyj,fzj,dsx,dsy,dsz,fac,r
  integer                          :: j
- logical                          :: tofrom,extrap
+ logical                          :: tofrom,extrap,pert_on_subg
  !
  ! Determine if acceleration is from/to gas, or to gas
  !
@@ -193,6 +195,12 @@ subroutine get_accel_sink_gas(nptmass,xi,yi,zi,hi,xyzmh_ptmass,fxi,fyi,fzi,phi, 
     extrap = .true.
  else
     extrap = .false.
+ endif
+
+ if (present(bin_info) .and. present(ponsubg))then
+   pert_on_subg = .true.
+ else
+   pert_on_subg = .false.
  endif
 
  ftmpxi = 0.  ! use temporary summation variable
@@ -304,9 +312,9 @@ subroutine get_accel_sink_gas(nptmass,xi,yi,zi,hi,xyzmh_ptmass,fxi,fyi,fzi,phi, 
 
        ! timestep is sqrt(separation/force)
        fonrmax = max(f1,f2,fonrmax)
-       if (use_regnbody) then
+       if (pert_on_subg) then
           if (abs(bin_info(isemi,j))>tiny(f2)) then
-             bin_info(ipert,j) = bin_info(ipert,j) + f2
+             ponsubg(j) = ponsubg(j) + f2
           endif
        endif
     endif

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -197,10 +197,10 @@ subroutine get_accel_sink_gas(nptmass,xi,yi,zi,hi,xyzmh_ptmass,fxi,fyi,fzi,phi, 
     extrap = .false.
  endif
 
- if (present(bin_info) .and. present(ponsubg))then
-   pert_on_subg = .true.
+ if (present(bin_info) .and. present(ponsubg) .and. use_regnbody)then
+    pert_on_subg = .true.
  else
-   pert_on_subg = .false.
+    pert_on_subg = .false.
  endif
 
  ftmpxi = 0.  ! use temporary summation variable

--- a/src/main/subgroup.f90
+++ b/src/main/subgroup.f90
@@ -1353,7 +1353,7 @@ subroutine get_kappa_bin(xyzmh_ptmass,bin_info,i,j)
  rapo = bin_info(iapo,i)
  rapo3 = rapo*rapo*rapo
  kappa = kref/((rapo3/mu)*pert)
- !print*,xyzmh_ptmass(2,i),pert,kappa,rapo,bin_info(isemi,i),bin_info(iecc,i)
+
  if (kappa > 1. .and. isellip) then
     bin_info(ikap,i) = kappa
     bin_info(ikap,j) = kappa

--- a/src/main/substepping.F90
+++ b/src/main/substepping.F90
@@ -727,8 +727,8 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
  integer(kind=1),          intent(inout) :: nmatrix(:,:)
  real,           optional, intent(inout) :: fsink_old(4,maxptmass)
  logical,        optional, intent(in)    :: isionised(:)
- integer, allocatable :: merge_ij(:) 
- real,    allocatable :: ponsubg(:) 
+ integer, allocatable :: merge_ij(:)
+ real,    allocatable :: ponsubg(:)
  real(kind=4)         :: t1,t2,tcpu1,tcpu2
  integer              :: merge_n
  integer              :: i,itype
@@ -928,7 +928,7 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
  call get_timings(t2,tcpu2)
  call increment_timer(itimer_gasf,t2-t1,tcpu2-tcpu1)
 
- if (use_regnbody) bin_info(ipert,1:nptmass) = ponsubg
+ if (use_regnbody) bin_info(ipert,1:nptmass) = bin_info(ipert,1:nptmass) + ponsubg
 
 
  if (nptmass > 0) then

--- a/src/main/substepping.F90
+++ b/src/main/substepping.F90
@@ -703,7 +703,7 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
                            isdead_or_accreted,iamboundary,igas,iphase,iamtype,massoftype,divcurlv, &
                            fxyz_ptmass_sinksink,dsdt_ptmass_sinksink,dust_temp,tau,&
                            nucleation,idK2,idmu,idkappa,idgamma,imu,igamma,n_group,n_ingroup,n_sing,&
-                           apr_level,aprmassoftype
+                           apr_level,aprmassoftype,ipert
  use cooling_ism,     only:dphot0,dphotflag,abundsi,abundo,abunde,abundc,nabn
  use timestep,        only:bignumber,C_force
  use mpiutils,        only:bcast_mpi,reduce_in_place_mpi,reduceall_mpi
@@ -722,21 +722,25 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
  real,                     intent(inout) :: dtextforce
  real,                     intent(in)    :: timei,dki,dt
  logical,                  intent(in)    :: extf_vdep_flag
- real,                     intent(inout) :: bin_info(:,:)
+ real,                     intent(inout) :: bin_info(7,nptmass)
  integer,                  intent(inout) :: group_info(:,:)
  integer(kind=1),          intent(inout) :: nmatrix(:,:)
  real,           optional, intent(inout) :: fsink_old(4,maxptmass)
  logical,        optional, intent(in)    :: isionised(:)
- real(kind=4)    :: t1,t2,tcpu1,tcpu2
- integer         :: merge_ij(nptmass)
- integer         :: merge_n
- integer         :: i,itype
- real, save      :: dmdt = 0.
- real            :: dtf,dtextforcenew,dtsinkgas,dtphi2,fonrmax
- real            :: fextx,fexty,fextz,xi,yi,zi,pmassi,damp_fac
- real            :: fonrmaxi,phii,dtphi2i
- real            :: dkdt,extrapfac
- logical         :: extrap,last
+ integer, allocatable :: merge_ij(:) 
+ real,    allocatable :: ponsubg(:) 
+ real(kind=4)         :: t1,t2,tcpu1,tcpu2
+ integer              :: merge_n
+ integer              :: i,itype
+ real, save           :: dmdt = 0.
+ real                 :: dtf,dtextforcenew,dtsinkgas,dtphi2,fonrmax
+ real                 :: fextx,fexty,fextz,xi,yi,zi,pmassi,damp_fac
+ real                 :: fonrmaxi,phii,dtphi2i
+ real                 :: dkdt,extrapfac
+ logical              :: extrap,last
+
+ allocate(merge_ij(nptmass))
+ allocate(ponsubg(nptmass))
 
  if (present(fsink_old)) then
     fsink_old = fxyz_ptmass
@@ -826,13 +830,13 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
  !$omp shared(dkdt,dt,timei,iexternalforce,extf_vdep_flag,last,aprmassoftype,apr_level) &
  !$omp shared(divcurlv,dphotflag,dphot0,nucleation,extrap) &
  !$omp shared(abundc,abundo,abundsi,abunde,extrapfac,fsink_old) &
- !$omp shared(isink_radiation,itau_alloc,tau,isionised) &
+ !$omp shared(isink_radiation,itau_alloc,tau,isionised,bin_info) &
  !$omp private(fextx,fexty,fextz,xi,yi,zi) &
  !$omp private(i,fonrmaxi,dtphi2i,phii,dtf) &
  !$omp firstprivate(pmassi,itype) &
  !$omp reduction(min:dtextforcenew,dtphi2) &
  !$omp reduction(max:fonrmax) &
- !$omp reduction(+:fxyz_ptmass,dsdt_ptmass,bin_info)
+ !$omp reduction(+:fxyz_ptmass,dsdt_ptmass,ponsubg)
  !$omp do
  do i=1,npart
     if (.not.isdead_or_accreted(xyzh(4,i))) then
@@ -860,15 +864,15 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
           if (extrap) then
              call get_accel_sink_gas(nptmass,xi,yi,zi,xyzh(4,i),xyzmh_ptmass,&
                                      fextx,fexty,fextz,phii,pmassi,fxyz_ptmass, &
-                                     dsdt_ptmass,fonrmaxi,dtphi2i,bin_info,&
+                                     dsdt_ptmass,fonrmaxi,dtphi2i,bin_info,ponsubg,&
                                      extrapfac,fsink_old)
           else
              call get_accel_sink_gas(nptmass,xi,yi,zi,xyzh(4,i),xyzmh_ptmass,&
                                      fextx,fexty,fextz,phii,pmassi,fxyz_ptmass,&
-                                     dsdt_ptmass,fonrmaxi,dtphi2i,bin_info)
-             fonrmax = max(fonrmax,fonrmaxi)
-             dtphi2  = min(dtphi2,dtphi2i)
+                                     dsdt_ptmass,fonrmaxi,dtphi2i,bin_info,ponsubg)
           endif
+          fonrmax = max(fonrmax,fonrmaxi)
+          dtphi2  = min(dtphi2,dtphi2i)
        endif
 
        !
@@ -924,6 +928,8 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
  call get_timings(t2,tcpu2)
  call increment_timer(itimer_gasf,t2-t1,tcpu2-tcpu1)
 
+ if (use_regnbody) bin_info(ipert,1:nptmass) = ponsubg
+
 
  if (nptmass > 0) then
     call reduce_in_place_mpi('+',fxyz_ptmass(:,1:nptmass))
@@ -945,6 +951,9 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
     dtextforcenew = reduceall_mpi('min',dtextforcenew)
     dtextforce = dtextforcenew
  endif
+
+ deallocate(merge_ij)
+ deallocate(ponsubg)
 
 end subroutine get_force
 


### PR DESCRIPTION
Type of PR: 
Bug fix 

Description:
A reduction on bin_info was performed in the `get_force` routine to track perturbations of the gas on subgroups. During the calculation, the code needed to look up some variables stored in another column of the same array which was initialized at zero due to the reduction clause... This is easily fixed using a temporary array to do the reduction. 

Testing:

Did you run the bots? no

Did you update relevant documentation in the docs directory? no