### PR TITLE
Planetary wind

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -552,8 +552,8 @@ SOURCES= physcon.f90 ${CONFIG} ${SRCKERNEL} io.F90 units.f90 \
          ${SRCINJECT_DEPS} wind_equations.f90 wind.F90  \
          ${SRCKROME} memory.f90 ${SRCREADWRITE_DUMPS} ${SRCINJECT} \
          H2regions.f90 subgroup.f90 \
-         quitdump.f90 ptmass.F90\
-         dens.F90 force.F90 deriv.F90 ${SRCAPR} readwrite_infile.F90 energies.F90 sort_particles.f90 \
+         quitdump.f90 dens.F90\
+         ptmass.F90 force.F90 deriv.F90 ${SRCAPR} readwrite_infile.F90 energies.F90 sort_particles.f90 \
          utils_shuffleparticles.F90 evwrite.f90 substepping.F90 step_leapfrog.F90 writeheader.F90 ${SRCAN} step_supertimestep.F90 \
          mf_write.f90 evolve.F90 utils_orbits.f90 utils_linalg.f90 \
          checksetup.f90 initial.F90

--- a/build/Makefile_setups
+++ b/build/Makefile_setups
@@ -77,7 +77,7 @@ endif
 ifeq ($(SETUP), asteroidwind)
 #   asteroid emitting a wind (Trevascus et al. 2021)
     SETUPFILE=setup_asteroidwind.f90
-    SRCINJECT=utils_binary.f90 inject_randomwind.f90
+    SRCINJECT=utils_binary.f90 evolve_planet.f90 inject_randomwind.f90
     IND_TIMESTEPS=yes
     CONST_AV=yes
     ISOTHERMAL=yes
@@ -87,7 +87,7 @@ endif
 ifeq ($(SETUP), randomwind)
 #   asteroid emitting a wind (Trevascus et al. 2021)
     SETUPFILE=setup_disc.f90
-    SRCINJECT=utils_binary.f90 inject_randomwind.f90
+    SRCINJECT=utils_binary.f90 evolve_planet.f90 inject_randomwind.f90
     IND_TIMESTEPS=yes
     CONST_AV=yes
     ISOTHERMAL=yes
@@ -174,6 +174,17 @@ ifeq ($(SETUP), disc)
     KNOWN_SETUP=yes
     MULTIRUNFILE= multirun.f90
     IND_TIMESTEPS=yes
+endif
+
+ifeq ($(SETUP), boilingplanets)
+#   locally isothermal gas disc with planet evolution
+    DISC_VISCOSITY=yes
+    SETUPFILE= setup_disc.f90
+    ANALYSIS= analysis_disc.f90
+    ISOTHERMAL=yes
+    KNOWN_SETUP=yes
+    IND_TIMESTEPS=yes
+    SRCINJECT= utils_binary.f90 evolve_planet.f90 inject_randomwind.f90
 endif
 
 ifeq ($(SETUP), grtde)

--- a/src/main/H2regions.f90
+++ b/src/main/H2regions.f90
@@ -232,7 +232,7 @@ subroutine HII_feedback(nptmass,npart,xyzh,xyzmh_ptmass,vxyzu,isionised,dt)
           hcheck = Rmax
        endif
        do while(hcheck <= Rmax)
-          call getneigh_pos((/xi,yi,zi/),0.,hcheck,3,listneigh,nneigh,xyzh,xyzcache,maxcache,ifirstincell)
+          call getneigh_pos((/xi,yi,zi/),0.,hcheck,3,listneigh,nneigh,xyzcache,maxcache,ifirstincell)
           call set_r2func_origin(xi,yi,zi)
           call Knnfunc(nneigh,r2func_origin,xyzh,listneigh) !! Here still serial version of the quicksort. Parallel version in prep..
           if (nneigh > 0) exit

--- a/src/main/config.F90
+++ b/src/main/config.F90
@@ -42,7 +42,7 @@ module dim
 #else
  integer, parameter :: maxptmass = 1000
 #endif
- integer, parameter :: nsinkproperties = 22
+ integer, parameter :: nsinkproperties = 24
 
  logical :: store_sf_ptmass = .false.
 

--- a/src/main/dens.F90
+++ b/src/main/dens.F90
@@ -30,7 +30,7 @@ module densityforce
  character(len=80), parameter, public :: &  ! module version
     modid="$Id$"
 
- public :: densityiterate,get_neighbour_stats
+ public :: densityiterate,get_neighbour_stats,get_density_at_pos
 
  !--indexing for xpartveci array
  integer, parameter :: &
@@ -1691,5 +1691,71 @@ subroutine store_results(icall,cell,getdv,getdb,realviscosity,stressmax,xyzh,&
  ncalc = ncalc + cell%npcell * cell%nits
 
 end subroutine store_results
+
+subroutine get_density_at_pos(x,rho,itype)
+ use linklist, only:listneigh=>listneigh_global,getneigh_pos,ifirstincell
+ use kernel,   only:get_kernel,radkern2
+ use boundary, only:dxbound,dybound,dzbound
+ use dim,      only:periodic,maxphase,maxp,use_apr
+ use part,     only:xyzh,iphase,iamtype,ibasetype,apr_level,massoftype,aprmassoftype
+ real, intent(in) :: x(3)
+ integer, intent(in) :: itype
+ real, intent(out) :: rho
+ integer, parameter :: maxcache = 12000
+ real, save :: xyzcache(maxcache,4)
+ integer :: n,j,iamtypej,nneigh
+ real :: dx,dy,dz,hj1,rij2,q2j,qj,pmassj,wabi,grkerni
+ logical :: same_type
+  
+ call getneigh_pos(x,0.,0.,3,listneigh,nneigh,xyzcache,maxcache,ifirstincell,get_j=.true.)
+ same_type=.true.
+ rho = 0.
+ loop_over_neigh: do n=1,nneigh
+    j = listneigh(n)
+    if (n <=maxcache) then
+       ! positions from cache are already mod boundary
+       dx = x(1) - xyzcache(n,1)
+       dy = x(2) - xyzcache(n,2)
+       dz = x(3) - xyzcache(n,3)
+       hj1 = xyzcache(n,4)
+    else
+       dx = x(1) - xyzh(1,j)
+       dy = x(2) - xyzh(2,j)
+       dz = x(3) - xyzh(3,j)
+       hj1 = 1./xyzh(4,j)
+    endif
+    if (periodic) then
+       if (abs(dx) > 0.5*dxbound) dx = dx - dxbound*SIGN(1.0,dx)
+       if (abs(dy) > 0.5*dybound) dy = dy - dybound*SIGN(1.0,dy)
+       if (abs(dz) > 0.5*dzbound) dz = dz - dzbound*SIGN(1.0,dz)
+    endif
+    rij2 = dx*dx + dy*dy + dz*dz
+    q2j = rij2*hj1*hj1
+    if (q2j < radkern2) then
+       !
+       ! Density, gradh and div v are only computed using
+       ! neighbours of the same type
+       !
+       if (maxphase==maxp) then
+          iamtypej  = iamtype(iphase(j))
+          same_type = ((itype == iamtypej) .or. (ibasetype(iamtypej)==itype))
+       endif
+
+       ! adjust masses for apr
+       ! this defaults to massoftype if apr_level=1
+       if (use_apr) then
+          pmassj = aprmassoftype(iamtypej,apr_level(j))
+       else
+          pmassj = massoftype(iamtypej)
+       endif
+       if (same_type)  then
+          qj = sqrt(q2j)
+          call get_kernel(q2j,qj,wabi,grkerni)
+          rho = rho + wabi*pmassj*hj1*hj1*hj1
+       endif
+    endif
+ enddo loop_over_neigh
+
+end subroutine get_density_at_pos
 
 end module densityforce

--- a/src/main/dens.F90
+++ b/src/main/dens.F90
@@ -1692,7 +1692,7 @@ end subroutine store_results
 
 subroutine get_density_at_pos(x,rho,itype)
  use linklist, only:listneigh=>listneigh_global,getneigh_pos,ifirstincell
- use kernel,   only:get_kernel,radkern2
+ use kernel,   only:get_kernel,radkern2,cnormk
  use boundary, only:dxbound,dybound,dzbound
  use dim,      only:periodic,maxphase,maxp,use_apr
  use part,     only:xyzh,iphase,iamtype,ibasetype,apr_level,massoftype,aprmassoftype
@@ -1749,7 +1749,7 @@ subroutine get_density_at_pos(x,rho,itype)
        if (same_type)  then
           qj = sqrt(q2j)
           call get_kernel(q2j,qj,wabi,grkerni)
-          rho = rho + wabi*pmassj*hj1*hj1*hj1
+          rho = rho + wabi*pmassj*hj1*hj1*hj1*cnormk
        endif
     endif
  enddo loop_over_neigh

--- a/src/main/dens.F90
+++ b/src/main/dens.F90
@@ -27,8 +27,6 @@ module densityforce
  use timing,  only:getused,printused,print_time
 
  implicit none
- character(len=80), parameter, public :: &  ! module version
-    modid="$Id$"
 
  public :: densityiterate,get_neighbour_stats,get_density_at_pos
 

--- a/src/main/deriv.F90
+++ b/src/main/deriv.F90
@@ -43,7 +43,7 @@ subroutine derivs(icall,npart,nactive,xyzh,vxyzu,fxyzu,fext,divcurlv,divcurlB,&
  use io,             only:iprint,fatal,error
  use linklist,       only:set_linklist
  use densityforce,   only:densityiterate
- use ptmass,         only:ipart_rhomax,ptmass_calc_enclosed_mass,ptmass_boundary_crossing
+ use ptmass,         only:ipart_rhomax,ptmass_calc_enclosed_mass,ptmass_boundary_crossing,get_pressure_on_sinks
  use externalforces, only:externalforce
  use part,           only:dustgasprop,dvdx,Bxyz,set_boundaries_to_active,&
                           nptmass,xyzmh_ptmass,sinks_have_heating,dust_temp,VrelVf,fxyz_drag
@@ -62,7 +62,7 @@ subroutine derivs(icall,npart,nactive,xyzh,vxyzu,fxyzu,fext,divcurlv,divcurlB,&
  use cons2prim,      only:cons2primall,cons2prim_everything
  use metric_tools,   only:init_metric
  use radiation_implicit, only:do_radiation_implicit,ierr_failed_to_converge
- use options,        only:implicit_radiation,implicit_radiation_store_drad,use_porosity
+ use options,        only:implicit_radiation,implicit_radiation_store_drad,use_porosity,need_pressure_on_sinks
  integer,      intent(in)    :: icall
  integer,      intent(inout) :: npart
  integer,      intent(in)    :: nactive
@@ -183,7 +183,10 @@ subroutine derivs(icall,npart,nactive,xyzh,vxyzu,fxyzu,fext,divcurlv,divcurlB,&
     ! compute growth rate and probability of sticking/bouncing of porous dust
     if (use_porosity) call get_probastick(npart,xyzh,ddustprop(1,:),dustprop,dustgasprop,filfac)
  endif
-
+!
+! compute density and pressure at location of sink particles
+!
+ if (need_pressure_on_sinks) call get_pressure_on_sinks(nptmass,xyzmh_ptmass)
 !
 ! compute dust temperature
 !

--- a/src/main/evolve_planet.f90
+++ b/src/main/evolve_planet.f90
@@ -1,0 +1,40 @@
+!--------------------------------------------------------------------------!
+! The Phantom Smoothed Particle Hydrodynamics code, by Daniel Price et al. !
+! Copyright (c) 2007-2025 The Authors (see AUTHORS)                        !
+! See LICENCE file for usage and distribution conditions                   !
+! http://phantomsph.github.io/                                             !
+!--------------------------------------------------------------------------!
+module evolveplanet
+!
+!  This module evolve the embedded planet
+!   calculating the accretion and wind rate according
+!   to the pressure at the Bondi radius of the planet
+!
+! :References: Rogers et al. 2024 for the boil-off model
+!
+! :Owner: Cristiano Longarini
+!
+! :Runtime parameters: None
+!
+! :Dependencies: 
+!
+ implicit none
+ public :: evolve_planet
+
+ private
+    
+contains
+
+subroutine evolve_planet(pbondi,rbondi,mdotacc,mdotwind)
+! this routine should call James' code to calculate mdotacc and mdotwind for boil-off
+ use units, only:umass,utime
+ use physcon, only:jupiterm,years
+ real, intent(in) :: pbondi,rbondi
+ real, intent(out) :: mdotacc,mdotwind
+
+ mdotacc = 0.
+ mdotwind = 1.e-3*jupiterm/umass/(years/utime)
+
+end subroutine evolve_planet
+
+end module evolveplanet

--- a/src/main/linklist_kdtree.F90
+++ b/src/main/linklist_kdtree.F90
@@ -272,19 +272,22 @@ subroutine get_neighbour_list(inode,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesi
 
 end subroutine get_neighbour_list
 
-subroutine getneigh_pos(xpos,xsizei,rcuti,ndim,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesize,ifirstincell)
+subroutine getneigh_pos(xpos,xsizei,rcuti,ndim,mylistneigh,nneigh,xyzcache,ixyzcachesize,ifirstincell,get_j)
  use kdtree, only:getneigh
  integer, intent(in)  :: ndim,ixyzcachesize
  real,    intent(in)  :: xpos(ndim)
  real,    intent(in)  :: xsizei,rcuti
  integer, intent(out) :: mylistneigh(:)
  integer, intent(out) :: nneigh
- real,    intent(in)  :: xyzh(:,:)
  real,    intent(out) :: xyzcache(:,:)
  integer, intent(in)  :: ifirstincell(:) !ncellsmax+1)
+ logical, intent(in), optional :: get_j
+ logical :: getj
 
+ getj = .false.
+ if (present(get_j)) getj=get_j
  call getneigh(node,xpos,xsizei,rcuti,ndim,mylistneigh,nneigh,xyzcache,ixyzcachesize, &
-               ifirstincell,.false.,.false.)
+               ifirstincell,get_j,.false.)
 
 end subroutine getneigh_pos
 

--- a/src/main/options.f90
+++ b/src/main/options.f90
@@ -55,6 +55,9 @@ module options
  real(kind=sp), public :: mcfost_keep_part
  character(len=80), public :: Voronoi_limits_file
 
+ ! pressure on sinks
+ logical, public :: need_pressure_on_sinks
+
  ! radiation
  logical, public :: exchange_radiation_energy, limit_radiation_flux, implicit_radiation
  logical, public :: implicit_radiation_store_drad
@@ -168,6 +171,8 @@ subroutine set_default_options
 
  ! variable composition
  use_var_comp = .false.
+
+ need_pressure_on_sinks = .false.
 
 end subroutine set_default_options
 

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -215,6 +215,8 @@ module part
  integer, parameter :: irstrom = 20  ! Stromgren radius of the stars (icreate_sinks == 2)
  integer, parameter :: irateion = 21 ! Ionisation rate of the stars (log)(icreate_sinks == 2)
  integer, parameter :: itbirth = 22  ! birth time of the new sink
+ integer, parameter :: irbondi = 23  ! Bondi radius
+ integer, parameter :: ipbondi = 24 ! external pressure at the Bondi radius
  integer, parameter :: ndptmass = 13 ! number of properties to conserve after accretion phase or merge
  integer, allocatable :: sf_ptmass(:,:) ! star form prop 1 : type (1 sink ,2 star, 3 dead sink ), 2 : number of seeds
  real,    allocatable :: xyzmh_ptmass(:,:)
@@ -230,7 +232,7 @@ module part
     'hsoft    ','maccreted','spinx    ','spiny    ','spinz    ',&
     'tlast    ','lum      ','Teff     ','Reff     ','mdotloss ',&
     'mdotav   ','mprev    ','massenc  ','J2       ','Rstrom   ',&
-    'rate_ion ','tbirth   '/)
+    'rate_ion ','tbirth   ','Rbondi   ','Pr_Bondi '/)
  character(len=*), parameter :: vxyz_ptmass_label(3) = (/'vx','vy','vz'/)
  character(len=*), parameter :: sf_ptmass_label(2) = (/'type  ','nseed '/)
 !

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -60,6 +60,7 @@ module ptmass
  public :: ptmass_calc_enclosed_mass
  public :: ptmass_boundary_crossing
  public :: set_integration_precision
+ public :: get_pressure_on_sinks
 
  ! settings affecting routines in module (read from/written to input file)
  integer, public :: icreate_sinks = 0 ! 1-standard sink creation scheme 2-Star formation scheme using core prescription
@@ -1263,7 +1264,7 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,vxyzu,fxyzu,fext,divcurlv,pote
 
  ! CHECK 3: all neighbours are all active ( & perform math for checks 4-6)
  ! find neighbours within the checking radius of hcheck
- call getneigh_pos((/xi,yi,zi/),0.,hcheck,3,listneigh,nneigh,xyzh,xyzcache,maxcache,ifirstincell)
+ call getneigh_pos((/xi,yi,zi/),0.,hcheck,3,listneigh,nneigh,xyzcache,maxcache,ifirstincell)
  ! determine if we should approximate epot
  calc_exact_epot = .true.
  if ((nneigh_thresh > 0 .and. nneigh > nneigh_thresh) .or. (nprocs > 1)) calc_exact_epot = .false.
@@ -2656,5 +2657,32 @@ subroutine read_options_ptmass(name,valstring,imatch,igotall,ierr)
  endif
 
 end subroutine read_options_ptmass
+
+subroutine get_pressure_on_sinks(nptmass,xyzmh_ptmass)
+ use part, only:igas,maxvxyzu,ipbondi,irbondi
+ use options, only:ieos
+ use eos, only:equationofstate
+ use io, only:fatal
+ use densityforce, only:get_density_at_pos 
+ integer, intent(in) :: nptmass
+ real,    intent(inout) :: xyzmh_ptmass(:,:)
+ real :: rho,pbondi,cs,ponrho,rbondi,dum_temp
+ integer :: i
+
+ if (maxvxyzu >= 4) then
+   ! use HonR parameter
+   call fatal ('evolve planet', 'Bondi radius calculation not implemented for ISOTHERMAL=no')
+ endif
+
+ do i=1,nptmass
+    call get_density_at_pos(xyzmh_ptmass(1:3,i),rho,igas)
+    call equationofstate(ieos,ponrho,cs,rho,xyzmh_ptmass(1,i),xyzmh_ptmass(2,i),xyzmh_ptmass(3,i),dum_temp)
+    pbondi = ponrho*rho
+    rbondi = xyzmh_ptmass(4,i)/cs**2
+    xyzmh_ptmass(ipbondi,i) = pbondi
+    xyzmh_ptmass(irbondi,i) = rbondi
+ enddo
+
+end subroutine get_pressure_on_sinks
 
 end module ptmass

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -2663,7 +2663,7 @@ subroutine get_pressure_on_sinks(nptmass,xyzmh_ptmass)
  use options, only:ieos
  use eos, only:equationofstate
  use io, only:fatal
- use densityforce, only:get_density_at_pos 
+ use densityforce, only:get_density_at_pos
  integer, intent(in) :: nptmass
  real,    intent(inout) :: xyzmh_ptmass(:,:)
  real :: rho,pbondi,cs,ponrho,rbondi,dum_temp

--- a/src/main/utils_raytracer.f90
+++ b/src/main/utils_raytracer.f90
@@ -494,7 +494,7 @@ subroutine find_next(inpoint, h, ray, xyzh, kappa, dtaudr, distance, inext)
  distance = 0.
 
  !for a given point (inpoint), returns the list of neighbouring particles (listneigh) within a radius h*radkern
- call getneigh_pos(inpoint,0.,h*radkern,3,listneigh,nneigh,xyzh,xyzcache,nmaxcache,ifirstincell)
+ call getneigh_pos(inpoint,0.,h*radkern,3,listneigh,nneigh,xyzcache,nmaxcache,ifirstincell)
 
  dtaudr = 0.
  dmin = huge(0.)

--- a/src/utils/utils_raytracer_all.f90
+++ b/src/utils/utils_raytracer_all.f90
@@ -888,7 +888,7 @@ subroutine ray_tracer(primary, ray, xyzh, kappa, Rstar, tau_along_ray, dist_alon
  inext=0
  do while (inext==0)
     h = h*2.
-    call getneigh_pos(primary+Rstar*ray,0.,h,3,listneigh,nneigh,xyzh,xyzcache,maxcache,ifirstincell)
+    call getneigh_pos(primary+Rstar*ray,0.,h,3,listneigh,nneigh,xyzcache,maxcache,ifirstincell)
     call find_next(primary, ray, distance, xyzh, listneigh, inext, nneigh)
  enddo
  call calc_opacity(primary+Rstar*ray, xyzh, kappa, listneigh, nneigh, previousdtaudr)
@@ -900,7 +900,7 @@ subroutine ray_tracer(primary, ray, xyzh, kappa, Rstar, tau_along_ray, dist_alon
  do while (hasNext(inext,tau_along_ray(i),distance,maxDistance))
     i = i + 1
     call getneigh_pos(primary + distance*ray,0.,xyzh(4,inext)*radkern, &
-                              3,listneigh,nneigh,xyzh,xyzcache,maxcache,ifirstincell)
+                              3,listneigh,nneigh,xyzcache,maxcache,ifirstincell)
     call calc_opacity(primary + distance*ray, xyzh, kappa, listneigh, nneigh, nextdtaudr)
     dtaudr            = (nextdtaudr+previousdtaudr)/2
     previousdtaudr    = nextdtaudr
@@ -1075,7 +1075,7 @@ subroutine get_tau_inwards(point, primary, xyzh, neighbors, kappa, Rstar, tau)
  maxDist=max(maxDist-Rstar,0.)
  next=point
  call getneigh_pos(xyzh(1:3,point),0.,xyzh(4,point)*radkern, &
-                           3,listneigh,nneigh,xyzh,xyzcache,nmaxcache,ifirstincell)
+                           3,listneigh,nneigh,xyzcache,nmaxcache,ifirstincell)
  call calc_opacity(xyzh(1:3,point), xyzh, kappa, listneigh, nneigh, nextdtaudr)
  nextDist=0.
 
@@ -1090,7 +1090,7 @@ subroutine get_tau_inwards(point, primary, xyzh, neighbors, kappa, Rstar, tau)
        nextDist = maxDist
     endif
     call getneigh_pos(xyzh(1:3,point) + nextDist*ray,0.,xyzh(4,previous)*radkern, &
-                              3,listneigh,nneigh,xyzh,xyzcache,nmaxcache,ifirstincell)
+                              3,listneigh,nneigh,xyzcache,nmaxcache,ifirstincell)
     previousdtaudr=nextdtaudr
     call calc_opacity(xyzh(1:3,point) + nextDist*ray, xyzh, kappa, listneigh, nneigh, nextdtaudr)
     dtaudr = (nextdtaudr+previousdtaudr)/2


### PR DESCRIPTION
Type of PR: 
New physics + modification to the existing code

Description:
Added the possibility for a planet embedded in a disc to produce a wind at the Bondi radius using the inject_random module (wind_type=2, new setup boilingplanets). 
Added the possibility to compute the Bondi radius as a function of time only for a locally isothermal disc and to compute the pressure at the Bondi radius. This will be useful to properly implement the boil-off.

Testing:
The code compiles and run. Roughly tested that the injected mass is the prescribed one. More testing should be done but in the meantime it's worth merging this to the repository.

Did you run the bots? no

Did you update relevant documentation in the docs directory? not yet