### PR TITLE
ev file goes beyond 99

### DIFF
--- a/src/main/utils_filenames.f90
+++ b/src/main/utils_filenames.f90
@@ -36,7 +36,7 @@ contains
 !----------------------------------------------------------------
 function getnextfilename(filename,ifilename)
  character(len=*), intent(in) :: filename
- character(len=len(filename)) :: getnextfilename
+ character(len=len(filename)+1) :: getnextfilename
  integer :: idot,istartnum,ilen,i,ierr,num
  integer, optional, intent(out) :: ifilename
  character(len=10) :: fmtstring
@@ -63,12 +63,13 @@ function getnextfilename(filename,ifilename)
 !--increment number by one
 !
     num = num + 1
-    write(fmtstring,"('(i',i1,'.',i1,')')") ilen,ilen
+    if (log10(real(num)) >= ilen) ilen = ilen + 1
+    write(fmtstring,"('(a,i',i1,'.',i1,',a)')") ilen,ilen
     getnextfilename = trim(filename)
 !
 !--replace number in new filename
 !
-    write(getnextfilename(istartnum:istartnum+ilen-1),fmtstring) num
+    write(getnextfilename,fmtstring) filename(1:istartnum-1), num, filename(idot:len(filename))
  else
     getnextfilename = trim(filename)//'001'
  endif


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
increase file number digits when the number overflows so it does not give **

Testing:
ev/log file number increase digit correctly to 100 when exceed 99
also tested with dumps, when dump exceed 99999 the digit increases correctly to 100000