### PR TITLE
(#635) fix seg fault caused by shuffling of particle types by 1

### DIFF
--- a/src/main/checksetup.f90
+++ b/src/main/checksetup.f90
@@ -251,6 +251,11 @@ subroutine check_setup(nerror,nwarn,restart)
 !--check that mass of each type has been set
 !
  do itype=1,maxtypes
+    if (isnan(massoftype(itype))) then
+       print*,'WARNING: massoftype = NaN for '//trim(labeltype(itype))//' particles'
+       nwarn = nwarn + 1
+       massoftype(itype) = 0.
+    endif
     if (npartoftype(itype) > 0 .and. abs(massoftype(itype)) < tiny(0.)) then
        print*,'WARNING: npartoftype > 0 for '//trim(labeltype(itype))//' particles but massoftype = 0'
        nwarn = nwarn + 1

--- a/src/main/config.F90
+++ b/src/main/config.F90
@@ -185,7 +185,7 @@ module dim
 
  ! Maximum number of particle types
  !
- integer, parameter :: maxtypes = 8 + 2*maxdustlarge - 1
+ integer, parameter :: maxtypes = 7 + 2*maxdustlarge - 1
 
  !
  ! Number of dimensions, where it is needed

--- a/src/main/kdtree.F90
+++ b/src/main/kdtree.F90
@@ -638,7 +638,7 @@ subroutine construct_node(nodeentry, nnode, mymum, level, xmini, xmaxi, npnode, 
        zi = xyzh_soa(i,3)
        hi = xyzh_soa(i,4)
        if (maxphase==maxp) then
-          if (iphase_soa(i) == isink) then
+          if (sinktree .and. (iamtype(iphase_soa(i)) == isink))then
              hi = xyzmh_ptmass(ihsoft,inodeparts(i)-maxpsph)
              pmassi = xyzh_soa(i,4)
           elseif (use_apr) then
@@ -665,7 +665,7 @@ subroutine construct_node(nodeentry, nnode, mymum, level, xmini, xmaxi, npnode, 
        zi = xyzh_soa(i,3)
        hi = xyzh_soa(i,4)
        if (maxphase==maxp) then
-          if (sinktree .and.iamtype(iphase_soa(i)) == isink) then
+          if (sinktree .and. (iamtype(iphase_soa(i)) == isink)) then
              hi = xyzmh_ptmass(ihsoft,inodeparts(i)-maxpsph)
              pmassi = xyzh_soa(i,4)
           elseif (use_apr) then
@@ -719,7 +719,7 @@ subroutine construct_node(nodeentry, nnode, mymum, level, xmini, xmaxi, npnode, 
  !!$omp parallel do if (npnode > 1000 .and. doparallel) &
  !!$omp default(none) schedule(static) &
  !!$omp shared(npnode,xyzh_soa,x0,i1,apr_level_soa) &
- !!$omp shared(iphase_soa,massoftype) &
+ !!$omp shared(iphase_soa,massoftype,sinktree) &
  !!$omp private(i,xi,yi,zi,dx,dy,dz,dr2,pmassi) &
 #ifdef GRAVITY
  !!$omp reduction(+:quads) &
@@ -742,7 +742,7 @@ subroutine construct_node(nodeentry, nnode, mymum, level, xmini, xmaxi, npnode, 
     if (maxphase==maxp) then
        if (use_apr) then
           pmassi = aprmassoftype(iamtype(iphase_soa(i)),apr_level_soa(i))
-       elseif (iamtype(iphase_soa(i)) == isink) then
+       elseif (sinktree .and. (iamtype(iphase_soa(i)) == isink)) then
           pmassi = xyzh_soa(i,4)
        else
           pmassi = massoftype(iamtype(iphase_soa(i)))

--- a/src/main/kdtree.F90
+++ b/src/main/kdtree.F90
@@ -554,7 +554,7 @@ subroutine construct_node(nodeentry, nnode, mymum, level, xmini, xmaxi, npnode, 
  real    :: totmassg
  integer :: npnodetot
 
- logical :: nodeisactive
+ logical :: nodeisactive,sinktree
  integer :: i,npcounter,i1
  real    :: xi,yi,zi,hi,dx,dy,dz,dr2
  real    :: r2max, hmax
@@ -567,6 +567,7 @@ subroutine construct_node(nodeentry, nnode, mymum, level, xmini, xmaxi, npnode, 
 #endif
  real    :: pmassi
 
+ sinktree = present(xyzmh_ptmass)
  nodeisactive = .false.
  if (inoderange(1,nnode) > 0) then
     checkactive: do i = inoderange(1,nnode),inoderange(2,nnode)
@@ -626,7 +627,7 @@ subroutine construct_node(nodeentry, nnode, mymum, level, xmini, xmaxi, npnode, 
     !$omp shared(maxp,maxphase,maxpsph,inodeparts) &
     !$omp shared(npnode,massoftype,dfac,aprmassoftype) &
     !$omp shared(xyzh_soa,apr_level_soa,i1,iphase_soa) &
-    !$omp shared(xyzmh_ptmass) &
+    !$omp shared(xyzmh_ptmass,sinktree) &
     !$omp private(i,xi,yi,zi,hi) &
     !$omp firstprivate(pmassi,fac) &
     !$omp reduction(+:xcofm,ycofm,zcofm,totmass_node) &
@@ -649,10 +650,6 @@ subroutine construct_node(nodeentry, nnode, mymum, level, xmini, xmaxi, npnode, 
        elseif (use_apr) then
           pmassi = aprmassoftype(igas,apr_level_soa(i))
           fac    = pmassi*dfac ! to avoid round-off error
-       elseif (iphase_soa(i) == isink) then
-          hi = xyzmh_ptmass(ihsoft,inodeparts(i)-maxpsph)
-          pmassi = xyzh_soa(i,4)
-          fac    = pmassi*dfac
        endif
        hmax  = max(hmax,hi)
        totmass_node = totmass_node + pmassi
@@ -668,7 +665,7 @@ subroutine construct_node(nodeentry, nnode, mymum, level, xmini, xmaxi, npnode, 
        zi = xyzh_soa(i,3)
        hi = xyzh_soa(i,4)
        if (maxphase==maxp) then
-          if (iphase_soa(i) == isink) then
+          if (sinktree .and.iamtype(iphase_soa(i)) == isink) then
              hi = xyzmh_ptmass(ihsoft,inodeparts(i)-maxpsph)
              pmassi = xyzh_soa(i,4)
           elseif (use_apr) then
@@ -680,10 +677,6 @@ subroutine construct_node(nodeentry, nnode, mymum, level, xmini, xmaxi, npnode, 
        elseif (use_apr) then
           pmassi = aprmassoftype(igas,apr_level_soa(i))
           fac    = pmassi*dfac ! to avoid round-off error
-       elseif (iphase_soa(i) == isink) then
-          hi = xyzmh_ptmass(ihsoft,inodeparts(i)-maxpsph)
-          pmassi = xyzh_soa(i,4)
-          fac    = pmassi*dfac
        endif
        hmax  = max(hmax,hi)
        totmass_node = totmass_node + pmassi
@@ -749,7 +742,7 @@ subroutine construct_node(nodeentry, nnode, mymum, level, xmini, xmaxi, npnode, 
     if (maxphase==maxp) then
        if (use_apr) then
           pmassi = aprmassoftype(iamtype(iphase_soa(i)),apr_level_soa(i))
-       elseif (iphase_soa(i) == isink) then
+       elseif (iamtype(iphase_soa(i)) == isink) then
           pmassi = xyzh_soa(i,4)
        else
           pmassi = massoftype(iamtype(iphase_soa(i)))

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -425,17 +425,17 @@ module part
  integer, parameter :: istar       = 4
  integer, parameter :: idarkmatter = 5
  integer, parameter :: ibulge      = 6
- integer, parameter :: isink       = 7 ! if sink is in tree...
- integer, parameter :: idust       = 8
+ integer, parameter :: idust       = 7
  integer, parameter :: idustlast   = idust + maxdustlarge - 1
  integer, parameter :: idustbound  = idustlast + 1
  integer, parameter :: idustboundl = idustbound + maxdustlarge - 1
  integer, parameter :: iunknown    = 0
+ integer, parameter :: isink       = 0 ! if sink is in tree...
  logical            :: set_boundaries_to_active = .true.
  integer :: i
  character(len=7), dimension(maxtypes), parameter :: &
    labeltype = (/'gas    ','empty  ','bound  ','star   ','darkm  ','bulge  ', &
-                 'sink   ',('dust   ', i=idust,idustlast),&
+                 ('dust   ', i=idust,idustlast),&
                  ('dustbnd',i=idustbound,idustboundl)/)
 !
 !--generic interfaces for routines

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -1027,7 +1027,7 @@ pure subroutine get_partinfo(iphasei,isactive,isgas,isdust,itype)
 ! isdust = itype==idust
 
 !--inline versions of above (for speed)
- if (iphasei > 0) then
+ if (iphasei >= 0) then
     isactive = .true.
     itype    = iphasei
  else

--- a/src/main/substepping.F90
+++ b/src/main/substepping.F90
@@ -758,6 +758,7 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
  dtsinkgas     = bignumber
  dtphi2        = bignumber
  fonrmax       = 0
+ ponsubg       = 0.
  last          = (force_count == n_force_order)
 
  !
@@ -928,7 +929,7 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
  call get_timings(t2,tcpu2)
  call increment_timer(itimer_gasf,t2-t1,tcpu2-tcpu1)
 
- if (use_regnbody) bin_info(ipert,1:nptmass) = bin_info(ipert,1:nptmass) + ponsubg
+ if (use_regnbody) bin_info(ipert,1:nptmass) = bin_info(ipert,1:nptmass) + ponsubg(1:nptmass)
 
 
  if (nptmass > 0) then

--- a/src/tests/test_ptmass.f90
+++ b/src/tests/test_ptmass.f90
@@ -355,8 +355,8 @@ subroutine test_binary(ntests,npass,string)
        call get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_sinksink,epot_sinksink,&
                                 dtsinksink,iexternalforce,0.,merge_ij,merge_n,dsdt_sinksink)
     endif
-    fxyz_ptmass(:,1:nptmass) = 0.
-    dsdt_ptmass(:,1:nptmass) = 0.
+    fxyz_ptmass(:,:) = 0.
+    dsdt_ptmass(:,:) = 0.
     call bcast_mpi(epot_sinksink)
     call bcast_mpi(dtsinksink)
 


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
Fix for #635 reported by Vasu Prasad. The underlying issue was breaking of backwards compatibility with previous runs using dust particles because the dust particle type had been shuffled by +1 to make room for the isink particle type.

A better solution is to make the isink type needed to identify sink particles in the tree equal to 0. This works because it is also the "unknown" particle type, does not correspond to an entry in the massoftype array, and does not need a sign when referenced as iphase because sink particles cannot be active/inactive.

Testing:

Using dump file standard_run_00122 supplied by Vasu. This file has 10^6 gas particles (type 1) and 10^5 dust particles of type 7. The seg fault occurred because the type 7 particles read from the dump were incorrectly identified as sink particles during the tree build.
```
./phantom standard_run.in
```

Did you run the bots? no

Did you update relevant documentation in the docs directory? no