### PR TITLE
tde setup for white dwarfs with fake GR

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -83,7 +83,8 @@ Lionel Siess <lionel.siess@astro.ulb.ac.be> <Lionel.Siess@astro.ulb.ac.be>
 David Liptai <dliptai@swin.edu.au> <dliptai@hotmail.com>
 David Liptai <dliptai@swin.edu.au> <david.liptai@monash.edu>
 David Liptai <dliptai@swin.edu.au> <31463304+dliptai@users.noreply.github.com>
-<cristiano.longarini@unimi.it> <81079965+crislong@users.noreply.github.com>
+<cl2000@cam.ac.uk> <81079965+crislong@users.noreply.github.com>
+<cl2000@cam.ac.uk> <cristiano.longarini@unimi.it>
 Fangyi (Fitz) Hu <fhuu0005@student.monash.edu> Fitz <fhuu0005@student.monash.edu.au>
 Fangyi (Fitz) Hu <fhuu0005@student.monash.edu> Fitz-Hu <54089891+Fitz-Hu@users.noreply.github.com>
 Fangyi (Fitz) Hu <fhuu0005@student.monash.edu> root <root@Heartie的小电脑.localdomain>

--- a/AUTHORS
+++ b/AUTHORS
@@ -11,8 +11,8 @@ Conrad Chan <conradchan@hotmail.com.au>
 James Wurster <jhw5@st-andrews.ac.uk>
 David Liptai <dliptai@swin.edu.au>
 Lionel Siess <lionel.siess@astro.ulb.ac.be>
-Fangyi (Fitz) Hu <fhuu0005@student.monash.edu>
 Yann Bernard <yann.bernard@univ-grenoble-alpes.fr>
+Fangyi (Fitz) Hu <fhuu0005@student.monash.edu>
 Megha Sharma <msha0023@student.monash.edu>
 Daniel Mentiplay <daniel.mentiplay@protonmail.com>
 Alison Young <alison.young@ed.ac.uk>
@@ -28,9 +28,9 @@ Stephane Michoulier <stephane.michoulier@gmail.com>
 Simone Ceppi <simo.ceppi@gmail.com>
 Spencer Magnall <spencermagnall@gmail.com>
 Caitlyn Hardiman <caitlyn.hardiman1@monash.edu>
+Cristiano Longarini <cl2000@cam.ac.uk>
 Enrico Ragusa <enr.ragusa@gmail.com>
 Amber Tilly <amber.abs@gmail.com>
-Cristiano Longarini <cristiano.longarini@unimi.it>
 Sergei Biriukov <svbiriukov@gmail.com>
 Ana Lourdes Juarez <analourdesjg17@gmail.com>
 Giovanni Dipierro <giovanni.dipierro@leicester.ac.uk>
@@ -70,6 +70,7 @@ Shunquan Huang <shunq@Shunquans-MBP.lan>
 Zachary Pellow <zpel1@student.monash.edu>
 Alison Young <phskpt@login01.avon.hpc>
 Ariel Chitan <arielchitan@gmail.com>
+Bec Nealon <53286864+becnealon@users.noreply.github.com>
 Chunliang Mu <86601204+chunliangmu@users.noreply.github.com>
 Chunliang Mu <Mclliang7326@outlook.com>
 Cox, Samuel <sc676@leicester.ac.uk>
@@ -77,6 +78,7 @@ David Bamba <dbambague@unal.edu.co>
 Hugh Griffiths <hgri0008@student.monash.edu>
 Jeremy Smallwood <drjeremysmallwood@gmail.com>
 Jorge Cuadra <jcuadra@astro.puc.cl>
+Mario Aguilar <mario.aguilar@ung.si>
 Rebecca Martin <rebecca.martin@unlv.edu>
 Shunquan Huang <huangs18@unlv.nevada.edu>
 Steven Rieder <steven@rieder.nl>

--- a/build/Makefile_setups
+++ b/build/Makefile_setups
@@ -398,13 +398,13 @@ endif
 
 ifeq ($(SETUP), tde)
 #   tidal disruption simulations
-    SETUPFILE= setup_star.f90
+    SETUPFILE= setup_grtde.f90
 #    ANALYSIS=analysis_tde.f90
     ANALYSIS=analysis_gws.f90
     GRAVITY=yes
-    ISOTHERMAL=yes
     MODFILE=moddump_tidal.f90
     KNOWN_SETUP=yes
+    IND_TIMESTEPS=yes
 endif
 
 ifeq ($(SETUP), polytrope)

--- a/docs/examples/star.rst
+++ b/docs/examples/star.rst
@@ -1,23 +1,22 @@
-Setting up stars and tidal disruption events
-============================================
+Tidal disruption events
+=======================
 
 Setting up and relaxing a star
 ------------------------------
 
 First, follow the :doc:`usual procedure for initiating a new simulation with
-phantom </getting-started/running-first-calculation>`. We’ll use the “:doc:`star </user-guide/setups>`” setup, but you can also use the
-“:doc:`polytrope </user-guide/setups>`” or “:doc:`neutronstar </user-guide/setups>`” configurations (the first two use self-gravity
-for the star, the last one uses an external potential). For tidal disruption
-events in general relativity use “:doc:`grtde </user-guide/setups>`”. That is:
+phantom </getting-started/running-first-calculation>`. We’ll use the “:doc:`grtde </user-guide/setups>`” setup.
 
 make a new directory and write a local Makefile
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
-   $ mkdir star
-   $ cd star
-   $ ~/phantom/scripts/writemake.sh star > Makefile
+    mkdir tde
+    cd tde
+    ~/phantom/scripts/writemake.sh grtde > Makefile
+
+If you prefer Newtonian gravity use :doc:`tde </user-guide/setups>` instead of :doc:`grtde </user-guide/setups>`
 
 compile phantom and phantomsetup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -34,44 +33,22 @@ run phantomsetup
 
 ::
 
-   $./phantomsetup star
+   ./phantomsetup tde
 
-   star.setup not found: using interactive setup
+ writing setup options file tde.setup
+  Edit tde.setup and rerun phantomsetup
 
-   1) Uniform density profile
-   2) Polytrope
-   3) Density vs r from ascii file
-   4) KEPLER star from file
-   5) MESA star from file
-   6) Piecewise polytrope
-   7) Evrard collapse
-  Enter which density profile to use ([1:7], default=1): 2
-  Setting up Polytrope
-  Enter mass unit (e.g. solarm,jupiterm,earthm) (blank="blank",default="solarm"):
-  Enter distance unit (e.g. au,pc,kpc,0.1pc) (blank="blank",default="solarr"):
-  Enter the approximate number of particles in the sphere ([0:], default=100000):
-  Enter the desired EoS for setup (default=2):
-  Enter gamma (adiabatic index) ([1.000:7.000], default=1.667):
-  Enter the mass of the star (code units) ([0.000:], default=1.000):
-  Enter the radius of the star (code units) ([0.000:], default=1.000):
-  Relax star automatically during setup? (default=no): y
-   Writing star.setup
-  STOP please check and edit .setup file and rerun phantomsetup
-
-once you have answered the questions once, they are written to a file
-called star.setup, which you can use for subsequent runs of phantomsetup
-without having to answer prompts (see below)
 
 relax the star
 ~~~~~~~~~~~~~~
 
-Open the star.setup file and make sure the parameter “relax_star” to True::
+Open the tde.setup file and make sure the parameter “relax_star” to True::
 
                    relax_star =       T    ! artificial damping of velocities (if on, v=0 initially)
 
 Then run phantomsetup::
 
-   ./phantomsetup star.setup
+   ./phantomsetup tde.setup
 
 Which will generate a sequence of snapshots of the relaxation process::
 
@@ -94,111 +71,39 @@ is less than the specified tolerance, OR the number of iterations reaches the sp
 
 Once complete, you should obtain a relaxed initial conditions snapshot with the correct density and pressure profiles::
 
-   -------->   TIME =    0.000    : full dump written to file star_00000.tmp   <--------
+   -------->   TIME =    0.000    : full dump written to file tde_00000.tmp   <--------
 
 
-    input file poly.in written successfully.
+    input file tde.in written successfully.
     To start the calculation, use:
 
-    ./phantom star.in
+    ./phantom tde.in
 
-evolve the star
-~~~~~~~~~~~~~~~
 
-If you really want to, you can evolve the star in isolation with the regular code to double-check that the relaxation process worked::
-
-    ./phantom star.in
-
-check the output
-~~~~~~~~~~~~~~~~
+check the relaxed stellar profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
-   splash star_0*
+   splash relax1_* -y density -x r
 
-(if you have version 2 of splash, the relevant command is "ssplash")
+If you have the latest version of splash, this should automatically plot the analytic profile for comparison based on the contents of the relax1.profile file.
 
 Putting the star on an orbit for a tidal disruption event
 ---------------------------------------------------------
+This should be done automatically using the “tde” or "grtde" setup and it controlled by the following set of options in the .setup file ::
 
-If you used the “tde” or "grtde" setup then simply compile :doc:`moddump </user-guide/moddump>`::
+   # options for orbit around black hole
+      provide_params =           F    ! manually specify the position and velocity of the star(s)
+                beta =       5.000    ! penetration factor
+              ecc_bh =       0.800    ! eccentricity (1 for parabolic)
+            theta_bh =       0.000    ! inclination of orbit (degrees)
+             norbits =       5.000    ! number of orbits
+       dumpsperorbit =         100    ! number of dumps per orbit
 
-   $ make moddump
-
-otherwise you need to specify the tidal moddump file::
-
-   $ make moddump MODFILE=moddump_tidal.f90
-
-Then run moddump on your relaxed star::
-
-   $ ./phantommoddump star_00000 tde 0.0
-   ...
-   ...
-   ...
-    writing moddump params file tde.tdeparams
-     Edit tde.tdeparams and rerun phantommoddump
-
-When you first run this, a “tde.tdeparams” file will be created. Edit
-this to set the star on your desired orbit, and then rerun
-phantommoddump::
-
-   # parameters file for a TDE phantommodump
-                   beta =       1.000    ! penetration factor
-                     mh =   1.000E+06    ! mass of black hole (code units)
-                     ms =       1.000    ! mass of star       (code units)
-                     rs =       1.000    ! radius of star     (code units)
-                  theta =       0.000    ! stellar rotation with respect to x-axis (in degrees)
-                    phi =       0.000    ! stellar rotation with respect to y-axis (in degrees)
-                     r0 =        490.    ! starting distance
+Running the simulation
+----------------------
 
 After this you can simply run phantom::
 
-   $ ./phantom tde.in
-
-Adding a magnetic field to the star
------------------------------------
-
-compile phantommoddump
-~~~~~~~~~~~~~~~~~~~~~~
-
-The module used to compile this utility is specified using MODFILE= in
-`build/Makefile_setups <https://github.com/danieljprice/phantom/blob/master/build/Makefile_setups>`__. 
-The default for the “polytrope” setup is currently moddump_spheres.f90::
-
-   MODFILE=moddump_spheres.f90
-
-Change this to moddump_default.f90. You can do this temporarily on the
-command line by compiling phantommoddump as follows::
-
-   make moddump MODFILE=moddump_default.f90 MHD=yes
-
-run phantommoddump
-~~~~~~~~~~~~~~~~~~
-
-::
-
-   $ ./phantommoddump
-   PhantomSPH: (c) 2007-2023 The Authors
-
-    Usage: moddump dumpfilein dumpfileout [time] [outformat]
-
-in our case we want::
-
-   ./phantommoddump star_00010 magstar_00000
-
-which will give some errors::
-
-    ERROR! MHD arrays not found in Phantom dump file: got            0
-
-but then prompt you to add magnetic fields::
-
-   add/reset magnetic fields? (default=no): yes
-
-you can follow the prompts to add uniform magnetic fields using this
-routine.
-
-now implement something decent in src/setup/set_Bfield.f90
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-you can either use the pre-cooked magnetic field setups in this routine,
-or you can just make a new :doc:`moddump </user-guide/moddump>` module that sets up the magnetic field in a custom way.
+   ./phantom tde.in

--- a/src/main/apr.f90
+++ b/src/main/apr.f90
@@ -315,9 +315,9 @@ subroutine get_apr(pos,apri)
     dz = pos(3) - apr_centre(3)
 
     if (apr_region_is_circle) dz = 0.
-    
+
     r = sqrt(dx**2 + dy**2 + dz**2)
-    
+
     if (r < apr_regions(kk)) then
        apri = kk
        return

--- a/src/main/apr.f90
+++ b/src/main/apr.f90
@@ -16,7 +16,7 @@ module apr
 !   - apr_drad   : *size of step to next region*
 !   - apr_max    : *number of additional refinement levels (3 -> 2x resolution)*
 !   - apr_rad    : *radius of innermost region*
-!   - apr_type   : *1: static, 2: moving sink, 3: create clumps*
+!   - apr_type   : *1: static, 2: sink, 3: clumps, 4: sequential sinks, 5: com*
 !   - ref_dir    : *increase (1) or decrease (-1) resolution*
 !   - track_part : *number of sink to track*
 !

--- a/src/main/apr.f90
+++ b/src/main/apr.f90
@@ -139,7 +139,7 @@ subroutine update_apr(npart,xyzh,vxyzu,fxyzu,apr_level)
  real :: get_apr_in(3),radi,radi_max
 
  if (npart >= 0.9*maxp) then
-   call fatal('apr','maxp is not large enough; double factor for maxp_apr in config.F90 and recompile')
+    call fatal('apr','maxp is not large enough; double factor for maxp_apr in config.F90 and recompile')
  endif
 
  ! if the centre of the region can move, update it
@@ -178,7 +178,7 @@ subroutine update_apr(npart,xyzh,vxyzu,fxyzu,apr_level)
        endif
     enddo
  else
-   allocate(relaxlist(1))  ! it is passed but not used in merge
+    allocate(relaxlist(1))  ! it is passed but not used in merge
  endif
 
  ! Do any particles need to be split?
@@ -631,7 +631,7 @@ subroutine write_options_apr(iunit)
  case(2,4)
     call write_inopt(track_part,'track_part','number of sink to track',iunit)
  case default
-   ! write nothing
+    ! write nothing
  end select
 
  call write_inopt(apr_rad,'apr_rad','radius of innermost region',iunit)

--- a/src/main/apr_region.f90
+++ b/src/main/apr_region.f90
@@ -14,7 +14,7 @@ module apr_region
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: part
+! :Dependencies: centreofmass, part
 !
  implicit none
 

--- a/src/main/dust.f90
+++ b/src/main/dust.f90
@@ -16,6 +16,7 @@ module dust
 !
 ! :Runtime parameters:
 !   - K_code            : *drag constant when constant drag is used*
+!   - drag_implicit     : *gas/dust drag implicit scheme (works only with IND_TIMESTEPS=no)*
 !   - graindens         : *Intrinsic grain density in g/cm^3*
 !   - grainsize         : *Grain size in cm*
 !   - icut_backreaction : *cut the drag on the gas phase (0=no, 1=yes)*

--- a/src/main/externalforces.f90
+++ b/src/main/externalforces.f90
@@ -23,8 +23,9 @@ module externalforces
 !   extern_lensethirring, extern_prdrag, extern_spiral, extern_staticsine,
 !   infile_utils, io, part, units
 !
- use extern_binary,   only:accradius1,mass1,accretedmass1,accretedmass2
- use extern_corotate, only:omega_corotate  ! so public from this module
+ use extern_binary,        only:accradius1,mass1,accretedmass1,accretedmass2
+ use extern_corotate,      only:omega_corotate  ! so public from this module
+ use extern_lensethirring, only:a=>blackhole_spin
  implicit none
 
  private
@@ -44,7 +45,7 @@ module externalforces
  real, public :: accradius1_hard = 0.
  logical, public :: extract_iextern_from_hdr = .false.
 
- public :: mass1
+ public :: mass1,a
 
  !
  ! enumerated list of external forces

--- a/src/main/externalforces_gr.f90
+++ b/src/main/externalforces_gr.f90
@@ -19,7 +19,7 @@ module externalforces
 ! :Dependencies: dump_utils, infile_utils, io, metric, metric_tools, part,
 !   units
 !
- use metric, only:mass1
+ use metric, only:mass1,a
  implicit none
 
  private
@@ -36,7 +36,7 @@ module externalforces
  !
  integer, parameter, public :: iext_gr = 1
 
- public :: mass1  ! exported from metric module
+ public :: mass1,a  ! exported from metric module
  real, public :: accradius1 = 0.
  real, public :: accradius1_hard = 0.
  real, public :: accretedmass1 = 0.

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -381,7 +381,7 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
     !$omp end parallel do
  endif
 
- if(use_sinktree) then
+ if (use_sinktree) then
     !$omp parallel do default(none) shared(shortsinktree,fxyz_ptmass_tree,nptmass) private(i)
     do i=1,nptmass
        shortsinktree(1:nptmass,i) = 0
@@ -2964,7 +2964,7 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
 
 #ifdef GRAVITY
     !--add self-contribution
-    if(iamsinki)then
+    if (iamsinki) then
        epoti = 0.5*pmassi*fsum(ipot)
     else
        call kernel_softening(0.,0.,potensoft0,dum)
@@ -3044,7 +3044,7 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
        fxyzu(1,i) = fxyzu(1,i) + fsum(ifdragxi)
        fxyzu(2,i) = fxyzu(2,i) + fsum(ifdragyi)
        fxyzu(3,i) = fxyzu(3,i) + fsum(ifdragzi)
-    elseif(use_sinktree) then
+    elseif (use_sinktree) then
        fxyzu(1,i) = fxyzu(1,i) + fsum(ifskxi)
        fxyzu(2,i) = fxyzu(2,i) + fsum(ifskyi)
        fxyzu(3,i) = fxyzu(3,i) + fsum(ifskzi)

--- a/src/main/kdtree.F90
+++ b/src/main/kdtree.F90
@@ -263,7 +263,7 @@ subroutine maketree(node, xyzh, np, ndim, ifirstincell, ncells, apr_tree, refine
           call pop_off_stack(stack(istack), istack, nnode, mymum, level, npnode, xmini, xmaxi, ndim)
 
           ! construct node
-          if(sinktree) then
+          if (sinktree) then
              call construct_node(node(nnode), nnode, mymum, level, xmini, xmaxi, npnode, .false., &  ! don't construct in parallel
                                  il, ir, nl, nr, xminl, xmaxl, xminr, xmaxr, ncells, ifirstincell, &
                                  minlevel, maxlevel, ndim, wassplit, .false.,apr_tree,xyzmh_ptmass)
@@ -453,7 +453,7 @@ subroutine construct_root_node(np,nproot,irootnode,ndim,xmini,xmaxi,ifirstincell
  if (use_sinktree) then
     if (nptmass > 0) then
        do i=1,nptmass
-          if (mpi)then
+          if (mpi) then
              if (ibelong(maxpsph+i) /= id) cycle
           endif
           if (xyzmh_ptmass(4,i)<0.) cycle

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -197,7 +197,7 @@ subroutine get_accel_sink_gas(nptmass,xi,yi,zi,hi,xyzmh_ptmass,fxi,fyi,fzi,phi, 
     extrap = .false.
  endif
 
- if (present(bin_info) .and. present(ponsubg) .and. use_regnbody)then
+ if (present(bin_info) .and. present(ponsubg) .and. use_regnbody) then
     pert_on_subg = .true.
  else
     pert_on_subg = .false.

--- a/src/main/subgroup.f90
+++ b/src/main/subgroup.f90
@@ -18,7 +18,8 @@ module subgroup
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: io, mpiutils, part, timing, utils_kepler, utils_subgroup
+! :Dependencies: dim, io, mpiutils, part, timing, utils_kepler,
+!   utils_subgroup
 !
  use utils_subgroup
  implicit none

--- a/src/main/utils_raytracer.f90
+++ b/src/main/utils_raytracer.f90
@@ -20,7 +20,7 @@ module raytracer
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: healpix, kernel, linklist, part, units
+! :Dependencies: dim, healpix, kernel, linklist, part, units
 !
  use healpix
 

--- a/src/setup/set_star.f90
+++ b/src/setup/set_star.f90
@@ -28,10 +28,9 @@ module setstar
 !   - use_var_comp      : *Use variable composition (X, Z, mu)*
 !   - write_rho_to_file : *write density profile(s) to file*
 !
-! :Dependencies: apr, centreofmass, dim, eos, eos_piecewise,
-!   extern_densprofile, infile_utils, io, mpiutils, part, physcon,
-!   prompting, radiation_utils, relaxstar, setstar_utils, unifdis, units,
-!   vectorutils
+! :Dependencies: centreofmass, dim, eos, eos_piecewise, extern_densprofile,
+!   infile_utils, io, mpiutils, part, physcon, prompting, radiation_utils,
+!   relaxstar, setstar_utils, unifdis, units, vectorutils
 !
  use setstar_utils, only:ikepler,imesa,ibpwpoly,ipoly,iuniform,ifromfile,ievrard,&
                          need_polyk,need_mu

--- a/src/setup/set_star_utils.f90
+++ b/src/setup/set_star_utils.f90
@@ -491,9 +491,9 @@ subroutine set_star_thermalenergy(ieos,den,pres,r,npts,npart,xyzh,vxyzu,rad,eos_
     if (relaxed) then
        hi = xyzh(4,i)
        if (use_apr) then
-         pmassi = aprmassoftype(igas,apr_level(i))
+          pmassi = aprmassoftype(igas,apr_level(i))
        else
-         pmassi = massoftype(igas)
+          pmassi = massoftype(igas)
        endif
        densi = rhoh(hi,pmassi)
        presi = eos_vars(igasP,i)  ! retrieve pressure from relax_star calculated with the fake (ieos=2) internal energy

--- a/src/setup/setup_grtde.f90
+++ b/src/setup/setup_grtde.f90
@@ -555,35 +555,35 @@ subroutine refine_velocity(x, y, z, vx, vy, vz, M_h, a, r, epsilon_target, alpha
 
  iter = 0
  do while (iter < max_iters)
-  ! Compute epsilon at current velocity
-  call compute_epsilon(x, y, z, vx, vy, vz, M_h, a, r, epsilon_0)
+    ! Compute epsilon at current velocity
+    call compute_epsilon(x, y, z, vx, vy, vz, M_h, a, r, epsilon_0)
 
-  ! Check convergence
-  if (abs(epsilon_0 - epsilon_target) < tol) exit
+    ! Check convergence
+    if (abs(epsilon_0 - epsilon_target) < tol) exit
 
-  ! Determine sign of epsilon - epsilon_target
-  sign_epsilon = sign(1.0d0, epsilon_0 - epsilon_target)
+    ! Determine sign of epsilon - epsilon_target
+    sign_epsilon = sign(1.0d0, epsilon_0 - epsilon_target)
 
-  ! We only iterate in the x-y plane.
-  ! Compute epsilon_x by changing vx by a small delta
-  temp_vx = vx + delta_v
-  call compute_epsilon(x, y, z, temp_vx, vy, vz, M_h, a, r, epsilon_x)
-  d_eps_dx = (epsilon_x - epsilon_0) / delta_v
+    ! We only iterate in the x-y plane.
+    ! Compute epsilon_x by changing vx by a small delta
+    temp_vx = vx + delta_v
+    call compute_epsilon(x, y, z, temp_vx, vy, vz, M_h, a, r, epsilon_x)
+    d_eps_dx = (epsilon_x - epsilon_0) / delta_v
 
-  ! Compute epsilon_y by changing vy by a small delta
-  temp_vy = vy + delta_v
-  call compute_epsilon(x, y, z, vx, temp_vy, vz, M_h, a, r, epsilon_y)
-  d_eps_dy = (epsilon_y - epsilon_0) / delta_v
+    ! Compute epsilon_y by changing vy by a small delta
+    temp_vy = vy + delta_v
+    call compute_epsilon(x, y, z, vx, temp_vy, vz, M_h, a, r, epsilon_y)
+    d_eps_dy = (epsilon_y - epsilon_0) / delta_v
 
-  ! Update velocities using gradient descent with sign adjustment
-  vx = vx - alpha * sign_epsilon * d_eps_dx
-  vy = vy - alpha * sign_epsilon * d_eps_dy
+    ! Update velocities using gradient descent with sign adjustment
+    vx = vx - alpha * sign_epsilon * d_eps_dx
+    vy = vy - alpha * sign_epsilon * d_eps_dy
 
-  iter = iter + 1
+    iter = iter + 1
  enddo
  call compute_epsilon(x, y, z, vx, vy, vz, M_h, a, r, epsilon_0)
  if (iter == max_iters) then
-  print *, 'Warning: Gradient descent did not converge after ', max_iters, ' iterations.'
+    print *, 'Warning: Gradient descent did not converge after ', max_iters, ' iterations.'
  endif
 end subroutine refine_velocity
 

--- a/src/setup/setup_grtde.f90
+++ b/src/setup/setup_grtde.f90
@@ -19,8 +19,10 @@ module setup
 !   - mhole          : *mass of black hole (solar mass)*
 !   - norbits        : *number of orbits*
 !   - provide_params : *manually specify the position and velocity of the star(s)*
+!   - racc           : *accretion radius for the central object (code units or e.g. 1*km)*
 !   - sep_initial    : *initial separation from BH in tidal radii*
 !   - theta_bh       : *inclination of orbit (degrees)*
+!   - use_gr_ic      : *whether initial velocity condition computed in GR is used*
 !   - vx1            : *vel x star 1*
 !   - vx2            : *vel x star 2*
 !   - vy1            : *vel y star 1*
@@ -35,8 +37,8 @@ module setup
 !   - z2             : *pos z star 2*
 !
 ! :Dependencies: eos, externalforces, gravwaveutils, infile_utils, io,
-!   kernel, metric, mpidomain, options, part, physcon, relaxstar,
-!   setbinary, setorbit, setstar, setup_params, systemutils, timestep,
+!   kernel, mpidomain, options, part, physcon, relaxstar, setbinary,
+!   setorbit, setstar, setunits, setup_params, systemutils, timestep,
 !   units, vectorutils
 !
 

--- a/src/setup/setup_grtde.f90
+++ b/src/setup/setup_grtde.f90
@@ -580,11 +580,11 @@ subroutine refine_velocity(x, y, z, vx, vy, vz, M_h, a, r, epsilon_target, alpha
   vy = vy - alpha * sign_epsilon * d_eps_dy
 
   iter = iter + 1
- end do
+ enddo
  call compute_epsilon(x, y, z, vx, vy, vz, M_h, a, r, epsilon_0)
  if (iter == max_iters) then
   print *, 'Warning: Gradient descent did not converge after ', max_iters, ' iterations.'
- end if
+ endif
 end subroutine refine_velocity
 
 !--------------------------------------------------------------------------

--- a/src/setup/setup_star.f90
+++ b/src/setup/setup_star.f90
@@ -14,7 +14,7 @@ module setup
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: dim, eos, externalforces, infile_utils, io, kernel,
+! :Dependencies: apr, dim, eos, externalforces, infile_utils, io, kernel,
 !   mpidomain, options, part, physcon, setstar, setunits, setup_params,
 !   timestep
 !

--- a/src/setup/setup_star.f90
+++ b/src/setup/setup_star.f90
@@ -123,12 +123,12 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  ! note that this needs to be done before the particles are set up
  !
  if (use_apr .and. relax_star_in_setup) then
-   if (iexist) then
-      call read_aprsetupfile(inname,ierr)
-   else
-      call warning('setup_star','apr options needed for relaxation not found; making you a .in file, update and try again')
-      relax_star_in_setup = .false.
-   endif
+    if (iexist) then
+       call read_aprsetupfile(inname,ierr)
+    else
+       call warning('setup_star','apr options needed for relaxation not found; making you a .in file, update and try again')
+       relax_star_in_setup = .false.
+    endif
  endif
 
  !

--- a/src/tests/test_gravity.f90
+++ b/src/tests/test_gravity.f90
@@ -518,7 +518,7 @@ subroutine test_directsum(ntests,npass)
     call copy_half_gas_particles_to_sinks(npart,nptmass,xyzh,xyzmh_ptmass,pmassi,hfact*psep)
     !nptmass = 0
 
-    if(mpi) then
+    if (mpi) then
        if (use_sinktree) then
           ibelong((maxpsph)+1:maxp) = -1
           boundi = (maxpsph)+(nptmass / nprocs)*id
@@ -540,7 +540,7 @@ subroutine test_directsum(ntests,npass)
 !
     if (id /= master) epoti = 0.0
 
-    if(use_sinktree) then
+    if (use_sinktree) then
        epot_gas_sink = 0.
        do i=1,npart
           epoti = epoti + poten(i)

--- a/src/utils/utils_raytracer_all.f90
+++ b/src/utils/utils_raytracer_all.f90
@@ -14,7 +14,7 @@ module raytracer_all
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: healpix, kernel, linklist, part, units
+! :Dependencies: dim, healpix, kernel, linklist, part, units
 !
  use healpix
  implicit none


### PR DESCRIPTION
Type of PR: 
Modification of existing code

Description:
- modified SETUP=tde to use setup_grtde.f90 instead of setup_star.f90
- modification necessary to make setup_grtde work for the SETUP=tde
- separate definition black hole mass from units settings
- added option for accretion radius in the .setup file
- consistent way to set up central mass and black hole spin for gr/non gr code

Testing:
```
~/phantom/scripts/writemake.sh tde > Makefile
make; make setup
./phantomsetup tde
```

Did you run the bots? yes

Did you update relevant documentation in the docs directory? yes