### PR TITLE
Fix analysis common envelope star stability radius definitions

### DIFF
--- a/src/utils/analysis_common_envelope.f90
+++ b/src/utils/analysis_common_envelope.f90
@@ -1153,7 +1153,6 @@ subroutine star_stabilisation_suite(time,npart_in,particlemass,xyzh,vxyzu)
  npart = npart_in    ! npart might shrink in the process
  do i = 1,npart_in
     if (isdead(i)) then
-      xyzh(4,i) = 1.    ! Mark as alive to force re-killing and addition to dead list
       call kill_particle(i)
     endif
  enddo

--- a/src/utils/analysis_common_envelope.f90
+++ b/src/utils/analysis_common_envelope.f90
@@ -1133,7 +1133,7 @@ subroutine star_stabilisation_suite(time,npart,particlemass,xyzh,vxyzu)
  real, intent(inout)            :: xyzh(:,:),vxyzu(:,:)
  character(len=17), allocatable :: columns(:)
  integer                        :: i,j,k,ncols,mean_rad_num,npart_a
- integer, allocatable           :: iorder(:),iorder_a(:)
+ integer, allocatable           :: iorder(:)
  real, allocatable              :: star_stability(:)
  real                           :: total_mass,rhovol,totvol,rhopart,virialpart,virialfluid
  real                           :: phii,ponrhoi,spsoundi,tempi,epoti,ekini,egasi,eradi,ereci,etoti
@@ -1150,7 +1150,7 @@ subroutine star_stabilisation_suite(time,npart,particlemass,xyzh,vxyzu)
  integer, parameter             :: ivirialfluid = 10
 
  ncols = 10
- allocate(columns(ncols),star_stability(ncols),iorder(npart),iorder_a(npart))
+ allocate(columns(ncols),star_stability(ncols),iorder(npart))
  columns = (/'vol. eq. rad',&
              ' density rad',&
              'mass outside',&
@@ -1202,19 +1202,16 @@ subroutine star_stabilisation_suite(time,npart,particlemass,xyzh,vxyzu)
  virialpart = virialpart / (abs(totepot) + 2.*abs(totekin)) ! Normalisation for the virial
  virialfluid = (virialintegral + totepot) / (abs(virialintegral) + abs(totepot))
 
- ! Sort particles within "surface" by radius
- call indexxfunc(npart_a,r2func_origin,xyzh,iorder_a)
-
  mean_rad_num = npart / 200 ! 0.5 percent of particles
  star_stability = 0.
  ! Loop over the outermost npart/200 particles that are within the "surface"
- do i = npart_a - mean_rad_num,npart_a
-    j = iorder(i)
-    k = iorder_a(i)
+ do i = -mean_rad_num,0
+    j = iorder(npart + i)
+    k = iorder(npart_a + i)
     star_stability(ipartrad)    = star_stability(ipartrad)    + separation(xyzh(1:3,j),xyzmh_ptmass(1:3,1))
-    star_stability(ipart2hrad)  = star_stability(ipart2hrad)  + separation(xyzh(1:3,j),xyzmh_ptmass(1:3,1)) + xyzh(4,j)
+    star_stability(ipart2hrad)  = star_stability(ipart2hrad)  + separation(xyzh(1:3,j),xyzmh_ptmass(1:3,1)) + xyzh(4,j)*2
     star_stability(ipdensrad)   = star_stability(ipdensrad)   + separation(xyzh(1:3,k),xyzmh_ptmass(1:3,1))
-    star_stability(ip2hdensrad) = star_stability(ip2hdensrad) + separation(xyzh(1:3,k),xyzmh_ptmass(1:3,1)) + xyzh(4,j)
+    star_stability(ip2hdensrad) = star_stability(ip2hdensrad) + separation(xyzh(1:3,k),xyzmh_ptmass(1:3,1)) + xyzh(4,j)*2
  enddo
 
  star_stability(ipartrad)    = star_stability(ipartrad)    / real(mean_rad_num)
@@ -1241,7 +1238,7 @@ subroutine star_stabilisation_suite(time,npart,particlemass,xyzh,vxyzu)
 
  star_stability(imassfracout) = star_stability(imassout) / total_mass
  call write_time_file('star_stability', columns, time, star_stability, ncols, dump_number)
- deallocate(columns,star_stability,iorder,iorder_a)
+ deallocate(columns,star_stability,iorder)
 
 end subroutine star_stabilisation_suite
 

--- a/src/utils/analysis_common_envelope.f90
+++ b/src/utils/analysis_common_envelope.f90
@@ -1211,7 +1211,7 @@ subroutine star_stabilisation_suite(time,npart,particlemass,xyzh,vxyzu)
     star_stability(ipartrad)    = star_stability(ipartrad)    + separation(xyzh(1:3,j),xyzmh_ptmass(1:3,1))
     star_stability(ipart2hrad)  = star_stability(ipart2hrad)  + separation(xyzh(1:3,j),xyzmh_ptmass(1:3,1)) + xyzh(4,j)*2
     star_stability(ipdensrad)   = star_stability(ipdensrad)   + separation(xyzh(1:3,k),xyzmh_ptmass(1:3,1))
-    star_stability(ip2hdensrad) = star_stability(ip2hdensrad) + separation(xyzh(1:3,k),xyzmh_ptmass(1:3,1)) + xyzh(4,j)*2
+    star_stability(ip2hdensrad) = star_stability(ip2hdensrad) + separation(xyzh(1:3,k),xyzmh_ptmass(1:3,1)) + xyzh(4,k)*2
  enddo
 
  star_stability(ipartrad)    = star_stability(ipartrad)    / real(mean_rad_num)

--- a/src/utils/analysis_common_envelope.f90
+++ b/src/utils/analysis_common_envelope.f90
@@ -1125,14 +1125,14 @@ end subroutine roche_lobe_values
 !  Star stabilisation
 !+
 !----------------------------------------------------------------
-subroutine star_stabilisation_suite(time,npart,particlemass,xyzh,vxyzu)
- use part,   only:fxyzu
+subroutine star_stabilisation_suite(time,npart1,particlemass,xyzh,vxyzu)
+ use part,   only:fxyzu,isdead,kill_particle,shuffle_part
  use eos,    only:equationofstate
- integer, intent(in)            :: npart
+ integer, intent(in)            :: npart1
  real, intent(in)               :: time, particlemass
  real, intent(inout)            :: xyzh(:,:),vxyzu(:,:)
  character(len=17), allocatable :: columns(:)
- integer                        :: i,j,k,ncols,mean_rad_num,npart_a
+ integer                        :: i,j,k,ncols,mean_rad_num,npart,npart_a
  integer, allocatable           :: iorder(:)
  real, allocatable              :: star_stability(:)
  real                           :: total_mass,rhovol,totvol,rhopart,virialpart,virialfluid
@@ -1148,6 +1148,16 @@ subroutine star_stabilisation_suite(time,npart,particlemass,xyzh,vxyzu)
  integer, parameter             :: ip2hdensrad  = 8
  integer, parameter             :: ivirialpart  = 9
  integer, parameter             :: ivirialfluid = 10
+
+ ! remove dead particles
+ npart = npart1    ! npart might shrink in the process
+ do i = 1,npart1
+    if (isdead(i)) then
+      xyzh(4,i) = 1.    ! fake alive before re-killing it to accommodate shuffle process later
+      call kill_particle(i)
+    endif
+ enddo
+ call shuffle_part(npart)
 
  ncols = 10
  allocate(columns(ncols),star_stability(ncols),iorder(npart))

--- a/src/utils/analysis_common_envelope.f90
+++ b/src/utils/analysis_common_envelope.f90
@@ -1126,7 +1126,7 @@ end subroutine roche_lobe_values
 !+
 !----------------------------------------------------------------
 subroutine star_stabilisation_suite(time,npart_in,particlemass,xyzh,vxyzu)
- use part,   only:fxyzu,isdead,kill_particle,shuffle_part
+ use part,   only:fxyzu,isdead_or_accreted,kill_particle,shuffle_part
  use eos,    only:equationofstate
  integer, intent(in)            :: npart_in
  real, intent(in)               :: time, particlemass
@@ -1152,7 +1152,7 @@ subroutine star_stabilisation_suite(time,npart_in,particlemass,xyzh,vxyzu)
  ! remove dead particles
  npart = npart_in    ! npart might shrink in the process
  do i = 1,npart_in
-    if (isdead(i)) then
+    if (isdead_or_accreted(xyzh(4,i))) then
       call kill_particle(i)
     endif
  enddo


### PR DESCRIPTION
Description:
There seems to be several bugs in the radius calculations in the *star stabilization suite* in `phantomanalysis`.
For example, the `ipartrad` actually calculates the particle density radius instead of particle radius,
and the `ipdensrad`, instead of calculating the particle density radius, doesn't seem to calculate anything physical (because `iorder_a` is not actually sorting 'particles within surface by radius', since `xyzh` is not a sorted array; it is just sorting the first `npart_a` number of particles, which are not necessarily all within the surface);
also there seems to be a missing factor of 2 for the particle 2h radius calculations.
This results in some very confusing outputs, such as the calculated particle radius is smaller than the particle density radius, which shouldn't have happened because particle density radius only accounts for particles within the density surfaces, while particle radius accounts for all particles.
I also added a few lines to remove dead particles before doing the calculation.

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Setup (src/setup)
- [ ] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [x] Analysis utilities (src/utils/analysis)
- [ ] Documentation (docs/)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [x] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [ ] Other (please describe)

Testing:
<!-- Describe how you have tested the change -->
`make test` passed;
`make analysis` can compile;
results no longer looks erratic in terms of radius.

Did you run the bots? no

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? yes

Is there a unit test that could be added for this feature/bug? yes

If so, please describe what a unit test might check:
<!--e.g.: a test should check that running phantomsetup on SETUP=disc with ieos=2 successfully creates a dump-->
<!--obviously it is desirable to actually add the test, but at least describing it helps to inform future development-->
A test could check the analyzed solar profile (or other pre-computed star dump file that we know the actual radii of) etc outputs vs the correct answers.

<!-- If this PR is related to an issue, please link it here -->
Related issues: #
