### PR TITLE
Merge sf_ptmass array in xyzmh_ptmass

### DIFF
--- a/docs/physics/sink-properties.rst
+++ b/docs/physics/sink-properties.rst
@@ -37,5 +37,9 @@
    +-----------+--------------------------------------------------------------+
    | itbirth   | birth time of the new sink                                   | 
    +-----------+--------------------------------------------------------------+
-   | ndptmass  | number of properties to conserve after accretion or merge    | 
+   | isftype   | type of the sink (1: sink,2: star, 3:dead)                   | 
+   +-----------+--------------------------------------------------------------+
+   | inseed    | number of seeds into a sink (icreate_sinks == 2)             | 
+   +-----------+--------------------------------------------------------------+
+   | ndptmass  | number of properties to conserve after accretion phase or merge | 
    +-----------+--------------------------------------------------------------+

--- a/src/main/config.F90
+++ b/src/main/config.F90
@@ -42,9 +42,8 @@ module dim
 #else
  integer, parameter :: maxptmass = 1000
 #endif
- integer, parameter :: nsinkproperties = 22
+ integer, parameter :: nsinkproperties = 24
 
- logical :: store_sf_ptmass = .false.
 
  ! storage of thermal energy or not
 #ifdef ISOTHERMAL

--- a/src/main/evolve.F90
+++ b/src/main/evolve.F90
@@ -93,7 +93,7 @@ subroutine evol(infile,logfile,evfile,dumpfile,flag)
                             xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,dptmass,gravity,iboundary, &
                             fxyz_ptmass_sinksink,ntot,poten,ndustsmall,&
                             accrete_particles_outside_sphere,apr_level,aprmassoftype,&
-                            sf_ptmass,isionised,dsdt_ptmass,isdead_or_accreted,&
+                            isionised,dsdt_ptmass,isdead_or_accreted,&
                             fxyz_ptmass_tree
  use part,             only:n_group,n_ingroup,n_sing,group_info,bin_info,nmatrix
  use quitdump,         only:quit
@@ -299,7 +299,7 @@ subroutine evol(infile,logfile,evfile,dumpfile,flag)
           call create_or_update_apr_clump(npart,xyzh,vxyzu,poten,apr_level,xyzmh_ptmass,aprmassoftype)
        else
           call ptmass_create(nptmass,npart,ipart_rhomax,xyzh,vxyzu,fxyzu,fext,divcurlv,&
-                          poten,massoftype,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_sinksink,sf_ptmass,dptmass,time)
+                          poten,massoftype,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_sinksink,dptmass,time)
        endif
     endif
 
@@ -308,14 +308,14 @@ subroutine evol(infile,logfile,evfile,dumpfile,flag)
        ! creation of new seeds into evolved sinks
        !
        if (ipart_createseeds /= 0) then
-          call ptmass_create_seeds(nptmass,ipart_createseeds,sf_ptmass,time)
+          call ptmass_create_seeds(nptmass,ipart_createseeds,xyzmh_ptmass,time)
        endif
        !
        ! creation of new stars from sinks (cores)
        !
        if (ipart_createstars /= 0) then
           call ptmass_create_stars(nptmass,ipart_createstars,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_sinksink, &
-                               sf_ptmass,time)
+                                   time)
        endif
     endif
 
@@ -337,8 +337,8 @@ subroutine evol(infile,logfile,evfile,dumpfile,flag)
                               new_ptmass=.true.,dtext=dtextforce)
        endif
        call get_force(nptmass,npart,0,1,time,dtextforce,xyzh,vxyzu,fext,xyzmh_ptmass,vxyz_ptmass,&
-                      fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,0.,0.,dummy,.false.,sf_ptmass,&
-                      bin_info,group_info,nmatrix)
+                      fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,0.,0.,dummy,.false.,bin_info,&
+                      group_info,nmatrix)
        if (ipart_createseeds /= 0) ipart_createseeds = 0 ! reset pointer to zero
        if (ipart_createstars /= 0) ipart_createstars = 0 ! reset pointer to zero
        dummy = 0

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -197,26 +197,28 @@ module part
 !
 !--sink particles
 !
- integer, parameter :: ihacc  = 5  ! accretion radius
- integer, parameter :: ihsoft = 6  ! softening radius
- integer, parameter :: imacc  = 7  ! accreted mass
- integer, parameter :: ispinx = 8  ! spin angular momentum x
- integer, parameter :: ispiny = 9  ! spin angular momentum y
- integer, parameter :: ispinz = 10 ! spin angular momentum z
- integer, parameter :: i_tlast = 11 ! time of last injection
- integer, parameter :: ilum   = 12 ! luminosity
- integer, parameter :: iTeff  = 13 ! effective temperature
- integer, parameter :: iReff  = 14 ! effective radius
- integer, parameter :: imloss = 15 ! mass loss rate
- integer, parameter :: imdotav = 16 ! accretion rate average
- integer, parameter :: i_mlast = 17 ! accreted mass of last time
+ integer, parameter :: ihacc    = 5  ! accretion radius
+ integer, parameter :: ihsoft   = 6  ! softening radius
+ integer, parameter :: imacc    = 7  ! accreted mass
+ integer, parameter :: ispinx   = 8  ! spin angular momentum x
+ integer, parameter :: ispiny   = 9  ! spin angular momentum y
+ integer, parameter :: ispinz   = 10 ! spin angular momentum z
+ integer, parameter :: i_tlast  = 11 ! time of last injection
+ integer, parameter :: ilum     = 12 ! luminosity
+ integer, parameter :: iTeff    = 13 ! effective temperature
+ integer, parameter :: iReff    = 14 ! effective radius
+ integer, parameter :: imloss   = 15 ! mass loss rate
+ integer, parameter :: imdotav  = 16 ! accretion rate average
+ integer, parameter :: i_mlast  = 17 ! accreted mass of last time
  integer, parameter :: imassenc = 18 ! mass enclosed in sink softening radius
- integer, parameter :: iJ2 = 19      ! 2nd gravity moment due to oblateness
- integer, parameter :: irstrom = 20  ! Stromgren radius of the stars (icreate_sinks == 2)
+ integer, parameter :: iJ2      = 19 ! 2nd gravity moment due to oblateness
+ integer, parameter :: irstrom  = 20 ! Stromgren radius of the stars (icreate_sinks == 2)
  integer, parameter :: irateion = 21 ! Ionisation rate of the stars (log)(icreate_sinks == 2)
- integer, parameter :: itbirth = 22  ! birth time of the new sink
+ integer, parameter :: itbirth  = 22 ! birth time of the new sink
+ integer, parameter :: isftype  = 23 ! type of the sink (1: sink,2: star, 3:dead)
+ integer, parameter :: inseed   = 24 ! number of seeds into a sink (icreate_sinks == 2)
  integer, parameter :: ndptmass = 13 ! number of properties to conserve after accretion phase or merge
- integer, allocatable :: sf_ptmass(:,:) ! star form prop 1 : type (1 sink ,2 star, 3 dead sink ), 2 : number of seeds
+ 
  real,    allocatable :: xyzmh_ptmass(:,:)
  real,    allocatable :: vxyz_ptmass(:,:)
  real,    allocatable :: fxyz_ptmass(:,:),fxyz_ptmass_sinksink(:,:),fsink_old(:,:),fxyz_ptmass_tree(:,:)
@@ -230,9 +232,8 @@ module part
     'hsoft    ','maccreted','spinx    ','spiny    ','spinz    ',&
     'tlast    ','lum      ','Teff     ','Reff     ','mdotloss ',&
     'mdotav   ','mprev    ','massenc  ','J2       ','Rstrom   ',&
-    'rate_ion ','tbirth   '/)
+    'rate_ion ','tbirth   ','sftype   ','nseed    '/)
  character(len=*), parameter :: vxyz_ptmass_label(3) = (/'vx','vy','vz'/)
- character(len=*), parameter :: sf_ptmass_label(2) = (/'type  ','nseed '/)
 !
 !--self-gravity
 !
@@ -498,7 +499,6 @@ subroutine allocate_part
  call allocate_array('fxyz_ptmass_sinksink', fxyz_ptmass_sinksink, 4, maxptmass)
  call allocate_array('fsink_old', fsink_old, 4, maxptmass)
  call allocate_array('dptmass', dptmass, ndptmass,maxptmass)
- call allocate_array('sf_ptmass', sf_ptmass, 2, maxptmass)
  call allocate_array('dsdt_ptmass', dsdt_ptmass, 3, maxptmass)
  call allocate_array('dsdt_ptmass_sinksink', dsdt_ptmass_sinksink, 3, maxptmass)
  call allocate_array('poten', poten, maxgrav)
@@ -598,7 +598,6 @@ subroutine deallocate_part
  if (allocated(fxyz_ptmass_sinksink)) deallocate(fxyz_ptmass_sinksink)
  if (allocated(fsink_old))    deallocate(fsink_old)
  if (allocated(dptmass))      deallocate(dptmass)
- if (allocated(sf_ptmass)) deallocate(sf_ptmass)
  if (allocated(dsdt_ptmass))  deallocate(dsdt_ptmass)
  if (allocated(dsdt_ptmass_sinksink)) deallocate(dsdt_ptmass_sinksink)
  if (allocated(poten))        deallocate(poten)
@@ -667,7 +666,6 @@ subroutine init_part
  xyzmh_ptmass = 0.
  vxyz_ptmass  = 0.
  dsdt_ptmass  = 0.
- sf_ptmass = 0
 
 !--initialise sinktree array
  shortsinktree = 1

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -1124,9 +1124,10 @@ end subroutine update_ptmass
 !+
 !-------------------------------------------------------------------------
 subroutine ptmass_create(nptmass,npart,itest,xyzh,pxyzu,fxyzu,fext,divcurlv,poten,&
-                         massoftype,xyzmh_ptmass,pxyzu_ptmass,fxyz_ptmass,fxyz_ptmass_sinksink,sf_ptmass,dptmass,time)
+                         massoftype,xyzmh_ptmass,pxyzu_ptmass,fxyz_ptmass,fxyz_ptmass_sinksink,dptmass,time)
  use part,          only:ihacc,ihsoft,itbirth,igas,iamtype,get_partinfo,iphase,iactive,maxphase,rhoh, &
-                         ispinx,ispiny,ispinz,eos_vars,igasP,igamma,ndptmass,apr_level,aprmassoftype,metrics_ptmass
+                         ispinx,ispiny,ispinz,eos_vars,igasP,igamma,ndptmass,apr_level,aprmassoftype,metrics_ptmass,&
+                         isftype,inseed
  use dim,           only:maxp,maxneigh,maxvxyzu,maxptmass,ind_timesteps,use_apr,maxpsph,gr
  use kdtree,        only:getneigh
  use kernel,        only:kernel_softening,radkern
@@ -1153,7 +1154,6 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,pxyzu,fxyzu,fext,divcurlv,pote
  real(4),         intent(in)    :: divcurlv(:,:),poten(:)
  real,            intent(inout) :: xyzmh_ptmass(:,:),dptmass(ndptmass,maxptmass)
  real,            intent(inout) :: pxyzu_ptmass(:,:),fxyz_ptmass(4,maxptmass),fxyz_ptmass_sinksink(4,maxptmass)
- integer,         intent(inout) :: sf_ptmass(2,maxptmass)
  real,            intent(in)    :: time
  integer(kind=1)    :: iphasei,ibin_wakei,ibin_itest
  integer            :: nneigh
@@ -1692,8 +1692,8 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,pxyzu,fxyzu,fext,divcurlv,pote
     nptmass = new_nptmass
     ! link the new sink to nothing (waiting for age > tseeds)
     if (icreate_sinks == 2) then
-       sf_ptmass(1,nptmass) = 1
-       sf_ptmass(2,nptmass) = 0
+       xyzmh_ptmass(isftype,nptmass) = 1.
+       xyzmh_ptmass(inseed,nptmass)  = 0.
     endif
     !
     ! open new file to track new sink particle details & and update all sink-tracking files;
@@ -1725,20 +1725,20 @@ end subroutine ptmass_create
 !  subroutine to create a bunch of star "seeds" inside a sink particle
 !+
 !-------------------------------------------------------------------------
-subroutine ptmass_create_seeds(nptmass,itest,sf_ptmass,time)
- use part,   only:itbirth,ihacc
+subroutine ptmass_create_seeds(nptmass,itest,xyzmh_ptmass,time)
+ use part,   only:itbirth,ihacc,inseed
  use random, only:ran2
  use io,     only:iprint
  integer, intent(inout) :: nptmass
  integer, intent(in)    :: itest
- integer, intent(inout) :: sf_ptmass(:,:)
+ real, intent(inout)    :: xyzmh_ptmass(:,:)
  real,    intent(in)    :: time
  integer :: nseed
 !
 !-- Draw the number of star seeds in the core
 !
  nseed = ceiling(n_max*ran2(iseed_sf))
- sf_ptmass(2,itest) = nseed
+ xyzmh_ptmass(inseed,itest) = real(nseed)
 
  write(iprint,"(a,i3,a,i3,a,es10.3)") ' Star formation prescription : creation of :',&
                                            nseed, ' seeds in sink n° :', itest, " t= ",time
@@ -1751,16 +1751,16 @@ end subroutine ptmass_create_seeds
 !+
 !-------------------------------------------------------------------------
 subroutine ptmass_create_stars(nptmass,itest,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,&
-                               fxyz_ptmass_sinksink,sf_ptmass,time)
+                               fxyz_ptmass_sinksink,time)
  use dim,       only:maxptmass
  use physcon,   only:solarm,pi
  use io,        only:iprint,iverbose
  use units,     only:umass
- use part,      only:itbirth,ihacc,ihsoft,ispinx,ispiny,ispinz
+ use part,      only:itbirth,ihacc,ihsoft,ispinx,ispiny,ispinz,isftype,inseed
  use random ,   only:ran2,gauss_random,divide_unit_seg
  use HIIRegion, only:update_ionrate,iH2R
  integer, intent(in)    :: itest
- integer, intent(inout) :: nptmass,sf_ptmass(2,maxptmass)
+ integer, intent(inout) :: nptmass
  real,    intent(inout) :: xyzmh_ptmass(nsinkproperties,maxptmass),vxyz_ptmass(3,maxptmass)
  real,    intent(inout) :: fxyz_ptmass(4,maxptmass),fxyz_ptmass_sinksink(4,maxptmass)
  real,    intent(in)    :: time
@@ -1784,11 +1784,10 @@ subroutine ptmass_create_stars(nptmass,itest,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmas
  spini(1) = xyzmh_ptmass(ispinx,itest)
  spini(2) = xyzmh_ptmass(ispiny,itest)
  spini(3) = xyzmh_ptmass(ispinz,itest)
+ n        = nint(xyzmh_ptmass(inseed,itest))
  vi(1)    = vxyz_ptmass(1,itest)
  vi(2)    = vxyz_ptmass(2,itest)
  vi(3)    = vxyz_ptmass(3,itest)
-
- n     = sf_ptmass(2,itest)
  vcom = 0.
  xcom = 0.
 
@@ -1799,9 +1798,9 @@ subroutine ptmass_create_stars(nptmass,itest,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmas
  !
  if (n<2) then
     xyzmh_ptmass(ihacc,itest)       = hacci*1.e-3
-    fxyz_ptmass(1:4,itest)          = 0.
+    xyzmh_ptmass(isftype,itest)     = 2.
     fxyz_ptmass_sinksink(1:4,itest) = 0.
-    sf_ptmass(1,itest)              = 2
+    fxyz_ptmass(1:4,itest)          = 0.
     if (iH2R > 0) call update_ionrate(itest,xyzmh_ptmass,h_acc)
  else
     allocate(masses(n))
@@ -1874,8 +1873,8 @@ subroutine ptmass_create_stars(nptmass,itest,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmas
           vxyz_ptmass(3,k)            = vk(3)
           fxyz_ptmass(1:4,k)          = 0.
           fxyz_ptmass_sinksink(1:4,k) = 0.
-          sf_ptmass(1,k) = 2
-          sf_ptmass(2,k) = 0
+          xyzmh_ptmass(isftype,k) = 2.
+          xyzmh_ptmass(inseed,k)  = 0.
        enddo
 
        !
@@ -1969,15 +1968,16 @@ end subroutine ptmass_create_stars
 ! by releasing and killing some of them...
 !+
 !-------------------------------------------------------------------------
-subroutine ptmass_merge_release(itest,ni,nj,mi,mj,nptmass,xyzmh_ptmass,pxyz_ptmass,fxyz_ptmass,sf_ptmass)
+subroutine ptmass_merge_release(itest,ni,nj,mi,mj,nptmass,xyzmh_ptmass,pxyz_ptmass,fxyz_ptmass)
  use random ,   only:ran2,rinsphere,divide_unit_seg,ronsphere
  use dim,       only:maxptmass,nvel_ptmass
  use io,        only:iverbose,iprint
  use units,     only:umass
  use physcon,   only:solarm
+ use part,      only:isftype,inseed
  integer, intent(in)    :: itest,ni,nj
  real,    intent(in)    :: mi,mj
- integer, intent(inout) :: nptmass,sf_ptmass(2,maxptmass)
+ integer, intent(inout) :: nptmass
  real,    intent(inout) :: xyzmh_ptmass(nsinkproperties,maxptmass), &
                            pxyz_ptmass(nvel_ptmass,maxptmass),fxyz_ptmass(4,maxptmass)
  real, allocatable :: masses(:)
@@ -2032,7 +2032,7 @@ subroutine ptmass_merge_release(itest,ni,nj,mi,mj,nptmass,xyzmh_ptmass,pxyz_ptma
  vi(1)   = pxyz_ptmass(1,itest)
  vi(2)   = pxyz_ptmass(2,itest)
  vi(3)   = pxyz_ptmass(3,itest)
- sf_ptmass(2,itest) = nsav
+ xyzmh_ptmass(inseed,itest) = real(nsav)
 
  vcom = 0.
  xcom = 0.
@@ -2057,12 +2057,12 @@ subroutine ptmass_merge_release(itest,ni,nj,mi,mj,nptmass,xyzmh_ptmass,pxyz_ptma
     xyzmh_ptmass(ispinx,nptmass+i)      = 0. !
     xyzmh_ptmass(ispiny,nptmass+i)      = 0. ! -- No spin for the instant
     xyzmh_ptmass(ispinz,nptmass+i)      = 0. !
+    xyzmh_ptmass(isftype,nptmass+i)     = 2.
+    xyzmh_ptmass(inseed,nptmass+i)      = 0.
     pxyz_ptmass(1,nptmass+i)            = vk(1)
     pxyz_ptmass(2,nptmass+i)            = vk(2)
     pxyz_ptmass(3,nptmass+i)            = vk(3)
     fxyz_ptmass(1:4,nptmass+i)          = 0.
-    sf_ptmass(1,nptmass+i)              = 2
-    sf_ptmass(2,nptmass+i)              = 0
  enddo
 
  !
@@ -2110,22 +2110,21 @@ end subroutine ptmass_merge_release
 !  subroutine to check if a core needs to create seeds or stars
 !+
 !-------------------------------------------------------------------------
-subroutine ptmass_check_stars(xyzmh_ptmass,sf_ptmass,nptmass,time)
- use part, only : itbirth
+subroutine ptmass_check_stars(xyzmh_ptmass,nptmass,time)
+ use part, only : itbirth,isftype,inseed
  real,    intent(in) :: time
  integer, intent(in) :: nptmass
  real,    intent(in) :: xyzmh_ptmass(:,:)
- integer, intent(in) :: sf_ptmass(:,:)
  integer :: i
  real    :: tbirthi
 
  do i=1,nptmass
     tbirthi = xyzmh_ptmass(itbirth,i)
-    if (sf_ptmass(1,i) == 1 .and. xyzmh_ptmass(4,i)>0.) then
+    if (nint(xyzmh_ptmass(isftype,i)) == 1 .and. xyzmh_ptmass(4,i)>0.) then
        if (tbirthi + tmax_acc < time) then
           if (ipart_createstars == 0) ipart_createstars = i
        endif
-       if ((tbirthi + tseeds < time) .and. (sf_ptmass(2,i) == 0) .and. &
+       if ((tbirthi + tseeds < time) .and. (nint(xyzmh_ptmass(inseed,i)) == 0) .and. &
         (ipart_createseeds == 0)) then
           ipart_createseeds = i
        endif
@@ -2158,16 +2157,15 @@ end subroutine ptmass_check_stars
 !+
 !-----------------------------------------------------------------------
 subroutine merge_sinks(time,nptmass,xyzmh_ptmass,pxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,&
-                       sf_ptmass,merge_ij,metrics_ptmass)
+                       merge_ij,metrics_ptmass)
  use io,           only:iprint,warning,iverbose,id,master,fatal
  use dim,          only:maxptmass,gr,nvel_ptmass
- use part,         only:itbirth
+ use part,         only:itbirth,isftype,inseed
  use dim,          only:use_sinktree
  use metric_tools, only:pack_metric
  real,    intent(in)    :: time
  integer, intent(inout) :: nptmass
  integer, intent(in)    :: merge_ij(nptmass)
- integer, intent(inout) :: sf_ptmass(2,maxptmass)
  real,    intent(inout) :: xyzmh_ptmass(nsinkproperties,maxptmass)
  real,    intent(inout) :: pxyz_ptmass(nvel_ptmass,maxptmass),fxyz_ptmass(4,maxptmass)
  real,    intent(inout) :: fxyz_ptmass_tree(3,maxptmass)
@@ -2249,18 +2247,18 @@ subroutine merge_sinks(time,nptmass,xyzmh_ptmass,pxyz_ptmass,fxyz_ptmass,fxyz_pt
              xyzmh_ptmass(ihacc,j)  = -1.
              if (icreate_sinks == 2) then
                 ! Merge stars seeds and release escapers
-                if (sf_ptmass(2,j)>=0) then
-                   ni = sf_ptmass(2,i)
-                   nj = sf_ptmass(2,j)
+                if (nint(xyzmh_ptmass(inseed,j))>=0) then
+                   ni = nint(xyzmh_ptmass(inseed,i))
+                   nj = nint(xyzmh_ptmass(inseed,j))
                    if (ni+nj > 3) then
-                      call ptmass_merge_release(i,ni,nj,mi,mj,nptmass,xyzmh_ptmass,pxyz_ptmass,fxyz_ptmass,sf_ptmass)
+                      call ptmass_merge_release(i,ni,nj,mi,mj,nptmass,xyzmh_ptmass,pxyz_ptmass,fxyz_ptmass)
                    else
-                      sf_ptmass(2,i) = ni+nj
+                      xyzmh_ptmass(inseed,i) = real(ni+nj)
                    endif
                 else
                    call fatal(label,'Merge with a star or a dead clump of gas... Something wrong')
                 endif
-                sf_ptmass(1,j) = 3
+                xyzmh_ptmass(isftype,j) = 3.
              endif
              ! print success
              write(iprint,"(/,1x,3a,i8,a,i8,a,1pg10.4)") 'merge_sinks: ',typ,' merged sinks ',i,' & ',j,' at time = ',time
@@ -2590,7 +2588,7 @@ end subroutine write_options_ptmass
 subroutine read_options_ptmass(name,valstring,imatch,igotall,ierr)
  use io,         only:warning,fatal
  use subgroup,   only:r_neigh
- use dim,        only:store_sf_ptmass,use_sinktree
+ use dim,        only:use_sinktree
  character(len=*), intent(in)  :: name,valstring
  logical,          intent(out) :: imatch,igotall
  integer,          intent(out) :: ierr
@@ -2680,7 +2678,6 @@ subroutine read_options_ptmass(name,valstring,imatch,igotall,ierr)
     imatch = .false.
  end select
 
- if (icreate_sinks == 2) store_sf_ptmass = .true.
 
  !--make sure we have got all compulsory options (otherwise, rewrite input file)
  if (icreate_sinks > 0) then

--- a/src/main/readwrite_dumps_common.f90
+++ b/src/main/readwrite_dumps_common.f90
@@ -573,7 +573,7 @@ subroutine check_arrays(i1,i2,noffset,npartoftype,npartread,nptmass,nsinkpropert
                         got_eosvars,got_nucleation,got_iorig,got_apr_level,&
                         iphase,xyzh,vxyzu,pxyzu,alphaind,xyzmh_ptmass,Bevol,iorig,iprint,ierr)
  use dim,  only:maxp,maxvxyzu,maxalpha,maxBevol,mhd,h2chemistry,use_dustgrowth,gr,&
-                do_radiation,store_dust_temperature,do_nucleation,use_krome,use_apr,store_sf_ptmass
+                do_radiation,store_dust_temperature,do_nucleation,use_krome,use_apr
  use eos,  only:ieos,polyk,gamma,eos_is_non_ideal
  use part, only:maxphase,isetphase,set_particle_type,igas,ihacc,ihsoft,imacc,ilum,ikappa,&
                 xyzmh_ptmass_label,vxyz_ptmass_label,get_pmass,rhoh,dustfrac,ndusttypes,norig,&
@@ -768,9 +768,6 @@ subroutine check_arrays(i1,i2,noffset,npartoftype,npartread,nptmass,nsinkpropert
     enddo
     if (.not.all(got_sink_vels(1:3))) then
        if (id==master .and. i1==1) write(*,"(/,a,/)") 'WARNING! sink particle velocities not found'
-    endif
-    if ( store_sf_ptmass .and. .not.all(got_sink_sfprop(1:2))) then
-       if (id==master .and. i1==1) write(*,"(/,a,/)") 'WARNING! sink particle link list not found'
     endif
     if (id==master .and. i1==1) then
        print "(2(a,i4),a)",' got ',nsinkproperties,' sink properties from ',nptmass,' sink particles'

--- a/src/main/readwrite_dumps_fortran.f90
+++ b/src/main/readwrite_dumps_fortran.f90
@@ -53,15 +53,14 @@ contains
 subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
  use dim,   only:maxp,maxvxyzu,maxalpha,ndivcurlv,ndivcurlB,maxgrav,gravity,use_dust,&
                  lightcurve,use_dustgrowth,store_dust_temperature,gr,do_nucleation,&
-                 ind_timesteps,mhd_nonideal,use_krome,h2chemistry,update_muGamma,mpi,use_apr,&
-                 store_sf_ptmass
+                 ind_timesteps,mhd_nonideal,use_krome,h2chemistry,update_muGamma,mpi,use_apr
  use eos,   only:ieos,eos_is_non_ideal,eos_outputs_mu,eos_outputs_gasP
  use io,    only:idump,iprint,real4,id,master,error,warning,nprocs
  use part,  only:xyzh,xyzh_label,vxyzu,vxyzu_label,Bevol,Bevol_label,Bxyz,Bxyz_label,npart,maxtypes, &
                  npartoftypetot,update_npartoftypetot, &
                  alphaind,rhoh,divBsymm,maxphase,iphase,iamtype_int1,iamtype_int11, &
-                 nptmass,nsinkproperties,xyzmh_ptmass,xyzmh_ptmass_label,vxyz_ptmass,vxyz_ptmass_label, sf_ptmass, &
-                 sf_ptmass_label,maxptmass,get_pmass,nabundances,abundance,abundance_label,mhd,&
+                 nptmass,nsinkproperties,xyzmh_ptmass,xyzmh_ptmass_label,vxyz_ptmass,vxyz_ptmass_label, &
+                 maxptmass,get_pmass,nabundances,abundance,abundance_label,mhd,&
                  divcurlv,divcurlv_label,divcurlB,divcurlB_label,poten,dustfrac,deltav,deltav_label,tstop,&
                  dustfrac_label,tstop_label,dustprop,dustprop_label,eos_vars,eos_vars_label,ndusttypes,ndustsmall,VrelVf,&
                  VrelVf_label,dustgasprop,dustgasprop_label,filfac,filfac_label,dust_temp,pxyzu,pxyzu_label,dens,& !,dvdx,dvdx_label
@@ -321,9 +320,6 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
           ilen(2) = int(nptmass,kind=8)
           call write_array(2,xyzmh_ptmass,xyzmh_ptmass_label,nsinkproperties,nptmass,k,ipass,idump,nums,nerr)
           call write_array(2,vxyz_ptmass,vxyz_ptmass_label,3,nptmass,k,ipass,idump,nums,nerr)
-          if (store_sf_ptmass) then
-             call write_array(2,sf_ptmass,sf_ptmass_label,2,nptmass,k,ipass,idump,nums,nerr)
-          endif
           if (nerr > 0) call error('write_dump','error writing sink particle arrays')
        endif
     enddo
@@ -993,10 +989,10 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
  use dump_utils, only:read_array,match_tag
  use dim,        only:use_dust,h2chemistry,maxalpha,maxp,gravity,maxgrav,maxvxyzu,do_nucleation, &
                       use_dustgrowth,maxdusttypes,ndivcurlv,maxphase,gr,store_dust_temperature,&
-                      ind_timesteps,use_krome,use_apr,store_sf_ptmass,mhd
+                      ind_timesteps,use_krome,use_apr,mhd
  use part,       only:xyzh,xyzh_label,vxyzu,vxyzu_label,dustfrac,dustfrac_label,abundance,abundance_label, &
-                      alphaind,poten,xyzmh_ptmass,xyzmh_ptmass_label,vxyz_ptmass,vxyz_ptmass_label,sf_ptmass, &
-                      sf_ptmass_label,Bevol,Bxyz,Bxyz_label,nabundances,iphase,idust, &
+                      alphaind,poten,xyzmh_ptmass,xyzmh_ptmass_label,vxyz_ptmass,vxyz_ptmass_label, &
+                      Bevol,Bxyz,Bxyz_label,nabundances,iphase,idust, &
                       eos_vars,eos_vars_label,maxeosvars,dustprop,dustprop_label,divcurlv,divcurlv_label,iX,iZ,imu, &
                       VrelVf,VrelVf_label,dustgasprop,dustgasprop_label,filfac,filfac_label,pxyzu,pxyzu_label,dust_temp, &
                       rad,rad_label,radprop,radprop_label,do_radiation,maxirad,maxradprop,ifluxx,ifluxy,ifluxz, &
@@ -1145,9 +1141,6 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
           case(2)
              call read_array(xyzmh_ptmass,xyzmh_ptmass_label,got_sink_data,ik,1,nptmass,0,idisk1,tag,match,ierr)
              call read_array(vxyz_ptmass, vxyz_ptmass_label, got_sink_vels,ik,1,nptmass,0,idisk1,tag,match,ierr)
-             if (store_sf_ptmass) then
-                call read_array(sf_ptmass,sf_ptmass_label,got_sink_sfprop,ik,1,nptmass,0,idisk1,tag,match,ierr)
-             endif
           end select
           select case(iarr)   ! MHD arrays can either be in block 1 or block 4
           case(1,4)

--- a/src/main/step_leapfrog.F90
+++ b/src/main/step_leapfrog.F90
@@ -105,7 +105,7 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
  use timestep,       only:dterr,bignumber,tolv
  use mpiutils,       only:reduceall_mpi,bcast_mpi
  use part,           only:nptmass,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass, &
-                          dsdt_ptmass,fsink_old,ibin_wake,dptmass,sf_ptmass, &
+                          dsdt_ptmass,fsink_old,ibin_wake,dptmass, &
                           pxyzu_ptmass,metrics_ptmass
  use part,           only:n_group,n_ingroup,n_sing,gtgrad,group_info,bin_info,nmatrix
  use io_summary,     only:summary_printout,summary_variable,iosumtvi,iowake, &
@@ -264,7 +264,7 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
        call substep_gr(npart,ntypes,nptmass,dtsph,dtextforce,t,xyzh,vxyzu,pxyzu,dens,metrics,metricderivs, &
                        fext,xyzmh_ptmass,vxyz_ptmass,pxyzu_ptmass,metrics_ptmass,metricderivs_ptmass,&
                        fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass, &
-                       dptmass,sf_ptmass,fsink_old,nbinmax,ibin_wake,gtgrad, &
+                       dptmass,fsink_old,nbinmax,ibin_wake,gtgrad, &
                        group_info,bin_info,nmatrix,n_group,n_ingroup,n_sing,isionised)
     else
        call substep_sph_gr(dtsph,npart,xyzh,vxyzu,dens,pxyzu,metrics)
@@ -273,7 +273,7 @@ subroutine step(npart,nactive,t,dtsph,dtextforce,dtnew)
     if (nptmass > 0 .or. iexternalforce > 0 .or. h2chemistry .or. cooling_in_step .or. idamp > 0) then
        call substep(npart,ntypes,nptmass,dtsph,dtextforce,t,xyzh,vxyzu,&
                     fext,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,&
-                    dptmass,sf_ptmass,fsink_old,nbinmax,ibin_wake,gtgrad, &
+                    dptmass,fsink_old,nbinmax,ibin_wake,gtgrad, &
                     group_info,bin_info,nmatrix,n_group,n_ingroup,n_sing,isionised)
     else
        call substep_sph(dtsph,npart,xyzh,vxyzu)

--- a/src/main/substepping.F90
+++ b/src/main/substepping.F90
@@ -110,7 +110,7 @@ end subroutine substep_sph_gr
 
 subroutine substep_gr(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,pxyzu,dens,metrics,metricderivs,fext, &
                       xyzmh_ptmass,vxyz_ptmass,pxyzu_ptmass,metrics_ptmass,metricderivs_ptmass,fxyz_ptmass,&
-                      fxyz_ptmass_tree,dsdt_ptmass,dptmass,sf_ptmass,fsink_old,nbinmax,ibin_wake,gtgrad,group_info, &
+                      fxyz_ptmass_tree,dsdt_ptmass,dptmass,fsink_old,nbinmax,ibin_wake,gtgrad,group_info, &
                       bin_info,nmatrix,n_group,n_ingroup,n_sing,isionised)
 use io,             only:iverbose,id,master,iprint,fatal
 use part,           only:fxyz_ptmass_sinksink,ndptmass
@@ -128,7 +128,6 @@ real,            intent(inout) :: pxyzu_ptmass(:,:),metrics_ptmass(:,:,:,:),metr
 real,            intent(inout) :: dptmass(ndptmass,nptmass),fsink_old(:,:),gtgrad(:,:),bin_info(:,:)
 real,            intent(inout) :: fxyz_ptmass_tree(:,:)
 integer(kind=1), intent(in)    :: nbinmax
-integer        , intent(inout) :: sf_ptmass(:,:)
 integer(kind=1), intent(inout) :: ibin_wake(:),nmatrix(nptmass,nptmass)
 logical,         intent(in)    :: isionised(:)
 logical :: extf_vdep_flag,done,last_step,accreted
@@ -173,7 +172,7 @@ accreted       = .false.
     extf_vdep_flag = .false.
     call get_force(nptmass,npart,nsubsteps,ntypes,time_par,dtextforce,xyzh,vxyzu,fext,xyzmh_ptmass, &
                    vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,dt,dk(2),force_count,&
-                   extf_vdep_flag,sf_ptmass,bin_info,group_info,nmatrix,isionised=isionised, &
+                   extf_vdep_flag,bin_info,group_info,nmatrix,isionised=isionised, &
                    metrics=metrics,metricderivs=metricderivs,&
                    metrics_ptmass=metrics_ptmass,metricderivs_ptmass=metricderivs_ptmass,dens=dens,&
                    pxyzu_ptmass=pxyzu_ptmass)
@@ -187,7 +186,7 @@ accreted       = .false.
        ! cons2prim call needed here
        call get_force(nptmass,npart,nsubsteps,ntypes,time_par,dtextforce,xyzh,vxyzu,fext,xyzmh_ptmass, &
                       vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,dt,dk(2),force_count,&
-                      extf_vdep_flag,sf_ptmass,bin_info,group_info,nmatrix,&
+                      extf_vdep_flag,bin_info,group_info,nmatrix,&
                       metrics=metrics,metricderivs=metricderivs,&
                       metrics_ptmass=metrics_ptmass,metricderivs_ptmass=metricderivs_ptmass,dens=dens)
     endif
@@ -206,7 +205,7 @@ accreted       = .false.
     endif
  enddo substeps
 
- if (icreate_sinks == 2) call ptmass_check_stars(xyzmh_ptmass,sf_ptmass,nptmass,timei)
+ if (icreate_sinks == 2) call ptmass_check_stars(xyzmh_ptmass,nptmass,timei)
 
  if (nsubsteps > 1) then
     if (iverbose >=1 .and. id==master) then
@@ -261,7 +260,7 @@ end subroutine substep_sph
 !----------------------------------------------------------------
 subroutine substep(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,fext, &
                    xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,&
-                   dptmass,sf_ptmass,fsink_old,nbinmax,ibin_wake,gtgrad,group_info, &
+                   dptmass,fsink_old,nbinmax,ibin_wake,gtgrad,group_info, &
                    bin_info,nmatrix,n_group,n_ingroup,n_sing,isionised)
  use io,             only:iverbose,id,master,iprint,fatal
  use options,        only:iexternalforce
@@ -280,7 +279,6 @@ subroutine substep(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,fext, &
  real,            intent(inout) :: dptmass(ndptmass,nptmass),fsink_old(:,:),gtgrad(:,:),bin_info(:,:)
  real,            intent(inout) :: fxyz_ptmass_tree(:,:)
  integer(kind=1), intent(in)    :: nbinmax
- integer        , intent(inout) :: sf_ptmass(:,:)
  integer(kind=1), intent(inout) :: ibin_wake(:),nmatrix(nptmass,nptmass)
  logical,         intent(in)    :: isionised(:)
  logical :: extf_vdep_flag,done,last_step,accreted
@@ -328,14 +326,14 @@ subroutine substep(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,fext, &
 
     call get_force(nptmass,npart,nsubsteps,ntypes,time_par,dtextforce,xyzh,vxyzu,fext,xyzmh_ptmass, &
                    vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,dt,dk(2),force_count,&
-                   extf_vdep_flag,sf_ptmass,bin_info,group_info,nmatrix,isionised=isionised)
+                   extf_vdep_flag,bin_info,group_info,nmatrix,isionised=isionised)
 
     if (use_fourthorder) then !! FSI 4th order scheme
 
        ! FSI extrapolation method (Omelyan 2006)
        call get_force(nptmass,npart,nsubsteps,ntypes,time_par,dtextforce,xyzh,vxyzu,fext,xyzmh_ptmass, &
                       vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,dt,dk(2),force_count,&
-                      extf_vdep_flag,sf_ptmass,bin_info,group_info,nmatrix,fsink_old)
+                      extf_vdep_flag,bin_info,group_info,nmatrix,fsink_old)
 
        call kick(dk(2),dt,npart,nptmass,ntypes,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
                  fext,fxyz_ptmass,dsdt_ptmass,dptmass)
@@ -346,7 +344,7 @@ subroutine substep(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,fext, &
 
        call get_force(nptmass,npart,nsubsteps,ntypes,time_par,dtextforce,xyzh,vxyzu,fext,xyzmh_ptmass, &
                       vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,dt,dk(3),force_count,&
-                      extf_vdep_flag,sf_ptmass,bin_info,group_info,nmatrix,isionised=isionised)
+                      extf_vdep_flag,bin_info,group_info,nmatrix,isionised=isionised)
 
        ! the last kick phase of the scheme will perform the accretion loop after velocity update
 
@@ -359,11 +357,11 @@ subroutine substep(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,fext, &
                               dtext=dtgroup)
           call get_force(nptmass,npart,nsubsteps,ntypes,time_par,dtextforce,xyzh,vxyzu,fext,xyzmh_ptmass, &
                          vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,dt,dk(3),force_count,&
-                         extf_vdep_flag,sf_ptmass,bin_info,group_info,nmatrix)
+                         extf_vdep_flag,bin_info,group_info,nmatrix)
        elseif (accreted) then
           call get_force(nptmass,npart,nsubsteps,ntypes,time_par,dtextforce,xyzh,vxyzu,fext,xyzmh_ptmass, &
                          vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,dt,dk(3),force_count,&
-                         extf_vdep_flag,sf_ptmass,bin_info,group_info,nmatrix)
+                         extf_vdep_flag,bin_info,group_info,nmatrix)
        endif
     else  !! standard leapfrog scheme
        ! the last kick phase of the scheme will perform the accretion loop after velocity update
@@ -373,7 +371,7 @@ subroutine substep(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,fext, &
        if (accreted) then
           call get_force(nptmass,npart,nsubsteps,ntypes,time_par,dtextforce,xyzh,vxyzu,fext,xyzmh_ptmass, &
                          vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,dt,dk(2),force_count,&
-                         extf_vdep_flag,sf_ptmass,bin_info,group_info,nmatrix)
+                         extf_vdep_flag,bin_info,group_info,nmatrix)
        endif
     endif
 
@@ -391,7 +389,7 @@ subroutine substep(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,fext, &
     endif
  enddo substeps
 
- if (icreate_sinks == 2) call ptmass_check_stars(xyzmh_ptmass,sf_ptmass,nptmass,timei)
+ if (icreate_sinks == 2) call ptmass_check_stars(xyzmh_ptmass,nptmass,timei)
 
  if (nsubsteps > 1) then
     if (iverbose >=1 .and. id==master) then
@@ -673,8 +671,8 @@ end subroutine kick
 !----------------------------------------------------------------
 subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu, &
                      fext,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,&
-                     dsdt_ptmass,dt,dki,force_count,extf_vdep_flag,sf_ptmass,&
-                     bin_info,group_info,nmatrix,fsink_old,isionised,&
+                     dsdt_ptmass,dt,dki,force_count,extf_vdep_flag,bin_info,&
+                     group_info,nmatrix,fsink_old,isionised,&
                      metrics,metricderivs,metrics_ptmass,metricderivs_ptmass,dens,pxyzu_ptmass)
  use io,              only:iverbose,master,id,iprint,warning,fatal
  use dim,             only:maxp,maxvxyzu,itau_alloc,gr,use_apr,maxptmass,use_sinktree
@@ -699,7 +697,6 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
  use timing,          only:get_timings,increment_timer,itimer_gasf,itimer_sinksink
  integer,                  intent(in)    :: npart,nsubsteps,ntypes
  integer,                  intent(inout) :: force_count,nptmass
- integer,                  intent(inout) :: sf_ptmass(:,:)
  real,                     intent(inout) :: xyzh(:,:),vxyzu(:,:),fext(:,:)
  real,                     intent(inout) :: xyzmh_ptmass(:,:),vxyz_ptmass(:,:)
  real,                     intent(inout) :: fxyz_ptmass(4,maxptmass),dsdt_ptmass(3,maxptmass)
@@ -767,7 +764,7 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
                                    group_info,bin_info,extrapfac,fsink_old)
           if (merge_n > 0) then
              call merge_sinks(timei,nptmass,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,&
-                              fxyz_ptmass_tree,sf_ptmass,merge_ij)
+                              fxyz_ptmass_tree,merge_ij)
              if (use_regnbody) call group_identify(nptmass,n_group,n_ingroup,n_sing,xyzmh_ptmass,&
                                                    vxyz_ptmass,group_info,bin_info,nmatrix,dtext=dt)
              call get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,epot_sinksink,&
@@ -783,7 +780,7 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
              if (merge_n > 0) then
                 ! for GR we have to pass in pxyzu_ptmass instead of vxyz_ptmass to merge_sinks
                 call merge_sinks(timei,nptmass,xyzmh_ptmass,pxyzu_ptmass,fxyz_ptmass,&
-                                 fxyz_ptmass_tree,sf_ptmass,merge_ij,metrics_ptmass=metrics_ptmass)
+                                 fxyz_ptmass_tree,merge_ij,metrics_ptmass=metrics_ptmass)
                 if (use_regnbody) call group_identify(nptmass,n_group,n_ingroup,n_sing,xyzmh_ptmass,&
                                                       vxyz_ptmass,group_info,bin_info,nmatrix,dtext=dt)
                 call get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,epot_sinksink,&
@@ -797,7 +794,7 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
                                       group_info,bin_info)
              if (merge_n > 0) then
                 call merge_sinks(timei,nptmass,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,&
-                                 fxyz_ptmass_tree,sf_ptmass,merge_ij)
+                                 fxyz_ptmass_tree,merge_ij)
                 if (use_regnbody) call group_identify(nptmass,n_group,n_ingroup,n_sing,xyzmh_ptmass,&
                                                    vxyz_ptmass,group_info,bin_info,nmatrix,dtext=dt)
                 call get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,epot_sinksink,&
@@ -819,7 +816,6 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
     call bcast_mpi(dtf)
     if (icreate_sinks==2) then
        call bcast_mpi(nptmass)
-       call bcast_mpi(sf_ptmass)
     endif
     dtextforcenew = min(dtextforcenew,C_force*dtf)
     call get_timings(t2,tcpu2)

--- a/src/tests/test_gr.f90
+++ b/src/tests/test_gr.f90
@@ -171,7 +171,7 @@ subroutine integrate_geodesic(tmax,dt,xyz,vxyz,angmom0,angmom,use_sink)
  use part,           only:igas,npartoftype,massoftype,set_particle_type,get_ntypes,ien_type,&
                           xyzmh_ptmass,vxyz_ptmass,pxyzu_ptmass,metrics_ptmass,&
                           metricderivs_ptmass,fxyz_ptmass,nptmass,&
-                          fxyz_ptmass_tree,dsdt_ptmass,dptmass,sf_ptmass,fsink_old,ibin_wake,gtgrad,group_info, &
+                          fxyz_ptmass_tree,dsdt_ptmass,dptmass,fsink_old,ibin_wake,gtgrad,group_info, &
                           bin_info,nmatrix,n_group,n_ingroup,n_sing,isionised
  use substepping,    only:substep_gr
  use eos,            only:ieos,gamma
@@ -260,7 +260,7 @@ subroutine integrate_geodesic(tmax,dt,xyz,vxyz,angmom0,angmom,use_sink)
     dtextforce = blah
     call substep_gr(npart,ntypes,nptmass,dt,dtextforce,time,xyzh,vxyzu,pxyzu,dens,metrics,metricderivs,fext, &
                     xyzmh_ptmass,vxyz_ptmass,pxyzu_ptmass,metrics_ptmass,metricderivs_ptmass,fxyz_ptmass,&
-                    fxyz_ptmass_tree,dsdt_ptmass,dptmass,sf_ptmass,fsink_old,nbinmax,ibin_wake,gtgrad,group_info, &
+                    fxyz_ptmass_tree,dsdt_ptmass,dptmass,fsink_old,nbinmax,ibin_wake,gtgrad,group_info, &
                     bin_info,nmatrix,n_group,n_ingroup,n_sing,isionised)
  enddo
 

--- a/src/tests/test_ptmass.f90
+++ b/src/tests/test_ptmass.f90
@@ -1068,7 +1068,7 @@ subroutine test_createsink(ntests,npass)
  use part,         only:init_part,npart,npartoftype,igas,xyzh,massoftype,hfact,rhoh,&
                         iphase,isetphase,fext,divcurlv,vxyzu,fxyzu,poten, &
                         nptmass,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,ndptmass, &
-                        dptmass,fxyz_ptmass_sinksink,sf_ptmass,pxyzu_ptmass,metrics_ptmass
+                        dptmass,fxyz_ptmass_sinksink,pxyzu_ptmass,metrics_ptmass
  use ptmass,       only:ptmass_accrete,update_ptmass,icreate_sinks,&
                         ptmass_create,finish_ptmass,ipart_rhomax,h_acc,rho_crit,rho_crit_cgs, &
                         ptmass_create_stars,tmax_acc,tseeds,ipart_createseeds,ipart_createstars,&
@@ -1161,7 +1161,6 @@ subroutine test_createsink(ntests,npass)
     tree_accuracy = 0.
     if (itest==3) then
        icreate_sinks = 2
-       sf_ptmass = 0.
        tmax_acc = 0.
        tseeds = 0.
        ipart_createseeds = 1
@@ -1226,7 +1225,7 @@ subroutine test_createsink(ntests,npass)
        call reduceloc_mpi('max',ipart_rhomax_global,id_rhomax)
     endif
     call ptmass_create(nptmass,npart,itestp,xyzh,vxyzu,fxyzu,fext,divcurlv,poten,&
-                       massoftype,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_sinksink,sf_ptmass,dptmass,0.)
+                       massoftype,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_sinksink,dptmass,0.)
     if (itest==3) then
        coremass = 0.
        starsmass = 0.
@@ -1237,9 +1236,9 @@ subroutine test_createsink(ntests,npass)
        ri(3)    = xyzmh_ptmass(3,1)
        ri(2)    = xyzmh_ptmass(2,1)
        ri(1)    = xyzmh_ptmass(1,1)
-       call ptmass_create_seeds(nptmass,ipart_createseeds,sf_ptmass,0.)
+       call ptmass_create_seeds(nptmass,ipart_createseeds,xyzmh_ptmass,0.)
        call ptmass_create_stars(nptmass,ipart_createstars,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass, &
-                                fxyz_ptmass_sinksink,sf_ptmass,0.)
+                                fxyz_ptmass_sinksink,0.)
        do i=1,nptmass
           pei = 0.
           do j=1,nptmass
@@ -1314,8 +1313,8 @@ subroutine test_merger(ntests,npass)
  use io,             only:id,master,iverbose
  use part,           only:nptmass,xyzmh_ptmass,vxyz_ptmass,fxyz_ptmass, &
                           npart,ihacc,itbirth,epot_sinksink,dsdt_ptmass,&
-                          sf_ptmass,shortsinktree,fxyz_ptmass_tree,pxyzu_ptmass,&
-                          metrics_ptmass,metricderivs_ptmass
+                          shortsinktree,fxyz_ptmass_tree,pxyzu_ptmass,&
+                          metrics_ptmass,metricderivs_ptmass,isftype,inseed
  use ptmass,         only:h_acc,h_soft_sinksink,get_accel_sink_sink, &
                           r_merge_uncond,r_merge_cond,r_merge_uncond2,&
                           r_merge_cond2,r_merge2,icreate_sinks,n_max
@@ -1433,9 +1432,9 @@ subroutine test_merger(ntests,npass)
        xyzmh_ptmass(2,itbirth) = 0.4*pos_fac + x0(2)
        n_max = 5
        icreate_sinks   = 2
-       sf_ptmass(1,:)  = 1
-       sf_ptmass(2,1)  = 4
-       sf_ptmass(2,2)  = 3
+       xyzmh_ptmass(isftype,:)  = 1.
+       xyzmh_ptmass(inseed,1)   = 4.
+       xyzmh_ptmass(inseed,2)   = 3.
        merged_expected = .true.
     case(10)
        if (id==master) write(*,"(/,a)") '--> testing merging with icreate_sinks == 2 (one sink is only gas)'
@@ -1447,9 +1446,9 @@ subroutine test_merger(ntests,npass)
        xyzmh_ptmass(2,itbirth) = 0.4*pos_fac + x0(2)
        n_max = 5
        icreate_sinks   = 2
-       sf_ptmass(1,:)  = 1
-       sf_ptmass(2,1)  = 0
-       sf_ptmass(2,2)  = 3
+       xyzmh_ptmass(isftype,:)  = 1.
+       xyzmh_ptmass(inseed,1)   = 0.
+       xyzmh_ptmass(inseed,2)   = 3.
        merged_expected = .true.
     end select
     if (itest /= 8) then
@@ -1557,9 +1556,9 @@ subroutine test_merger(ntests,npass)
     endif
     call checkval(mtot,mtot0,1.e-13,nfailed(7*itest),'conservation of mass')
     if (itest==9) then
-       call checkval(sf_ptmass(2,1)+nsinkF,8,0,nfailed(8*itest),'conservation of star seeds')
+       call checkval(nint(xyzmh_ptmass(inseed,1))+nsinkF,8,0,nfailed(8*itest),'conservation of star seeds')
     elseif (itest==10) then
-       call checkval(sf_ptmass(2,2)+nsinkF,4,0,nfailed(8*itest),'conservation of star seeds')
+       call checkval(nint(xyzmh_ptmass(inseed,2))+nsinkF,4,0,nfailed(8*itest),'conservation of star seeds')
     endif
  enddo
  call update_test_scores(ntests,nfailed(1:80),npass)


### PR DESCRIPTION
Type of PR: 
Cleaning

Description:
There is no need to separate `sf_ptmass` and `xyzmh_ptmass`. Merging both simplifies the read and write of dumps and lightens main routine interfaces.

Testing:
All ptmass tests with `icreate_sinks == 2` pass

Did you run the bots? no

Did you update relevant documentation in the docs directory? no