### PR TITLE
fix ptmass_heating division by zero error crashes

### DIFF
--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -2497,6 +2497,7 @@ end subroutine calculate_mdot
 !+
 !-----------------------------------------------------------------------
 subroutine ptmass_calc_enclosed_mass(nptmass,npart,xyzh)
+ use io,             only:error
  use part,           only:sink_has_heating,imassenc,ihsoft,massoftype,&
                      igas,xyzmh_ptmass,isdead_or_accreted,aprmassoftype,apr_level
  use ptmass_heating, only:isink_heating,heating_kernel
@@ -2531,6 +2532,9 @@ subroutine ptmass_calc_enclosed_mass(nptmass,npart,xyzh)
     else
        xyzmh_ptmass(imassenc,i) = wi * massoftype(igas)
     endif
+    if (wi .eq. 0.) then   ! wi will be exactly zero if hasn't been touched
+       call error('ptmass','Zero enclosed mass for a sink particle - heating from this sink will not be calculated properly')
+    end if
  enddo
 
 end subroutine ptmass_calc_enclosed_mass

--- a/src/main/ptmass_heating.f90
+++ b/src/main/ptmass_heating.f90
@@ -31,7 +31,7 @@ contains
 !+
 !-----------------------------------------------------------------------
 subroutine energ_sinkheat(nptmass,xyzmh_ptmass,xi,yi,zi,dudtheati)
- use part,   only:ihsoft,imassenc,iLum
+ use part,   only:ihsoft,imassenc,iLum, sink_has_heating
  use kernel, only:radkern2
  integer, intent(in) :: nptmass
  real, intent(in)    :: xi,yi,zi,xyzmh_ptmass(:,:)
@@ -41,10 +41,12 @@ subroutine energ_sinkheat(nptmass,xyzmh_ptmass,xi,yi,zi,dudtheati)
 
  dudtheati = 0.
  do i = 1,nptmass
+    if (.not. sink_has_heating(xyzmh_ptmass(:,i))) cycle
     dri2 = (xi-xyzmh_ptmass(1,i))**2 + (yi-xyzmh_ptmass(2,i))**2 + (zi-xyzmh_ptmass(3,i))**2
     q2 = dri2/xyzmh_ptmass(ihsoft,i)**2
-    if (q2 < radkern2 .and. xyzmh_ptmass(imassenc,i) > 0.) then
-       dudtheati = xyzmh_ptmass(iLum,i) / xyzmh_ptmass(imassenc,i) * heating_kernel(q2,isink_heating)
+    if (q2 < radkern2) then
+       ! this should deliberately crash if xyzmh_ptmass(imassenc,i) == 0, instead of ignoring that sink's heating
+       dudtheati = dudtheati + xyzmh_ptmass(iLum,i) / xyzmh_ptmass(imassenc,i) * heating_kernel(q2,isink_heating)
     endif
  enddo
 

--- a/src/main/ptmass_heating.f90
+++ b/src/main/ptmass_heating.f90
@@ -43,7 +43,7 @@ subroutine energ_sinkheat(nptmass,xyzmh_ptmass,xi,yi,zi,dudtheati)
  do i = 1,nptmass
     dri2 = (xi-xyzmh_ptmass(1,i))**2 + (yi-xyzmh_ptmass(2,i))**2 + (zi-xyzmh_ptmass(3,i))**2
     q2 = dri2/xyzmh_ptmass(ihsoft,i)**2
-    if (q2 < radkern2) then
+    if (q2 < radkern2 .and. xyzmh_ptmass(imassenc,i) > 0.) then
        dudtheati = xyzmh_ptmass(iLum,i) / xyzmh_ptmass(imassenc,i) * heating_kernel(q2,isink_heating)
     endif
  enddo


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
Fixes a bug in `ptmass_heating.f90::47` when there's a mix of sink particles with and without sink heating.
Because the code skips calculating the no-sink-heating sink particle's `massenc`, so when there's gas particles near that sink, it thinks `xyzmh_ptmass(imassenc,i)==0` for that sink particle and encounters a division by zero error.
Here is a quick fix for this.

Testing:
`make test` passes.
Previously crashing simulations stopped crashing.

Did you run the bots? no

Did you update relevant documentation in the docs directory? no