### PR TITLE
Disable compiler warnings with ifort and flang/aocc as well as gfortran

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,15 +132,15 @@ jobs:
         SYSTEM: ${{ matrix.system }}
         RETURN_ERR: yes
 
-    - name: logs/build-failures-${{ matrix.system }}.txt
+    - name: Summary of build failures with SYSTEM=${{ matrix.system }}
       if: always()
       run: cat logs/build-failures-${{ matrix.system }}.txt || true
 
-    - name: logs/setup-failures-${{ matrix.system }}.txt
+    - name: Summary of setup failures with SYSTEM=${{ matrix.system }}
       if: always()
       run: cat logs/setup-failures-${{ matrix.system }}.txt || true
 
-    - name: logs/analysis-failures-${{ matrix.system }}.txt
+    - name: Summary of analysis failures with SYSTEM=${{ matrix.system }}
       if: always()
       run: cat logs/analysis-failures-${{ matrix.system }}.txt || true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,16 +144,6 @@ jobs:
       if: always()
       run: cat logs/analysis-failures-${{ matrix.system }}.txt || true
 
-    - name: logs/make-*-${{ matrix.system }}.txt
-      if: always()
-      run: |
-        echo
-        for item in $(ls logs/make-*-${{ matrix.system }}.txt); do
-          echo ::group::"${item}"
-          cat $item
-          echo ::endgroup::
-        done
-
   # Gather results into a dummy job that will fail if the previous job fails
   gather_results:
     if: ${{ always() && github.event_name != 'schedule' }}

--- a/build/Makefile_defaults_aocc
+++ b/build/Makefile_defaults_aocc
@@ -14,3 +14,7 @@ OMPFLAGS= -fopenmp
 ifeq ($(UNAME), Darwin)
    LDFLAGS+=-L/opt/homebrew/opt/libomp/lib
 endif
+
+ifeq ($(NOWARN), yes)
+    FFLAGS+= -Werror
+endif

--- a/build/Makefile_defaults_ifort
+++ b/build/Makefile_defaults_ifort
@@ -22,5 +22,5 @@ else
 endif
 
 ifeq ($(NOWARN),yes)
-   FFLAGS+= -diag-error=warn,remark,vec,par,openmp
+   FFLAGS+= -diag-error=warn,remark,vec,par,openmp -diag-disable=13000 -warn all,nodec,interfaces,nousage
 endif

--- a/build/Makefile_defaults_ifort
+++ b/build/Makefile_defaults_ifort
@@ -22,5 +22,5 @@ else
 endif
 
 ifeq ($(NOWARN),yes)
-   FFLAGS+= -diag-error=warn,remark,vec,par,openmp -diag-disable=13000 -warn all,nodec,interfaces,nousage
+   FFLAGS+= -diag-error=warn,remark,vec,par,openmp -diag-disable=13000
 endif

--- a/build/Makefile_defaults_ifort
+++ b/build/Makefile_defaults_ifort
@@ -1,7 +1,7 @@
 # default settings for ifort compiler
 # override these in the Makefile
 FC= ifort
-FFLAGS= -O3 -inline-factor=500 -shared-intel -warn uninitialized -warn unused -warn truncated_source -no-wrap-margin
+FFLAGS= -O3 -inline-factor=500 -shared-intel -warn uninitialized -warn truncated_source -no-wrap-margin
 DBLFLAG= -r8
 DEBUGFLAG= -check all -WB -traceback -g -debug all # -fpe0 -fp-stack-check -debug all -noarg_temp_created
 #DEBUGFLAG= -g -traceback -check all -check bounds -check uninit -ftrapuv -debug all -warn all,nodec,interfaces,nousage -fpe0 -fp-stack-check -WB -no-diag-error-limit -no-wrap-margin -O0 -noarg_temp_created
@@ -19,4 +19,8 @@ ifeq ($(shell [ $(IFORT_VERSION_MAJOR) -lt 17 ] && echo true),true)
     OMPFLAGS= -openmp
 else
     OMPFLAGS = -qopenmp
+endif
+
+ifeq ($(NOWARN),yes)
+   FFLAGS+= -diag-error=warn,remark,vec,par,openmp
 endif

--- a/build/Makefile_defaults_ifx
+++ b/build/Makefile_defaults_ifx
@@ -1,8 +1,7 @@
 # default settings for ifx compiler
 # override these in the Makefile
 FC= ifx
-#FFLAGS= -O3 -inline-factor=500 -shared-intel -warn uninitialized -warn unused -warn truncated_source -no-wrap-margin
-FFLAGS= -O3 -shared-intel -warn uninitialized -warn unused -warn truncated_source -no-wrap-margin
+FFLAGS= -O3 -shared-intel -warn uninitialized -warn truncated_source -no-wrap-margin
 DBLFLAG= -r8
 DEBUGFLAG= -check all -WB -traceback -g -debug all # -fpe0 -fp-stack-check -debug all -noarg_temp_created
 #DEBUGFLAG= -g -traceback -check all -check bounds -check uninit -ftrapuv -debug all -warn all,nodec,interfaces,nousage -fpe0 -fp-stack-check -WB -no-diag-error-limit -no-wrap-margin -O0 -noarg_temp_created
@@ -15,3 +14,7 @@ LIBCXX = -cxxlib
 KNOWN_SYSTEM=yes
 
 OMPFLAGS= -qopenmp
+
+ifeq ($(NOWARN),yes)
+   FFLAGS+= -diag-error=warn,remark,vec,par,openmp
+endif

--- a/scripts/buildbot.sh
+++ b/scripts/buildbot.sh
@@ -399,15 +399,15 @@ for setup in $listofsetups; do
       else
          mynowarn=$nowarn;
       fi
-      make SETUP=$setup $nolibs $mynowarn $target $mydebug 1> $makeout 2> $errorlog; err=$?;
+      make SETUP=$setup $nolibs $mynowarn $target $mydebug 1> $makeout; err=$?;
       #--remove line numbers from error log files
-      sed -e 's/90(.*)/90/g' -e 's/90:.*:/90/g' $errorlog | grep -v '/tmp' > $errorlog.tmp && mv $errorlog.tmp $errorlog;
+      #sed -e 's/90(.*)/90/g' -e 's/90:.*:/90/g' $errorlog | grep -v '/tmp' > $errorlog.tmp && mv $errorlog.tmp $errorlog;
       if [ $err -eq 0 ]; then
          echo "OK";
          colour=$green;
          text='OK';
       else
-         echo "FAILED"; grep Error $errorlog;
+         echo "FAILED"; #grep Error $errorlog;
          colour=$red;
          text='**FAILED**';
          nfail=$((nfail + 1));
@@ -467,7 +467,7 @@ for setup in $listofsetups; do
       if [ "X$target" == "Xsetup" ] && [ "X$component" == "Xsetup" ]; then
          # also build phantom main binary
          echo "compiling phantom with SETUP=$setup"
-         make SETUP=$setup $nolibs $mynowarn $mydebug 1>> $makeout 2>> $errorlog; err=$?;
+         make SETUP=$setup $nolibs $mynowarn $mydebug 1>> $makeout; err=$?;
          check_phantomsetup $setup;
       elif [ "X$target" == "Xanalysis" ] && [ "X$component" == "Xanalysis" ]; then
          check_phantomanalysis $setup;

--- a/src/lib/NICIL/src/nicil.F90
+++ b/src/lib/NICIL/src/nicil.F90
@@ -727,7 +727,7 @@ subroutine nicil_initialise(utime,udist,umass,unit_Bfield,ierr,iprint_in,iprintw
  rhog_sum     = 0.0
  do j = 1,na
     ! grain radii
-    dloga = (log10(ax_grain) - log10(an_grain))/float(na)
+    dloga = (log10(ax_grain) - log10(an_grain))/real(na)
     if (present(a_grain_cgs_in)) then
        a_grain_cgs(j) = a_grain_cgs_in(j)                         ! user's input grain sizes
     else

--- a/src/main/dens.F90
+++ b/src/main/dens.F90
@@ -289,9 +289,9 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
 
  call init_cell_exchange(xrecvbuf,irequestrecv,thread_complete,ncomplete_mpi,mpitype)
 
- !$omp masked
+ !$omp single
  call get_timings(t1,tcpu1)
- !$omp end masked
+ !$omp end single
 
  !--initialise send requests to 0
  irequestsend = 0
@@ -398,7 +398,7 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
          irequestsend,thread_complete,cell_counters,ncomplete_mpi)
  endif
 
- !$omp masked
+ !$omp single
  call get_timings(t2,tcpu2)
  call increment_timer(itimer_dens_local,t2-t1,tcpu2-tcpu1)
  call get_timings(t1,tcpu1)
@@ -415,14 +415,14 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
  n_remote_its = 0
  iterations_finished = .false.
  if (.not.mpi) iterations_finished = .true.
- !$omp end masked
+ !$omp end single
  !$omp barrier
 
  remote_its: do while(.not. iterations_finished)
 
-    !$omp masked
+    !$omp single
     n_remote_its = n_remote_its + 1
-    !$omp end masked
+    !$omp end single
     call reset_cell_counters(cell_counters)
     !$omp barrier
 
@@ -451,9 +451,9 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
        enddo over_remote
        !$omp enddo
 
-       !$omp masked
+       !$omp single
        stack_remote%n = 0
-       !$omp end masked
+       !$omp end single
 
        idone(:) = .false.
        do while(.not.all(idone))
@@ -508,9 +508,9 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
        enddo over_waiting
        !$omp enddo
 
-       !$omp masked
+       !$omp single
        stack_waiting%n = 0
-       !$omp end masked
+       !$omp end single
 
        idone(:) = .false.
        do while(.not.all(idone))
@@ -522,22 +522,22 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
     if (mpi) call recv_while_wait(stack_remote,xrecvbuf,irequestrecv,&
              irequestsend,thread_complete,cell_counters,ncomplete_mpi)
 
-    !$omp masked
+    !$omp single
     if (reduceall_mpi('max',stack_redo%n) > 0) then
        call swap_stacks(stack_waiting, stack_redo)
     else
        iterations_finished = .true.
     endif
     stack_redo%n = 0
-    !$omp end masked
+    !$omp end single
     !$omp barrier
 
  enddo remote_its
 
- !$omp masked
+ !$omp single
  call get_timings(t2,tcpu2)
  call increment_timer(itimer_dens_remote,t2-t1,tcpu2-tcpu1)
- !$omp end masked
+ !$omp end single
 
  if (mpi) call finish_cell_exchange(irequestrecv,xsendbuf,mpitype)
 

--- a/src/main/dens.F90
+++ b/src/main/dens.F90
@@ -289,9 +289,9 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
 
  call init_cell_exchange(xrecvbuf,irequestrecv,thread_complete,ncomplete_mpi,mpitype)
 
- !$omp master
+ !$omp masked
  call get_timings(t1,tcpu1)
- !$omp end master
+ !$omp end masked
 
  !--initialise send requests to 0
  irequestsend = 0
@@ -398,7 +398,7 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
          irequestsend,thread_complete,cell_counters,ncomplete_mpi)
  endif
 
- !$omp master
+ !$omp masked
  call get_timings(t2,tcpu2)
  call increment_timer(itimer_dens_local,t2-t1,tcpu2-tcpu1)
  call get_timings(t1,tcpu1)
@@ -415,14 +415,14 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
  n_remote_its = 0
  iterations_finished = .false.
  if (.not.mpi) iterations_finished = .true.
- !$omp end master
+ !$omp end masked
  !$omp barrier
 
  remote_its: do while(.not. iterations_finished)
 
-    !$omp master
+    !$omp masked
     n_remote_its = n_remote_its + 1
-    !$omp end master
+    !$omp end masked
     call reset_cell_counters(cell_counters)
     !$omp barrier
 
@@ -451,9 +451,9 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
        enddo over_remote
        !$omp enddo
 
-       !$omp master
+       !$omp masked
        stack_remote%n = 0
-       !$omp end master
+       !$omp end masked
 
        idone(:) = .false.
        do while(.not.all(idone))
@@ -508,9 +508,9 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
        enddo over_waiting
        !$omp enddo
 
-       !$omp master
+       !$omp masked
        stack_waiting%n = 0
-       !$omp end master
+       !$omp end masked
 
        idone(:) = .false.
        do while(.not.all(idone))
@@ -522,22 +522,22 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
     if (mpi) call recv_while_wait(stack_remote,xrecvbuf,irequestrecv,&
              irequestsend,thread_complete,cell_counters,ncomplete_mpi)
 
-    !$omp master
+    !$omp masked
     if (reduceall_mpi('max',stack_redo%n) > 0) then
        call swap_stacks(stack_waiting, stack_redo)
     else
        iterations_finished = .true.
     endif
     stack_redo%n = 0
-    !$omp end master
+    !$omp end masked
     !$omp barrier
 
  enddo remote_its
 
- !$omp master
+ !$omp masked
  call get_timings(t2,tcpu2)
  call increment_timer(itimer_dens_remote,t2-t1,tcpu2-tcpu1)
- !$omp end master
+ !$omp end masked
 
  if (mpi) call finish_cell_exchange(irequestrecv,xsendbuf,mpitype)
 
@@ -1101,7 +1101,7 @@ end subroutine exactlinear
 !+
 !  subroutine to reduce and print warnings across processors
 !  related to h-rho iterations
-!+fxyzu
+!+
 !----------------------------------------------------------------
 subroutine reduce_and_print_warnings(nwarnup,nwarndown,nwarnroundoff)
  use mpiutils, only:reduce_mpi
@@ -1112,14 +1112,12 @@ subroutine reduce_and_print_warnings(nwarnup,nwarndown,nwarnroundoff)
  nwarndown     = int(reduce_mpi('+',nwarndown))
  nwarnroundoff = int(reduce_mpi('+',nwarnroundoff))
 
-#ifndef NOWARNRESTRICTEDHJUMP
  if (id==master .and. nwarnup > 0) then
     write(iprint,*) ' WARNING: restricted h jump (up) ',nwarnup,' times'
  endif
  if (id==master .and. nwarndown > 0) then
     write(iprint,*) ' WARNING: restricted h jump (down) ',nwarndown,' times'
  endif
-#endif
  if (id==master .and. nwarnroundoff > 0) then
     write(iprint,*) ' WARNING: denom in exact linear gradients zero on ',nwarnroundoff,' particles'
  endif

--- a/src/main/egg.f90
+++ b/src/main/egg.f90
@@ -10,7 +10,7 @@ module easter_egg
 !
 ! :References: None
 !
-! :Owner: Cheryl-Lau
+! :Owner: Daniel Price
 !
 ! :Runtime parameters: None
 !

--- a/src/main/eos_HIIR.f90
+++ b/src/main/eos_HIIR.f90
@@ -52,8 +52,8 @@ end subroutine init_eos_HIIR
  !+
  !-----------------------------------------------------------------------
 subroutine get_eos_HIIR_iso(polyk,temperature_coef,mui,tempi,ponrhoi,spsoundi,isionisedi)
- real, intent(in)    :: polyk,temperature_coef
- real, intent(out)   :: ponrhoi,spsoundi,mui,tempi
+ real, intent(in)    :: polyk,temperature_coef,mui
+ real, intent(out)   :: ponrhoi,spsoundi,tempi
  logical, intent(in) :: isionisedi
 
  !
@@ -84,8 +84,8 @@ end subroutine get_eos_HIIR_iso
  !-----------------------------------------------------------------------
 subroutine get_eos_HIIR_adiab(polyk,temperature_coef,mui,tempi,ponrhoi,rhoi,eni,gammai,spsoundi,isionisedi)
  use io, only:fatal
- real,    intent(in)              :: polyk,temperature_coef,rhoi,gammai
- real,    intent(out)             :: ponrhoi,spsoundi,mui,tempi
+ real,    intent(in)              :: polyk,temperature_coef,rhoi,gammai,mui
+ real,    intent(out)             :: ponrhoi,spsoundi,tempi
  logical, intent(in)              :: isionisedi
  real,    intent(in),    optional :: eni
 

--- a/src/main/eos_helmholtz.f90
+++ b/src/main/eos_helmholtz.f90
@@ -208,11 +208,11 @@ subroutine eos_helmholtz_init(ierr)
  ! for standard table limits
  tlo   = 3.0
  thi   = 13.0
- tstp  = (thi - tlo)/float(jmax-1)
+ tstp  = (thi - tlo)/real(jmax-1)
  tstpi = 1.0/tstp
  dlo   = -12.0
  dhi   = 15.0
- dstp  = (dhi - dlo)/float(imax-1)
+ dstp  = (dhi - dlo)/real(imax-1)
  dstpi = 1.0/dstp
 
  ! read the helmholtz free energy and its derivatives

--- a/src/main/eos_tillotson.f90
+++ b/src/main/eos_tillotson.f90
@@ -107,6 +107,8 @@ subroutine equationofstate_tillotson(rho,u,pressure,spsound,gamma)
     spsound = sqrt(spsound2)
  endif
 
+ gamma = spsound**2*rho/pressure
+
 end subroutine equationofstate_tillotson
 
 !----------------------------------------------------------------

--- a/src/main/externalforces_gr.f90
+++ b/src/main/externalforces_gr.f90
@@ -91,6 +91,12 @@ subroutine externalforce(iexternalforce,xi,yi,zi,hi,ti,fextxi,fextyi,fextzi,phi,
  !
  !  This doesn't doesn't actually get used in gr...
  !
+ fextxi = 0.
+ fextyi = 0.
+ fextzi = 0.
+ phi    = 0.
+ if (present(dtf)) dtf    = 0.
+
 end subroutine externalforce
 
 !-----------------------------------------------------------------------
@@ -129,6 +135,8 @@ subroutine externalforce_vdependent(iexternalforce,xyzi,veli,fexti,poti,densi,ui
  !
  ! This doesn't doesn't actually get used in gr...
  !
+ fexti = 0.
+
 end subroutine externalforce_vdependent
 
 !-----------------------------------------------------------------------
@@ -150,6 +158,8 @@ subroutine update_vdependent_extforce(iexternalforce, &
  !
  ! This doesn't doesn't actually get used in gr...
  !
+ fexti = 0.
+
 end subroutine update_vdependent_extforce
 
 !-----------------------------------------------------------------------
@@ -256,6 +266,8 @@ subroutine write_headeropts_extern(iexternalforce,hdr,time,ierr)
  real,         intent(in)    :: time
  integer,      intent(out)   :: ierr
 
+ ierr = 0
+
 end subroutine write_headeropts_extern
 
 !-----------------------------------------------------------------------
@@ -290,6 +302,7 @@ subroutine read_options_externalforces(name,valstring,imatch,igotall,ierr,iexter
 
  imatch            = .true.
  igotall           = .false.
+ ierr              = 0
 
  if (imetric /= imet_minkowski) then
 

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -492,9 +492,9 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
 
  call init_cell_exchange(xrecvbuf,irequestrecv,thread_complete,ncomplete_mpi,mpitype)
 
- !$omp masked
+ !$omp single
  call get_timings(t1,tcpu1)
- !$omp end masked
+ !$omp end single
 
  !--initialise send requests to 0
  irequestsend = 0
@@ -582,11 +582,11 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
     call reset_cell_counters(cell_counters)
  endif
 
- !$omp masked
+ !$omp single
  call get_timings(t2,tcpu2)
  call increment_timer(itimer_force_local,t2-t1,tcpu2-tcpu1)
  call get_timings(t1,tcpu1)
- !$omp end masked
+ !$omp end single
  !$omp barrier
 
  igot_remote: if (mpi .and. stack_remote%n > 0) then
@@ -617,9 +617,9 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
     enddo over_remote
     !$omp enddo
 
-    !$omp masked
+    !$omp single
     stack_remote%n = 0
-    !$omp end masked
+    !$omp end single
 
     idone(:) = .false.
     do while(.not.all(idone))
@@ -664,10 +664,10 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
 
  call finish_cell_exchange(irequestrecv,xsendbuf,mpitype)
 
-!$omp masked
+!$omp single
  call get_timings(t2,tcpu2)
  call increment_timer(itimer_force_remote,t2-t1,tcpu2-tcpu1)
-!$omp end masked
+!$omp end single
 
 #ifdef GRAVITY
  if (icreate_sinks > 0) then

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -492,9 +492,9 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
 
  call init_cell_exchange(xrecvbuf,irequestrecv,thread_complete,ncomplete_mpi,mpitype)
 
- !$omp master
+ !$omp masked
  call get_timings(t1,tcpu1)
- !$omp end master
+ !$omp end masked
 
  !--initialise send requests to 0
  irequestsend = 0
@@ -582,11 +582,11 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
     call reset_cell_counters(cell_counters)
  endif
 
- !$omp master
+ !$omp masked
  call get_timings(t2,tcpu2)
  call increment_timer(itimer_force_local,t2-t1,tcpu2-tcpu1)
  call get_timings(t1,tcpu1)
- !$omp end master
+ !$omp end masked
  !$omp barrier
 
  igot_remote: if (mpi .and. stack_remote%n > 0) then
@@ -617,9 +617,9 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
     enddo over_remote
     !$omp enddo
 
-    !$omp master
+    !$omp masked
     stack_remote%n = 0
-    !$omp end master
+    !$omp end masked
 
     idone(:) = .false.
     do while(.not.all(idone))
@@ -664,10 +664,10 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
 
  call finish_cell_exchange(irequestrecv,xsendbuf,mpitype)
 
-!$omp master
+!$omp masked
  call get_timings(t2,tcpu2)
  call increment_timer(itimer_force_remote,t2-t1,tcpu2-tcpu1)
-!$omp end master
+!$omp end masked
 
 #ifdef GRAVITY
  if (icreate_sinks > 0) then

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -991,7 +991,8 @@ subroutine compute_forces(i,iamgasi,iamdusti,xpartveci,hi,hi1,hi21,hi41,gradhi,g
  real,            intent(in)    :: alphau,alphaB,bulkvisc,stressmax
  integer,         intent(inout) :: ndrag,nstokes,nsuper
  real,            intent(out)   :: ts_min
- integer(kind=1), intent(out)   :: ibin_wake(:),ibin_neighi
+ integer(kind=1), intent(inout) :: ibin_wake(:) ! inout to avoid compiler warning
+ integer(kind=1), intent(out)   :: ibin_neighi
  integer(kind=1), intent(in)    :: ibinnow_m1
  logical,         intent(in)    :: ignoreself
  real,            intent(in)    :: rad(:,:),dens(:),metrics(:,:,:,:)
@@ -2711,7 +2712,7 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
 
  use io,             only:fatal,warning
  use dim,            only:mhd,mhd_nonideal,track_lum,use_dust,maxdvdx,use_dustgrowth,gr,use_krome,driving,isothermal,&
-                          store_dust_temperature,do_nucleation,update_muGamma,h2chemistry,use_apr,use_sinktree
+                          store_dust_temperature,do_nucleation,update_muGamma,h2chemistry,use_apr,use_sinktree,gravity,ind_timesteps
  use eos,            only:ieos,iopacity_type
  use options,        only:alpha,ipdv_heating,ishock_heating,psidecayfac,overcleanfac, &
                           use_dustfrac,icooling,implicit_radiation
@@ -2722,9 +2723,7 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
  use cooling,        only:energ_cooling,cooling_in_step
  use ptmass_heating, only:energ_sinkheat
  use dust,           only:drag_implicit
-#ifdef GRAVITY
  use part,           only:bin_info,ipertg,fxyz_ptmass_tree
-#endif
 #ifdef IND_TIMESTEPS
  use part,           only:ibin
  use timestep_ind,   only:get_newbin,check_dtmin
@@ -2799,15 +2798,13 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
  real    :: etaambii,etahalli,etaohmi
  real    :: vsigmax,vwavei,fxyz4
  real    :: dudt_radi
-#ifdef GRAVITY
  real    :: potensoft0,dum,dx,dy,dz,fxi,fyi,fzi,poti,epoti
-#endif
  real    :: vsigdtc,dtc,dtf,dti,dtcool,dtdiffi,ts_min,dtent
  real    :: dtohmi,dtambii,dthalli,dtvisci,dtdrag,dtdusti,dtclean
  integer :: iamtypei
  logical :: iactivei,iamgasi,iamdusti,iamsinki,realviscosity
-#ifdef IND_TIMESTEPS
  integer(kind=1)       :: ibin_neighi
+#ifdef IND_TIMESTEPS
  logical               :: allow_decrease,dtcheck
  character(len=16)     :: dtchar
 #endif
@@ -2853,9 +2850,7 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
 
     fsum(:)       = cell%fsums(:,ip)
     xpartveci(:)  = cell%xpartvec(:,ip)
-#ifdef IND_TIMESTEPS
-    ibin_neighi   = cell%ibinneigh(ip)
-#endif
+    if (ind_timesteps) ibin_neighi   = cell%ibinneigh(ip)
 
     dtc     = dtmax
     dtf     = bignumber
@@ -2958,38 +2953,35 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
        rhogasi = 0.  ! Initialize rhogasi for non-gas particles
     endif
 
-#ifdef GRAVITY
-    !--add self-contribution
-    if (iamsinki) then
-       epoti = 0.5*pmassi*fsum(ipot)
-    else
-       call kernel_softening(0.,0.,potensoft0,dum)
-       epoti = 0.5*pmassi*(fsum(ipot) + pmassi*potensoft0*hi1)
-    endif
-    !
-    !--add contribution from distant nodes, expand these in Taylor series about node centre
-    !  use xcen directly, -1 is placeholder
-    !
-    call get_distance_from_centre_of_mass(cell%icell,xi,yi,zi,dx,dy,dz)
-    call expand_fgrav_in_taylor_series(cell%fgrav,dx,dy,dz,fxi,fyi,fzi,poti)
-    fsum(ifxi) = fsum(ifxi) + fxi
-    fsum(ifyi) = fsum(ifyi) + fyi
-    fsum(ifzi) = fsum(ifzi) + fzi
-    if (gr .and. ien_type == ien_etotal) then
-       fsum(idudtdissi) = fsum(idudtdissi) + vxi*fxi + vyi*fyi + vzi*fzi
-    endif
-    epoti = epoti + 0.5*pmassi*poti
-    poten(i) = real(epoti,kind=kind(poten))
-    if (use_sinktree) then
+    if (gravity) then
+       !--add self-contribution
        if (iamsinki) then
-          fxyz_ptmass_tree(1,i-maxpsph) = fsum(ifxi) + fsum(ifskxi)
-          fxyz_ptmass_tree(2,i-maxpsph) = fsum(ifyi) + fsum(ifskyi)
-          fxyz_ptmass_tree(3,i-maxpsph) = fsum(ifzi) + fsum(ifskzi)
-          bin_info(ipertg,i-maxpsph)    = fsum(ipertouti)
-          cycle
+          epoti = 0.5*pmassi*fsum(ipot)
+       else
+          call kernel_softening(0.,0.,potensoft0,dum)
+          epoti = 0.5*pmassi*(fsum(ipot) + pmassi*potensoft0*hi1)
+       endif
+       !
+       !--add contribution from distant nodes, expand these in Taylor series about node centre
+       !  use xcen directly, -1 is placeholder
+       !
+       call get_distance_from_centre_of_mass(cell%icell,xi,yi,zi,dx,dy,dz)
+       call expand_fgrav_in_taylor_series(cell%fgrav,dx,dy,dz,fxi,fyi,fzi,poti)
+       fsum(ifxi) = fsum(ifxi) + fxi
+       fsum(ifyi) = fsum(ifyi) + fyi
+       fsum(ifzi) = fsum(ifzi) + fzi
+       epoti = epoti + 0.5*pmassi*poti
+       poten(i) = real(epoti,kind=kind(poten))
+       if (use_sinktree) then
+          if (iamsinki) then
+             fxyz_ptmass_tree(1,i-maxpsph) = fsum(ifxi) + fsum(ifskxi)
+             fxyz_ptmass_tree(2,i-maxpsph) = fsum(ifyi) + fsum(ifskyi)
+             fxyz_ptmass_tree(3,i-maxpsph) = fsum(ifzi) + fsum(ifskzi)
+             bin_info(ipertg,i-maxpsph)    = fsum(ipertouti)
+             cycle
+          endif
        endif
     endif
-#endif
 
     if (mhd .and. iamgasi) then
        !

--- a/src/main/forcing.f90
+++ b/src/main/forcing.f90
@@ -838,13 +838,11 @@ subroutine st_calcAccel(npart,xyzh,fxyzu)
     !!  fmean = reduceall_mpi('+',fmean)
     fmean(:) = fmean(:)/real(npart)
 
-    !!$omp master
     if (Debug) then
        print *, 'stir:  xforce_mean = ', fmean(1)
        print *, 'stir:  yforce_mean = ', fmean(2)
        print *, 'stir:  zforce_mean = ', fmean(3)
     endif
-    !!$omp end master
     !
     !--correction for bulk motion: note that, unlike in Christoph's code
     !  we do not do the time integration here - rather we return the

--- a/src/main/inject_masstransfer.f90
+++ b/src/main/inject_masstransfer.f90
@@ -135,7 +135,7 @@ subroutine inject_particles(time,dtlast,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
  integer, intent(inout) :: npart,npart_old
  integer, intent(inout) :: npartoftype(:)
  real, intent(out)      :: dtinject
- real                   :: irrational_number_close_to_one,xyz_acc(3),xyz_don(3),racc,rdon,xi,xyzi(3)
+ real                   :: irrational_number_close_to_one,xyz_acc(3),xyz_don(3),racc,rdon,xi,xyzi(3),vxyz(3)
  real                   :: pmass,cs_inf,rho_inf,pres_inf,kill_rad,time_between_layers,distance_between_layers
  integer                :: i,k,ierr,nodd,neven
  real, allocatable      :: xyz(:,:),layer_even(:,:),layer_odd(:,:)
@@ -212,7 +212,8 @@ subroutine inject_particles(time,dtlast,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
     xi = wind_injection_x + v_inf * (time-injection_time(k))
     do i = 1,nlayer(k)  ! loop over particles in layer
        xyzi = (/xi, y_layer(i,k), z_layer(i,k)/)
-       call add_or_update_particle(igas,xyzi,(/v_inf,0.,0./),h_inf,u_inf,ifirst(k)+i-1,npart,npartoftype,xyzh,vxyzu)
+       vxyz = (/v_inf,0.,0./)
+       call add_or_update_particle(igas,xyzi,vxyz,h_inf,u_inf,ifirst(k)+i-1,npart,npartoftype,xyzh,vxyzu)
     enddo
  enddo
 

--- a/src/main/inject_sne.f90
+++ b/src/main/inject_sne.f90
@@ -168,6 +168,7 @@ subroutine read_options_inject(name,valstring,imatch,igotall,ierr)
 
  imatch  = .true.
  igotall = .false.
+ ierr    = 0
  select case(trim(name))
     !case('dt_sn')
     !   read(valstring,*,iostat=ierr) dt_sn
@@ -181,7 +182,6 @@ subroutine read_options_inject(name,valstring,imatch,igotall,ierr)
 end subroutine read_options_inject
 
 subroutine set_default_options_inject(flag)
-
  integer, optional, intent(in) :: flag
 end subroutine set_default_options_inject
 

--- a/src/main/metric_et.f90
+++ b/src/main/metric_et.f90
@@ -205,6 +205,7 @@ subroutine read_options_metric(name,valstring,imatch,igotall,ierr)
  integer,          intent(out) :: ierr
  !integer, save :: ngot = 0
 
+ ierr = 0
  select case(trim(name))
     !case('metric_file')
     !   read(valstring,*,iostat=ierr) metric_file

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -2262,13 +2262,13 @@ subroutine merge_sinks(time,nptmass,xyzmh_ptmass,pxyz_ptmass,fxyz_ptmass,fxyz_pt
                 xyzmh_ptmass(isftype,j) = 3.
              endif
              ! print success
-             write(iprint,"(/,1x,3a,i8,a,i8,a,1pg10.4)") 'merge_sinks: ',typ,' merged sinks ',i,' & ',j,' at time = ',time
+             write(iprint,"(/,1x,3a,i8,a,i8,a,1pg12.4)") 'merge_sinks: ',typ,' merged sinks ',i,' & ',j,' at time = ',time
           elseif (id==master .and. iverbose>=1) then
-             write(iprint,"(/,1x,a,i8,a,i8,a,1pg10.4)") &
+             write(iprint,"(/,1x,a,i8,a,i8,a,1pg12.4)") &
              'merge_sinks: failed to conditionally merge sinks ',i,' & ',j,' at time = ',time
           endif
        elseif (xyzmh_ptmass(4,j) > 0. .and. id==master .and. iverbose>=1) then
-          write(iprint,"(/,1x,a,i8,a,i8,a,1pg10.4)") &
+          write(iprint,"(/,1x,a,i8,a,i8,a,1pg12.4)") &
           'merge_sinks: There is a mismatch in sink indicies and relative proximity for ',i,' & ',j,' at time = ',time
        endif
     endif

--- a/src/main/radiation_implicit.f90
+++ b/src/main/radiation_implicit.f90
@@ -197,9 +197,9 @@ subroutine do_radiation_onestep(dt,npart,rad,xyzh,vxyzu,radprop,origEU,EU0,faile
  call fill_arrays(ncompact,ncompactlocal,npart,icompactmax,dt,&
                   xyzh,vxyzu,ivar,ijvar,rad,vari,varij,varij2,EU0)
 
- !$omp master
+ !$omp masked
  call do_timing('radarrays',tlast,tcpulast)
- !$omp end master
+ !$omp end masked
 
  !$omp single
  maxerrE2last = huge(0.)
@@ -209,26 +209,26 @@ subroutine do_radiation_onestep(dt,npart,rad,xyzh,vxyzu,radprop,origEU,EU0,faile
 
  iterations: do its=1,itsmax_rad
 
-    !$omp master
+    !$omp masked
     call get_timings(t1,tcpu1)
-    !$omp end master
+    !$omp end masked
     call compute_flux(ivar,ijvar,ncompact,npart,icompactmax,varij2,vari,EU0,varinew,radprop,mask=mask)
-    !$omp master
+    !$omp masked
     call do_timing('radflux',t1,tcpu1)
-    !$omp end master
+    !$omp end masked
     call calc_diffusion_term(ivar,ijvar,varij,ncompact,npart,icompactmax,vari,EU0,varinew,mask,ierr)
-    !$omp master
+    !$omp masked
     call do_timing('raddiff',t1,tcpu1)
-    !$omp end master
+    !$omp end masked
 
     call update_gas_radiation_energy(ivar,vari,npart,ncompactlocal,&
                                      radprop,rad,origEU,varinew,EU0,&
                                      pdvvisc,dvdx,nucleation,dust_temp,eos_vars,drad,fxyzu,&
                                      mask,implicit_radiation_store_drad,moresweep,maxerrE2,maxerrU2)
 
-    !$omp master
+    !$omp masked
     call do_timing('radupdate',t1,tcpu1)
-    !$omp end master
+    !$omp end masked
 
     !$omp single
     if (iverbose >= 2) then

--- a/src/main/radiation_implicit.f90
+++ b/src/main/radiation_implicit.f90
@@ -197,9 +197,9 @@ subroutine do_radiation_onestep(dt,npart,rad,xyzh,vxyzu,radprop,origEU,EU0,faile
  call fill_arrays(ncompact,ncompactlocal,npart,icompactmax,dt,&
                   xyzh,vxyzu,ivar,ijvar,rad,vari,varij,varij2,EU0)
 
- !$omp masked
+ !$omp single
  call do_timing('radarrays',tlast,tcpulast)
- !$omp end masked
+ !$omp end single
 
  !$omp single
  maxerrE2last = huge(0.)
@@ -209,26 +209,26 @@ subroutine do_radiation_onestep(dt,npart,rad,xyzh,vxyzu,radprop,origEU,EU0,faile
 
  iterations: do its=1,itsmax_rad
 
-    !$omp masked
+    !$omp single
     call get_timings(t1,tcpu1)
-    !$omp end masked
+    !$omp end single
     call compute_flux(ivar,ijvar,ncompact,npart,icompactmax,varij2,vari,EU0,varinew,radprop,mask=mask)
-    !$omp masked
+    !$omp single
     call do_timing('radflux',t1,tcpu1)
-    !$omp end masked
+    !$omp end single
     call calc_diffusion_term(ivar,ijvar,varij,ncompact,npart,icompactmax,vari,EU0,varinew,mask,ierr)
-    !$omp masked
+    !$omp single
     call do_timing('raddiff',t1,tcpu1)
-    !$omp end masked
+    !$omp end single
 
     call update_gas_radiation_energy(ivar,vari,npart,ncompactlocal,&
                                      radprop,rad,origEU,varinew,EU0,&
                                      pdvvisc,dvdx,nucleation,dust_temp,eos_vars,drad,fxyzu,&
                                      mask,implicit_radiation_store_drad,moresweep,maxerrE2,maxerrU2)
 
-    !$omp masked
+    !$omp single
     call do_timing('radupdate',t1,tcpu1)
-    !$omp end masked
+    !$omp end single
 
     !$omp single
     if (iverbose >= 2) then

--- a/src/main/readwrite_infile.f90
+++ b/src/main/readwrite_infile.f90
@@ -62,6 +62,7 @@ module readwrite_infile
 !   - tol_rad            : *tolerance on backwards Euler implicit solve of dxi/dt*
 !   - tolh               : *tolerance on h-rho iterations*
 !   - tolv               : *tolerance on v iterations in timestepping*
+!   - track_lum          : *write du/dt to dump files (for a B-grade lightcurve)*
 !   - twallmax           : *maximum wall time (hhh:mm, 000:00=ignore)*
 !   - use_mcfost         : *use the mcfost library*
 !   - xtol               : *tolerance on xyz iterations*

--- a/src/main/substepping.F90
+++ b/src/main/substepping.F90
@@ -723,7 +723,7 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
  real                 :: fextx,fexty,fextz,xi,yi,zi,pmassi,damp_fac
  real                 :: fonrmaxi,phii,dtphi2i
  real                 :: dkdt,extrapfac
- real                 :: densi,uui,pri,pondensi,spsoundi,tempi,vxyz(3),fext_gr(3)
+ real                 :: densi,uui,pri,pondensi,spsoundi,tempi,vxyz(3),fext_gr(3),xyz(3)
  logical              :: extrap,last
 
  allocate(merge_ij(nptmass))
@@ -839,7 +839,7 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
  !$omp shared(metrics,metricderivs,metrics_ptmass,metricderivs_ptmass,ieos,C_force) &
  !$omp private(fextx,fexty,fextz,xi,yi,zi) &
  !$omp private(i,fonrmaxi,dtphi2i,phii,dtf) &
- !$omp private(densi,uui,pri,pondensi,spsoundi,tempi,vxyz,fext_gr) &
+ !$omp private(densi,uui,pri,pondensi,spsoundi,tempi,xyz,vxyz,fext_gr) &
  !$omp firstprivate(pmassi,itype) &
  !$omp reduction(min:dtextforcenew,dtphi2) &
  !$omp reduction(max:fonrmax) &
@@ -907,7 +907,8 @@ subroutine get_force(nptmass,npart,nsubsteps,ntypes,timei,dtextforce,xyzh,vxyzu,
        ! damping
        !
        if (idamp > 0) then
-          call apply_damp(fextx, fexty, fextz, vxyzu(1:3,i), (/xi,yi,zi/), damp_fac)
+          xyz = (/xi,yi,zi/)
+          call apply_damp(fextx, fexty, fextz, vxyzu(1:3,i), xyz, damp_fac)
        endif
        !
        ! Radiation pressure force with isink_radiation

--- a/src/main/substepping.F90
+++ b/src/main/substepping.F90
@@ -494,15 +494,15 @@ subroutine kick(dki,dt,npart,nptmass,ntypes,xyzh,pxyzu,xyzmh_ptmass,pxyz_ptmass,
  real,            optional, intent(in)    :: timei
  integer(kind=1), optional, intent(inout) :: ibin_wake(:)
  integer(kind=1), optional, intent(in)    :: nbinmax
- logical        , optional, intent(inout)   :: accreted
+ logical        , optional, intent(inout) :: accreted
  real(kind=4)    :: t1,t2,tcpu1,tcpu2
  integer(kind=1) :: ibin_wakei
- logical         :: is_accretion
+ logical         :: is_accretion,was_accreted
  integer         :: i,itype,nfaili
  integer         :: naccreted,nfail,nlive
  real            :: dkdt,pmassi,fxi,fyi,fzi,accretedmass
 
- if (present(timei) .and. present(ibin_wake) .and. present(nbinmax)) then
+ if (present(timei) .and. present(ibin_wake) .and. present(nbinmax) .and. present(accreted)) then
     is_accretion = .true.
  else
     is_accretion = .false.
@@ -561,7 +561,7 @@ subroutine kick(dki,dt,npart,nptmass,ntypes,xyzh,pxyzu,xyzmh_ptmass,pxyz_ptmass,
     !$omp shared(xyzmh_ptmass,pxyz_ptmass,fxyz_ptmass,f_acc,apr_level,aprmassoftype) &
     !$omp shared(iexternalforce) &
     !$omp shared(nbinmax,ibin_wake) &
-    !$omp private(i,accreted,nfaili,fxi,fyi,fzi) &
+    !$omp private(i,was_accreted,nfaili,fxi,fyi,fzi) &
     !$omp firstprivate(itype,pmassi,ibin_wakei) &
     !$omp reduction(+:accretedmass) &
     !$omp reduction(+:nfail) &
@@ -588,10 +588,11 @@ subroutine kick(dki,dt,npart,nptmass,ntypes,xyzh,pxyzu,xyzmh_ptmass,pxyz_ptmass,
           pxyzu(2,i) = pxyzu(2,i) + dkdt*fext(2,i)
           pxyzu(3,i) = pxyzu(3,i) + dkdt*fext(3,i)
 
+          was_accreted = .false.
           if (iexternalforce > 0) then
              call accrete_particles(iexternalforce,xyzh(1,i),xyzh(2,i), &
-                                    xyzh(3,i),xyzh(4,i),pmassi,timei,accreted)
-             if (accreted) accretedmass = accretedmass + pmassi
+                                    xyzh(3,i),xyzh(4,i),pmassi,timei,was_accreted)
+             if (was_accreted) accretedmass = accretedmass + pmassi
           endif
           !
           ! accretion onto sink particles
@@ -607,9 +608,9 @@ subroutine kick(dki,dt,npart,nptmass,ntypes,xyzh,pxyzu,xyzmh_ptmass,pxyz_ptmass,
 
              call ptmass_accrete(1,nptmass,xyzh(1,i),xyzh(2,i),xyzh(3,i),xyzh(4,i),&
                                  pxyzu(1,i),pxyzu(2,i),pxyzu(3,i),fxi,fyi,fzi,&
-                                 itype,pmassi,xyzmh_ptmass,pxyz_ptmass,accreted, &
+                                 itype,pmassi,xyzmh_ptmass,pxyz_ptmass,was_accreted, &
                                  dptmass,timei,f_acc,nbinmax,ibin_wakei,nfaili)
-             if (accreted) then
+             if (was_accreted) then
                 naccreted = naccreted + 1
                 cycle accreteloop
              else
@@ -632,12 +633,12 @@ subroutine kick(dki,dt,npart,nptmass,ntypes,xyzh,pxyzu,xyzmh_ptmass,pxyz_ptmass,
 !
 ! reduction of sink particle changes across MPI
 !
-    accreted = .false.
+    if (present(accreted)) accreted = .false.
     if (nptmass > 0) then
        naccreted = int(reduceall_mpi('+',naccreted))
        nfail = int(reduceall_mpi('+',nfail))
        if (naccreted > 0) then
-          accreted = .true.
+          if (present(accreted)) accreted = .true.
           call reduce_in_place_mpi('+',dptmass(:,1:nptmass))
           if (id==master) call update_ptmass(dptmass,xyzmh_ptmass,pxyz_ptmass,fxyz_ptmass,nptmass)
        endif

--- a/src/main/utils_infiles.f90
+++ b/src/main/utils_infiles.f90
@@ -1424,6 +1424,7 @@ end subroutine get_options_interactive
 logical function infile_exists(fileprefix)
  character(len=*), intent(in) :: fileprefix
 
+ infile_exists = .false. ! avoid compiler warning
  inquire(file=trim(fileprefix)//'.in',exist=infile_exists)
 
 end function infile_exists

--- a/src/main/utils_omp.F90
+++ b/src/main/utils_omp.F90
@@ -35,9 +35,9 @@ subroutine info_omp
  integer, external :: omp_get_num_threads
 
 !$omp parallel
-!$omp masked
+!$omp single
 !$ print "(a,i4,a)",' Running in openMP on',omp_get_num_threads(),' threads'
-!$omp end masked
+!$omp end single
 !$omp end parallel
 
 #else

--- a/src/main/utils_omp.F90
+++ b/src/main/utils_omp.F90
@@ -35,9 +35,9 @@ subroutine info_omp
  integer, external :: omp_get_num_threads
 
 !$omp parallel
-!$omp master
+!$omp masked
 !$ print "(a,i4,a)",' Running in openMP on',omp_get_num_threads(),' threads'
-!$omp end master
+!$omp end masked
 !$omp end parallel
 
 #else
@@ -54,21 +54,19 @@ end subroutine info_omp
 !+
 !----------------------------------------------------------------
 subroutine init_omp
-#ifdef _OPENMP
 !$ integer :: i
 !$ external :: omp_init_lock
- integer, external :: omp_get_num_threads
+!$ integer, external :: omp_get_num_threads
+
+ omp_num_threads = 1
 
 !$ do i = 0, nlocks
 !$  call omp_init_lock(ipart_omp_lock(i))
 !$ enddo
 
 !$omp parallel
- omp_num_threads = omp_get_num_threads()
+!$ omp_num_threads = omp_get_num_threads()
 !$omp end parallel
-#else
- omp_num_threads = 1
-#endif
 
 end subroutine init_omp
 
@@ -82,21 +80,17 @@ end subroutine init_omp
 subroutine limits_omp (n1,n2,i1,i2)
  integer, intent(in)  :: n1,n2
  integer, intent(out) :: i1,i2
-#ifdef _OPENMP
- integer, external :: omp_get_num_threads, omp_get_thread_num
- logical, external :: omp_in_parallel
+ !$ integer, external :: omp_get_num_threads, omp_get_thread_num
+ !$ logical, external :: omp_in_parallel
 
- if (omp_in_parallel()) then
-    i1 = n1 + ((omp_get_thread_num()  )*n2)/omp_get_num_threads()
-    i2 =      ((omp_get_thread_num()+1)*n2)/omp_get_num_threads()
- else
-    i1 = max(1,n1)
-    i2 = n2
- endif
-#else
  i1 = max(1,n1)
  i2 = n2
-#endif
+
+ !$ if (omp_in_parallel()) then
+ !$    i1 = n1 + ((omp_get_thread_num()  )*n2)/omp_get_num_threads()
+ !$    i2 =      ((omp_get_thread_num()+1)*n2)/omp_get_num_threads()
+ !$ endif
+
 end subroutine limits_omp
 
 !----------------------------------------------------------------
@@ -158,12 +152,11 @@ subroutine limits_omp_work (n1,n2,i1,i2,work,mask,iskip)
 end subroutine limits_omp_work
 
 integer function omp_thread_num()
-#ifdef _OPENMP
- integer, external :: omp_get_thread_num
- omp_thread_num = omp_get_thread_num()
-#else
+ !$ integer, external :: omp_get_thread_num
+
  omp_thread_num = 0
-#endif
+ !$ omp_thread_num = omp_get_thread_num()
+
 end function omp_thread_num
 
 end module omputils

--- a/src/main/utils_omp.F90
+++ b/src/main/utils_omp.F90
@@ -80,16 +80,16 @@ end subroutine init_omp
 subroutine limits_omp (n1,n2,i1,i2)
  integer, intent(in)  :: n1,n2
  integer, intent(out) :: i1,i2
- !$ integer, external :: omp_get_num_threads, omp_get_thread_num
- !$ logical, external :: omp_in_parallel
+!$ integer, external :: omp_get_num_threads, omp_get_thread_num
+!$ logical, external :: omp_in_parallel
 
  i1 = max(1,n1)
  i2 = n2
 
- !$ if (omp_in_parallel()) then
- !$    i1 = n1 + ((omp_get_thread_num()  )*n2)/omp_get_num_threads()
- !$    i2 =      ((omp_get_thread_num()+1)*n2)/omp_get_num_threads()
- !$ endif
+!$ if (omp_in_parallel()) then
+!$  i1 = n1 + ((omp_get_thread_num()  )*n2)/omp_get_num_threads()
+!$  i2 =      ((omp_get_thread_num()+1)*n2)/omp_get_num_threads()
+!$ endif
 
 end subroutine limits_omp
 
@@ -152,10 +152,10 @@ subroutine limits_omp_work (n1,n2,i1,i2,work,mask,iskip)
 end subroutine limits_omp_work
 
 integer function omp_thread_num()
- !$ integer, external :: omp_get_thread_num
+!$ integer, external :: omp_get_thread_num
 
  omp_thread_num = 0
- !$ omp_thread_num = omp_get_thread_num()
+!$ omp_thread_num = omp_get_thread_num()
 
 end function omp_thread_num
 

--- a/src/main/utils_supertimestep.F90
+++ b/src/main/utils_supertimestep.F90
@@ -322,7 +322,7 @@ subroutine sts_get_dtau_array(Nmegasts,dt_next,dtdiff_in,Nmega_in)
 
  ! Calculate the number of super and mega steps
  if (present(Nmega_in)) then
-    call sts_get_Ndtdiff(dt_next/float(Nmega_in),dtdiff_in,dtdiff_used,Nsts,Nmega,nu,Nreal,icase_sts)
+    call sts_get_Ndtdiff(dt_next/real(Nmega_in),dtdiff_in,dtdiff_used,Nsts,Nmega,nu,Nreal,icase_sts)
     Nmega = Nmega * Nmega_in
  else
     call sts_get_Ndtdiff(dt_next,dtdiff_in,dtdiff_used,Nsts,Nmega,nu,Nreal,icase_sts)
@@ -391,7 +391,7 @@ subroutine sts_get_Ndtdiff(dt,dtdiff_in,dtdiff_out,Nsts,Nmega,nu_local,Nreal,ica
        Nsts = int( sqrt(dt/(dtdiffcoef(i)*dtdiff_in*Nmega)) ) + 1
        if (Nsts*Nmega >= Nreal) find_dtdiff = .false.
        if (find_dtdiff) then
-          dtdiff_out = sts_get_dtdiff(i,dt/float(Nmega),Nsts)
+          dtdiff_out = sts_get_dtdiff(i,dt/real(Nmega),Nsts)
           if (Nsts < nnu) then
              nu_local   = nu(Nsts,i)
              dtau_local = sts_get_dtau(1,Nsts,nu_local,dtdiff_out)

--- a/src/setup/density_profiles.f90
+++ b/src/setup/density_profiles.f90
@@ -341,7 +341,7 @@ subroutine rho_bonnorebert(iBEparam,central_density,edge_density,rBE,xBE,mBE,fac
  phi            = 0.0
  func           = 0.0
  containedmass  = 0.0
- dxi            = 5.01*6.45/float(npts)
+ dxi            = 5.01*6.45/real(npts)
  dfunc          = (-exp(phi))*dxi
  rtab           = 0.  ! array of radii
  mtab           = 0.  ! array of enclosed masses

--- a/src/setup/set_solarsystem.f90
+++ b/src/setup/set_solarsystem.f90
@@ -227,11 +227,11 @@ subroutine add_body(body_name,nptmass,xyzmh_ptmass,vxyz_ptmass,mtot,ierr,epoch)
  gm_cgs = elems(7)*km**3
  mbody  = (gm_cgs/gg)/umass
  rbody = elems(8)*km/udist
- print "(1x,a,1pg10.3)",   '           m/msun = ',mbody*umass/solarm
- print "(1x,a,1pg10.3)",   '         m/mearth = ',mbody*umass/earthm
- print "(1x,a,1pg10.4,a)", '                a = ',a*udist/au,' au'
- print "(1x,a,1pg10.3,a)", '           radius = ',elems(8),' km'
- print "(1x,a,1pg10.3,a)", '          density = ',elems(9),' g/cm^3'
+ print "(1x,a,1pg11.4)",   '           m/msun = ',mbody*umass/solarm
+ print "(1x,a,1pg11.4)",   '         m/mearth = ',mbody*umass/earthm
+ print "(1x,a,1pg11.4,a)", '                a = ',a*udist/au,' au'
+ print "(1x,a,1pg11.4,a)", '           radius = ',elems(8),' km'
+ print "(1x,a,1pg11.5,a)", '          density = ',elems(9),' g/cm^3'
  ntmp = 0
  call set_binary(mtot,0.,a,e,0.01,rbody,&
       xyz_tmp,vxyz_tmp,ntmp,ierr,incl=inc,&

--- a/src/setup/set_solarsystem.f90
+++ b/src/setup/set_solarsystem.f90
@@ -231,7 +231,7 @@ subroutine add_body(body_name,nptmass,xyzmh_ptmass,vxyz_ptmass,mtot,ierr,epoch)
  print "(1x,a,1pg11.4)",   '         m/mearth = ',mbody*umass/earthm
  print "(1x,a,1pg11.4,a)", '                a = ',a*udist/au,' au'
  print "(1x,a,1pg11.4,a)", '           radius = ',elems(8),' km'
- print "(1x,a,1pg11.5,a)", '          density = ',elems(9),' g/cm^3'
+ print "(1x,a,1pg11.4,a)", '          density = ',elems(9),' g/cm^3'
  ntmp = 0
  call set_binary(mtot,0.,a,e,0.01,rbody,&
       xyz_tmp,vxyz_tmp,ntmp,ierr,incl=inc,&

--- a/src/setup/set_sphere.f90
+++ b/src/setup/set_sphere.f90
@@ -381,12 +381,12 @@ subroutine set_unifdis_sphereN(lattice,id,master,xmin,xmax,ymin,ymax,zmin,zmax,p
     else
        if (nps_requested - nps_lo < npart0 - nps_requested) then
           write(*,'(a,i0,a,f5.2,a)') " set_sphere: Closest number to requested is " &
-                       ,nps_lo,", which is ",float(nps_requested-nps_lo)/float(nps_requested)*100.0 &
+                       ,nps_lo,", which is ",real(nps_requested-nps_lo)/real(nps_requested)*100.0 &
                        ,"% less"
           write(*,'(a)') " set_sphere: We will not use fewer than requested number of particles"
        endif
        write(*,'(a,i0,a,f5.2,a)') " set_sphere: Using " &
-                 , npart0," particles, which is ",float(npart0- nps_requested)/float(nps_requested)*100.0 &
+                 , npart0," particles, which is ",real(npart0- nps_requested)/real(nps_requested)*100.0 &
                  ,"% more than requested"
     endif
  endif

--- a/src/setup/set_unifdis.f90
+++ b/src/setup/set_unifdis.f90
@@ -307,9 +307,9 @@ subroutine set_unifdis(lattice,id,master,xmin,xmax,ymin,ymax, &
           xstart = xstart + delx
        endif
 
-       xi = xstart + float(k - 1)*deltax
-       yi = ystart + float(l - 1)*deltay
-       zi = zstart + float(m - 1)*deltaz
+       xi = xstart + real(k - 1)*deltax
+       yi = ystart + real(l - 1)*deltay
+       zi = zstart + real(m - 1)*deltaz
 
        xpartmin = min(xpartmin,xi)
        ypartmin = min(ypartmin,yi)

--- a/src/setup/setup_BHL.f90
+++ b/src/setup/setup_BHL.f90
@@ -35,6 +35,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use physcon,    only:pi,au,solarm
  use units,      only:udist,umass,utime,set_units
  use inject,     only:init_inject,BHL_r_star,BHL_m_star,BHL_pmass
+ use kernel,     only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -54,7 +55,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  time  = 0.
  polyk = 0.
  gamma = 5./3.
-
+ hfact = hfact_default
  call init_inject(ierr)
  m     = BHL_m_star / umass ! Depends on parameters in the input file
  hacc  = BHL_r_star / udist ! Depends on parameters in the input file

--- a/src/setup/setup_bondi.f90
+++ b/src/setup/setup_bondi.f90
@@ -60,6 +60,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use part,           only:xyzmh_ptmass,vxyz_ptmass,nptmass,ihacc,igas,set_particle_type,iboundary
  use stretchmap,     only:get_mass_r,rho_func
  use infile_utils,   only:get_options
+ use kernel,         only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -86,7 +87,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
 !
  time           = 0.
  iexternalforce = 1
-
+ hfact = hfact_default
  rmin = 7.
  rmax = 8.
  np   = 10000

--- a/src/setup/setup_bondiinject.f90
+++ b/src/setup/setup_bondiinject.f90
@@ -44,6 +44,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma_eos,hf
  use externalforces, only:accradius1,accradius1_hard
  use bondiexact,     only:isol
  use infile_utils,   only:get_options
+ use kernel,         only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -91,6 +92,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma_eos,hf
  massoftype(igas) = pmassi
  gamma            = 5./3. !Set gamma in module eos since init_inject needs to know about it.
  gamma_eos        = gamma
+ hfact            = hfact_default
 
  call init_inject(ierr)
 

--- a/src/setup/setup_dustsettle.f90
+++ b/src/setup/setup_dustsettle.f90
@@ -71,6 +71,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use mpidomain,      only:i_belong
  use radiation_utils,only:set_radiation_and_gas_temperature_equal
  use infile_utils,   only:get_options
+ use kernel,         only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -90,6 +91,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
 !
 !--default options
 !
+ hfact        = hfact_default
  npartx       = 32
  rhozero      = 1.e-3
  dtg          = 0.01

--- a/src/setup/setup_empty.f90
+++ b/src/setup/setup_empty.f90
@@ -31,6 +31,7 @@ contains
 subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,time,fileprefix)
  use units,   only:set_units
  use physcon, only:au,solarm
+ use kernel,  only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -49,6 +50,9 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  npart = 0
  npartoftype(:) = 0
  massoftype = 1.
+ hfact = hfact_default
+ xyzh = 0.
+ vxyzu = 0.
 
 end subroutine setpart
 

--- a/src/setup/setup_firehose.f90
+++ b/src/setup/setup_firehose.f90
@@ -32,6 +32,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use units,   only:set_units,umass
  use physcon, only:au,solarm
  use part,    only:igas,xyzmh_ptmass,nptmass,vxyz_ptmass
+ use kernel,  only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -46,11 +47,13 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  time = 0.
  polyk = 0.
  gamma = 5./3.
-
+ hfact = hfact_default
  npart = 0
  npartoftype(:) = 0
  massoftype = 0.
  massoftype(igas) = 1.e-12*solarm/umass
+ xyzh = 0.
+ vxyzu = 0.
 
  nptmass = 1
  if (nptmass > 0) then

--- a/src/setup/setup_grtde.f90
+++ b/src/setup/setup_grtde.f90
@@ -106,7 +106,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  integer :: i
  logical :: iexist,use_var_comp
  real    :: rtidal,rp,semia,period,hacc1,hacc2
- real    :: vxyzstar(3),xyzstar(3)
+ real    :: vxyzstar(3),xyzstar(3),vec(3)
  real    :: r0,vel,lorentz
  real    :: vhat(3),x0,y0
  real    :: semi_maj_val
@@ -249,6 +249,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
     xyzstar  = 0.
     vxyzstar = 0.
     period   = 0.
+    vec      = (/0.,1.,0./)
 
     if (ecc_bh<1.) then
        !
@@ -266,8 +267,8 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
        xyzstar(:)  = xyzmh_ptmass(1:3,2)
        nptmass  = 0
 
-       call rotatevec(xyzstar,(/0.,1.,0./),-theta_bh)
-       call rotatevec(vxyzstar,(/0.,1.,0./),-theta_bh)
+       call rotatevec(xyzstar,vec,-theta_bh)
+       call rotatevec(vxyzstar,vec,-theta_bh)
 
     elseif (abs(ecc_bh-1.) < tiny(0.)) then
        !
@@ -298,8 +299,8 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
                                mass1, 0.0d0, r0, epsilon_target, alpha, delta_v, tol, max_iters)
        endif
 
-       call rotatevec(xyzstar,(/0.,1.,0./),theta_bh)
-       call rotatevec(vxyzstar,(/0.,1.,0./),theta_bh)
+       call rotatevec(xyzstar,vec,theta_bh)
+       call rotatevec(vxyzstar,vec,theta_bh)
 
     else
        call fatal('setup','please choose a valid eccentricity (0<ecc_bh<=1)',var='ecc_bh',val=ecc_bh)

--- a/src/setup/setup_gwdisc.f90
+++ b/src/setup/setup_gwdisc.f90
@@ -159,7 +159,7 @@ subroutine setup_interactive()
  call prompt('Enter H/R at R=R_in ',HoverRinput,0.)
  call prompt('Enter p index of surface density profile Sigma = Sigma0*R^-p',p_indexinput,0.)
  call prompt('Enter q index of temperature profile cs = cs0*R^-q',q_indexinput,0.)
- print "(a,es10.4,a)",'Enter disc mass in units of ',umass/solarm,' solar masses (Mjup = 8.6 x 10^-4 Msun) '
+ print "(a,es12.4,a)",'Enter disc mass in units of ',umass/solarm,' solar masses (Mjup = 8.6 x 10^-4 Msun) '
  call prompt(' ',discm,0.)
  call prompt('Enter desired value of alpha_SS',alphaSS,0.)
 

--- a/src/setup/setup_hierarchical.f90
+++ b/src/setup/setup_hierarchical.f90
@@ -39,6 +39,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use externalforces,  only:iext_corotate
  use infile_utils,    only:get_options
  use io,              only:master
+ use kernel,          only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -63,6 +64,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  time = 0.
  polyk = 0.
  gamma = 1.
+ hfact = hfact_default
 !
 !--space available for injected gas particles
 !

--- a/src/setup/setup_kh.f90
+++ b/src/setup/setup_kh.f90
@@ -60,6 +60,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,&
  use physcon,      only:pi
  use timestep,     only:dtmax,tmax
  use infile_utils, only:infile_exists,get_options
+ use kernel,       only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)

--- a/src/setup/setup_kh.f90
+++ b/src/setup/setup_kh.f90
@@ -79,6 +79,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,&
  time  = 0.
  gamma = 5./3
  polyk = 0.
+ hfact = hfact_default
  if (.not. infile_exists(filename)) then
     tmax      = 2.00
     dtmax     = 0.1

--- a/src/setup/setup_masstransfer.f90
+++ b/src/setup/setup_masstransfer.f90
@@ -64,6 +64,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use setunits,        only:mass_unit,dist_unit
  use timestep,        only:tmax
  use infile_utils,    only:get_options
+ use kernel,          only:hfact_default
 ! use readwrite_mesa,  only:read_masstransferrate
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
@@ -85,6 +86,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  time = 0.
  polyk = 0.
  gamma = 5./3.
+ hfact = hfact_default
 !
 !--space available for injected gas particles
 !  in case only sink particles are used

--- a/src/setup/setup_mhdrotor.f90
+++ b/src/setup/setup_mhdrotor.f90
@@ -43,6 +43,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,&
  use physcon,      only:pi
  use timestep,     only:tmax,dtmax
  use mpidomain,    only:i_belong
+ use kernel,       only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -61,6 +62,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,&
  time = 0.
  gamma = 1.4
  polyk = 0.
+ hfact = hfact_default
 !
 !--set particles
 !

--- a/src/setup/setup_orstang.f90
+++ b/src/setup/setup_orstang.f90
@@ -56,6 +56,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use physcon,      only:pi,fourpi
  use timestep,     only:dtmax,tmax
  use infile_utils, only:get_options,infile_exists
+ use kernel,       only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(out)   :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -72,6 +73,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
 !
  time    = 0.
  gamma   = 5./3.
+ hfact   = hfact_default
  if (.not. infile_exists(fileprefix)) then
     tmax  = 1.00
     dtmax = 0.05

--- a/src/setup/setup_shock.f90
+++ b/src/setup/setup_shock.f90
@@ -699,7 +699,7 @@ subroutine print_shock_params
  do i=1,max_states
     if (.not. mhd .and. (i==iBx .or. i==iBy .or. i==iBz)) cycle
     if (.not. do_radiation .and. (i==ixi)) cycle
-    write(*,"(11x,a4,' L: ',1pg11.5,'  R: ',1pg11.5)") &
+    write(*,"(11x,a4,' L: ',1pg12.5,'  R: ',1pg12.5)") &
          trim(var_label(i)),leftstate(i),rightstate(i)
  enddo
  print "(a)"

--- a/src/setup/setup_shock.f90
+++ b/src/setup/setup_shock.f90
@@ -131,9 +131,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  !
  ! verify a legitimate lattice type has been chosen
  !
- if (.not.is_valid_lattice(latticetype)) then
-    call fatal('setup','invalid lattice type')
- endif
+ if (.not.is_valid_lattice(latticetype)) call fatal('setup','invalid lattice type')
  use_closepacked = is_closepacked(latticetype)
  !
  ! determine if an .in file exists
@@ -168,8 +166,11 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
                   read_setupfile,write_setupfile,choose_shock)
  if (ierr /= 0) stop 'rerun phantomsetup after editing .setup file'
 
- if (gr) call set_units(G=1.,c=1.,mass=10.*solarm)
- if (use_radpulse_units) then
+ ! default is to use code units everywhere, but some shock tube
+ ! problems require physical units to be set
+ if (gr) then
+    call set_units(G=1.,c=1.,mass=10.*solarm)
+ elseif (use_radpulse_units) then
     call set_units(dist=1.,mass=1.,time=1.e-4)
  elseif (do_radiation .or. icooling > 0 .or. mhd_nonideal) then
     call set_units(dist=au,mass=solarm,G=1.d0)
@@ -209,7 +210,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  !
  ! adjust boundaries to allow space for boundary particles and inflow
  !
- dxleft = -xleft/float(nx)
+ dxleft = -xleft/real(nx)
  call adjust_shock_boundaries(dxleft,dxright,radkern, &
       leftstate(ivx),rightstate(ivx),rholeft,rhoright,tmax,ndim,&
       xleft,xright,yleft,yright,zleft,zright,is_closepacked(latticetype))

--- a/src/setup/setup_srpolytrope.f90
+++ b/src/setup/setup_srpolytrope.f90
@@ -46,6 +46,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use prompting,   only:prompt
  use setup_params, only:npart_total
  use infile_utils, only:get_options
+ use kernel,      only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -84,7 +85,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  npartoftype(:) = 0
  xyzh(:,:)      = 0.
  vxyzu(:,:)     = 0.
-
+ hfact          = hfact_default
  ! set units
  call set_units(mass=1.e6*solarm,c=1.,G=1.)
  mstar = 1.*solarm/umass

--- a/src/setup/setup_testparticles.f90
+++ b/src/setup/setup_testparticles.f90
@@ -69,6 +69,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use vectorutils,    only:cross_product3D
  use part,           only:gr
  use infile_utils,   only:get_options
+ use kernel,         only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(out)   :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -99,6 +100,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  tmax = 500.
  dtmax = 0.5
  period = tmax
+ hfact = hfact_default
  !
  ! read runtime parameters from setup file
  !

--- a/src/setup/setup_wave.f90
+++ b/src/setup/setup_wave.f90
@@ -60,6 +60,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use set_dust,     only:set_dustfrac
  use mpidomain,    only:i_belong
  use infile_utils, only:get_options
+ use kernel,       only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -95,7 +96,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  dtg = 1.
  idrag = 2
  K_code = 1000.
-
+ hfact = hfact_default
  ! Print setup header
  if (id==master) print "(/,a,/)",'  >>> Setting up particles for linear wave test <<<'
 

--- a/src/setup/setup_wavedamp.f90
+++ b/src/setup/setup_wavedamp.f90
@@ -71,6 +71,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use prompting,    only:prompt
  use mpidomain,    only:i_belong
  use infile_utils, only:get_options
+ use kernel,       only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -124,7 +125,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  kwave     = 2.0
  use_ambi  = .true.
  if (.not. mhd) isowave = .true.
-
+ hfact = hfact_default
  if (oned) then
     rhoin0  = 1.0
     Bxin0   = 1.0

--- a/src/setup/setup_wavedamp.f90
+++ b/src/setup/setup_wavedamp.f90
@@ -71,7 +71,6 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use prompting,    only:prompt
  use mpidomain,    only:i_belong
  use infile_utils, only:get_options
- use kernel,       only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -125,7 +124,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  kwave     = 2.0
  use_ambi  = .true.
  if (.not. mhd) isowave = .true.
- hfact = hfact_default
+
  if (oned) then
     rhoin0  = 1.0
     Bxin0   = 1.0

--- a/src/setup/setup_wddisc.f90
+++ b/src/setup/setup_wddisc.f90
@@ -51,6 +51,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use timestep,  only:tmax,dtmax
  use setup_params, only:npart_total
  use infile_utils, only:get_options
+ use kernel,       only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -77,7 +78,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  norbits       = 1.
  dumpsperorbit = 100
  nr            = 50
-
+ hfact         = hfact_default
  !
  !--Read runtime parameters from setup file
  !

--- a/src/setup/setup_wind.f90
+++ b/src/setup/setup_wind.f90
@@ -139,6 +139,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use eos,             only:gmw,ieos,isink,qfacdisc
  use spherical,       only:set_sphere
  use infile_utils,    only:get_options
+ use kernel,          only:hfact_default
  integer,           intent(in)    :: id
  integer,           intent(inout) :: npart
  integer,           intent(out)   :: npartoftype(:)
@@ -152,6 +153,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  integer :: ierr,k
  logical :: iexist
 
+ hfact = hfact_default
  call set_units(dist=au,mass=solarm,G=1.)
  call set_default_parameters_wind()
  filename = trim(fileprefix)//'.in'

--- a/src/tests/test_dust.f90
+++ b/src/tests/test_dust.f90
@@ -263,7 +263,7 @@ subroutine test_dustybox(ntests,npass)
     vd = 0.5*(1. + deltav)
     fd = K_code(1)*(vg - vd)
     if (write_output) then
-       write(filename,"(a,1pe8.2,a)") 'dustybox_t',t,'.out'
+       write(filename,"(a,1pe9.2,a)") 'dustybox_t',t,'.out'
        open(unit=lu,file=filename,status='replace')
        print "(a)",' writing '//trim(filename)
     endif
@@ -676,11 +676,11 @@ subroutine test_epsteinstokes(ntests,npass)
  do j=1,nrhopts
     rhogas = rhomin*10**((j-1)*drho)/unit_density
     if (write_output) then
-       write(filename,"(a,1pe8.2,a)") 'ts-rho',rhogas*unit_density,'.out'
+       write(filename,"(a,1pe9.2,a)") 'ts-rho',rhogas*unit_density,'.out'
        open(unit=lu,file=filename,status='replace')
        print "(a)",' writing '//trim(filename)
     endif
-    write(filename,"(a,1pe8.2)") 'rho=',rhogas*unit_density
+    write(filename,"(a,1pe9.2)") 'rho=',rhogas*unit_density
     ncheck = 0
     nfailed = 0
     errmax = 0.

--- a/src/tests/test_indtstep.f90
+++ b/src/tests/test_indtstep.f90
@@ -14,7 +14,7 @@ module testindtstep
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: io, testutils, timestep_ind
+! :Dependencies: dim, io, testutils, timestep_ind
 !
  implicit none
  public :: test_indtstep

--- a/src/tests/test_iorig.f90
+++ b/src/tests/test_iorig.f90
@@ -36,7 +36,7 @@ subroutine test_iorig(ntests,npass)
  integer, intent(inout) :: ntests,npass
  integer :: i, j, iseed, ncheck, ierrmax
  integer :: nfailed(1)
- character(len=10) :: stringi, stringj
+ character(len=12) :: stringi, stringj
 
  if (id==master) write(*,"(/,a,/)") '--> TESTING PARTICLE ID'
 
@@ -63,8 +63,8 @@ subroutine test_iorig(ntests,npass)
 
     call shuffle_part(npart)
 
-    write(stringi, "(I2)") i
-    call checkvalbuf(npart,100-4*i,0,'Check npart while deleting '//trim(stringi),nfailed(1),ncheck,ierrmax)
+    write(stringi,"(i12)") i
+    call checkvalbuf(npart,100-4*i,0,'Check npart while deleting '//trim(adjustl(stringi)),nfailed(1),ncheck,ierrmax)
  enddo
 
  call checkvalbuf_end('check npart while deleting', ncheck, nfailed(1), ierrmax, 0)
@@ -81,10 +81,10 @@ subroutine test_iorig(ntests,npass)
  nfailed(1)=0
  do i = 1, npart
     do j = i+1, npart
-       write(stringi, "(I2)") i
-       write(stringj, "(I2)") j
+       write(stringi,"(i12)") i
+       write(stringj,"(i12)") j
        call checkvalbuf(iorig(i)==iorig(j),.false.,&
-      'Check iorig('//trim(stringi)//' != iorig('//trim(stringj)//')',nfailed(1),ncheck)
+      'Check iorig('//trim(adjustl(stringi))//' != iorig('//trim(adjustl(stringj))//')',nfailed(1),ncheck)
     enddo
  enddo
  call checkvalbuf_end('Check iorig',ncheck,nfailed(1))

--- a/src/tests/test_luminosity.F90
+++ b/src/tests/test_luminosity.F90
@@ -14,8 +14,8 @@ module testlum
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: deriv, dim, energies, eos, io, options, part, setdisc,
-!   testutils, timing, viscosity
+! :Dependencies: deriv, dim, energies, eos, io, options, part, physcon,
+!   setdisc, testutils, units, viscosity
 !
  implicit none
  public :: test_lum

--- a/src/tests/test_luminosity.F90
+++ b/src/tests/test_luminosity.F90
@@ -151,7 +151,7 @@ subroutine test_lum(ntests,npass)
        enddo
        !
        ! check that the total luminosity is the same regardless of whether particles are active or not
-       ! i.e. that the luminosity is updated on active particles but preserved on non-active particles 
+       ! i.e. that the luminosity is updated on active particles but preserved on non-active particles
        ! between force updates
        !
        diff = (totlum_saved(1) - totlum_saved(2))/totlum_saved(1)

--- a/src/tests/testsuite.F90
+++ b/src/tests/testsuite.F90
@@ -19,7 +19,7 @@ module test
 !   testcooling, testcorotate, testdamping, testderivs, testdust, testeos,
 !   testexternf, testgeometry, testgnewton, testgr, testgravity,
 !   testgrowth, testindtstep, testiorig, testkdtree, testkernel, testlink,
-!   testmath, testmpi, testnimhd, testpart, testpoly, testptmass,
+!   testlum, testmath, testmpi, testnimhd, testpart, testpoly, testptmass,
 !   testradiation, testrwdump, testsedov, testsetdisc, testsethier,
 !   testsetstar, testsmol, teststep, testunits, testwind, timing
 !

--- a/src/utils/analysis_common_envelope.f90
+++ b/src/utils/analysis_common_envelope.f90
@@ -1412,7 +1412,7 @@ subroutine output_extra_quantities(time,dumpfile,npart,particlemass,xyzh,vxyzu)
        case(4) ! Mach number
           arr(k,i) = distance(vxyzu(1:3,i)) / spsoundi
        case(5) ! Opacity from MESA tables
-             call get_eos_kappa_mesa(rho_cgs,eos_vars(itemp,i),kappai,kappat,kappar)
+          call get_eos_kappa_mesa(rho_cgs,eos_vars(itemp,i),kappai,kappat,kappar)
           arr(k,i) = kappai/unit_opacity
        case(6) ! Gas omega w.r.t. sink CoM
           xyz_a  = xyzh(1:3,i)  - sinkcom_xyz(1:3)

--- a/src/utils/diffdumps.f90
+++ b/src/utils/diffdumps.f90
@@ -116,7 +116,7 @@ program diffdumps
  if (allocated(xyzh2)) deallocate(xyzh2)
  if (allocated(vxyzu2)) deallocate(vxyzu2)
 
- print "(/a,es10.4)",'MAX RMS ERROR: ',maxval(err)
+ print "(/a,es12.4)",'MAX RMS ERROR: ',maxval(err)
 
  if (ndiff > 0) then
     print "(/,a)",' FILES DIFFER'

--- a/src/utils/get_struct_slope.f90
+++ b/src/utils/get_struct_slope.f90
@@ -141,16 +141,16 @@ program get_struct_slope
           !enddo
           print*,' best fit slope = ',slope,' +/- ',errslope,' overall goodness of fit = ',100.*err,'%'
           print*,' y intercept    = ',yint,' +/- ',erryint,' unlogged = ',10**(yint),' angle = ',180*atan(slope)/3.1415936d0
-          !print "(a,es10.4,a,es10.4)",' function string: 10**(m*log10(x) + yint),m=',slope,',yint=',yint
+          !print "(a,es12.4,a,es12.4)",' function string: 10**(m*log10(x) + yint),m=',slope,',yint=',yint
           !print*,' writing to output file'
           if (i_sf==1) then
-             write(iunitw+1,"(i5,2x,6(es12.4,1x),2(a,es10.4))",iostat=ierr) iorder,slope,yint,errslope,erryint,err,&
+             write(iunitw+1,"(i5,2x,6(es12.4,1x),2(a,es12.4))",iostat=ierr) iorder,slope,yint,errslope,erryint,err,&
                slope/slope3longd,'10**(m*log10(x) + yint),m=',slope,',yint=',yint
-             write(iunitw+3,"(2(a,es10.4))",iostat=ierr) '10**(m*log10(x) + yint),m=',slope,',yint=',yint
+             write(iunitw+3,"(2(a,es12.4))",iostat=ierr) '10**(m*log10(x) + yint),m=',slope,',yint=',yint
           else
-             write(iunitw+2,"(i5,2x,6(es12.4,1x),2(a,es10.4))",iostat=ierr) iorder,slope,yint,errslope,erryint,err,&
+             write(iunitw+2,"(i5,2x,6(es12.4,1x),2(a,es12.4))",iostat=ierr) iorder,slope,yint,errslope,erryint,err,&
                slope/slope3trans,'10**(m*log10(x) + yint),m=',slope,',yint=',yint
-             write(iunitw+4,"(2(a,es10.4))",iostat=ierr) '10**(m*log10(x) + yint),m=',slope,',yint=',yint
+             write(iunitw+4,"(2(a,es12.4))",iostat=ierr) '10**(m*log10(x) + yint),m=',slope,',yint=',yint
           endif
        enddo
     enddo

--- a/src/utils/interpolate3D.f90
+++ b/src/utils/interpolate3D.f90
@@ -172,9 +172,9 @@ subroutine interpolate3D(xyzh,weight,dat,itype,npart,&
 !$omp private(pixint,wint,negflag,dfac,threadid) &
 !$omp firstprivate(iprintnext) &
 !$omp reduction(+:nwarn,usedpart)
-!$omp master
+!$omp masked
 !$ print "(1x,a,i3,a)",'Using ',omp_get_num_threads(),' cpus'
-!$omp end master
+!$omp end masked
 
 !$omp do schedule (guided, 2)
  over_parts: do i=1,npart
@@ -529,9 +529,9 @@ subroutine interpolate3D_vecexact(xyzh,weight,dat,ilendat,itype,npart,&
  !$omp private(pixint,wint,negflag,dfac,threadid,smoothindex) &
  !$omp firstprivate(iprintnext) &
  !$omp reduction(+:nwarn,usedpart)
- !$omp master
+ !$omp masked
 !$ print "(1x,a,i3,a)",'Using ',omp_get_num_threads(),' cpus'
- !$omp end master
+ !$omp end masked
 
  !$omp do schedule (guided, 2)
  over_parts: do i=1,npart

--- a/src/utils/interpolate3D.f90
+++ b/src/utils/interpolate3D.f90
@@ -64,7 +64,6 @@ subroutine interpolate3D(xyzh,weight,dat,itype,npart,&
  real, intent(in) :: xmin,ymin,zmin,pixwidthx,pixwidthy,pixwidthz
  real, intent(out), dimension(npixx,npixy,npixz) :: datsmooth
  logical, intent(in) :: normalise,periodicx,periodicy,periodicz
-!logical, intent(in), exact_rendering
  real, allocatable :: datnorm(:,:,:)
 
  integer :: i,ipix,jpix,kpix
@@ -82,10 +81,9 @@ subroutine interpolate3D(xyzh,weight,dat,itype,npart,&
 
 ! Exact rendering
  real :: pixint, wint
-!logical, parameter :: exact_rendering = .true.   ! use exact rendering y/n
  integer :: usedpart, negflag
 
-!$ integer, external :: omp_get_num_threads,omp_get_thread_num
+ !$ integer, external :: omp_get_num_threads,omp_get_thread_num
  integer(kind=selected_int_kind(10)) :: iprogress,j  ! up to 10 digits
 
 ! Fill the particle data with xyzh
@@ -172,9 +170,9 @@ subroutine interpolate3D(xyzh,weight,dat,itype,npart,&
 !$omp private(pixint,wint,negflag,dfac,threadid) &
 !$omp firstprivate(iprintnext) &
 !$omp reduction(+:nwarn,usedpart)
-!$omp masked
+!$omp single
 !$ print "(1x,a,i3,a)",'Using ',omp_get_num_threads(),' cpus'
-!$omp end masked
+!$omp end single nowait
 
 !$omp do schedule (guided, 2)
  over_parts: do i=1,npart
@@ -220,10 +218,8 @@ subroutine interpolate3D(xyzh,weight,dat,itype,npart,&
     hi1 = 1./hi
     hi21 = hi1*hi1
     radkernh = radkernel*hi   ! radius of the smoothing kernel
-!termnorm = const*weight(i)
     term = termnorm*dat(i)
     dfac = hi**3/(pixwidthx*pixwidthy*pixwidthz*const)
-!dfac = hi**3/(pixwidthx*pixwidthy*const)
 !
 !--for each particle work out which pixels it contributes to
 !
@@ -248,7 +244,6 @@ subroutine interpolate3D(xyzh,weight,dat,itype,npart,&
     endif
 
     negflag = 0
-
 !
 !--precalculate an array of dx2 for this particle (optimisation)
 !
@@ -396,7 +391,6 @@ subroutine interpolate3D_vecexact(xyzh,weight,dat,ilendat,itype,npart,&
 
  integer, intent(in) :: npart,npixx,npixy,npixz,ilendat
  real, intent(in)    :: xyzh(4,npart)
- !real, intent(in), dimension(npart) :: x,y,z,hh ! change to xyzh()
  real, intent(in), dimension(npart) :: weight
  real, intent(in),dimension(npart,ilendat) :: dat
  integer, intent(in), dimension(npart) :: itype
@@ -424,7 +418,6 @@ subroutine interpolate3D_vecexact(xyzh,weight,dat,ilendat,itype,npart,&
  !logical, parameter :: exact_rendering = .true.   ! use exact rendering y/n
  integer :: usedpart, negflag
 
-
 !$ integer, external :: omp_get_num_threads,omp_get_thread_num
  integer(kind=selected_int_kind(10)) :: iprogress,j  ! up to 10 digits
 
@@ -433,16 +426,9 @@ subroutine interpolate3D_vecexact(xyzh,weight,dat,ilendat,itype,npart,&
  y(:) = xyzh(2,:)
  z(:) = xyzh(3,:)
  hh(:) = xyzh(4,:)
- !print*, "smoothing length: ", hh(1:10)
- ! cnormk3D set the value from the kernel routine
  cnormk3D = cnormk
  radkernel = radkern
  radkernel2 = radkern2
-!  print*, "radkern: ", radkern
-!  print*, "radkernel: ",radkernel
-!  print*, "radkern2: ", radkern2
-
- !print*, "npix: ", npixx, npixy,npixz
 
  if (exact_rendering) then
     print "(1x,a)",'interpolating to 3D grid (exact/Petkova+2018 on subgrid) ...'
@@ -458,13 +444,6 @@ subroutine interpolate3D_vecexact(xyzh,weight,dat,ilendat,itype,npart,&
  if (any(hh(1:npart) <= tiny(hh))) then
     print*,'interpolate3D: WARNING: ignoring some or all particles with h < 0'
  endif
-
- !call wall_time(t_start)
-
-!! $ allocate(ilock(npixx*npixy*npixz))
-!! $ do i=1,npixx*npixy*npixz
-!! $  call omp_init_lock(ilock(i))
-!! $ enddo
 
  datsmooth = 0.
  if (normalise) then
@@ -492,11 +471,6 @@ subroutine interpolate3D_vecexact(xyzh,weight,dat,ilendat,itype,npart,&
  xminpix = xmin !- 0.5*pixwidthx
  yminpix = ymin !- 0.5*pixwidthy
  zminpix = zmin !- 0.5*pixwidthz
-!  print*, "xminpix: ", xminpix
-!  print*, "yminpix: ", yminpix
-!  print*, "zminpix: ", zminpix
-!  print*, "dat: ", dat(1:10)
-!  print*, "weights: ", weight(1:10)
  pixwidthmax = max(pixwidthx,pixwidthy,pixwidthz)
  !
  !--use a minimum smoothing length on the grid to make
@@ -529,9 +503,9 @@ subroutine interpolate3D_vecexact(xyzh,weight,dat,ilendat,itype,npart,&
  !$omp private(pixint,wint,negflag,dfac,threadid,smoothindex) &
  !$omp firstprivate(iprintnext) &
  !$omp reduction(+:nwarn,usedpart)
- !$omp masked
-!$ print "(1x,a,i3,a)",'Using ',omp_get_num_threads(),' cpus'
- !$omp end masked
+ !$omp single
+ !$ print "(1x,a,i3,a)",'Using ',omp_get_num_threads(),' cpus'
+ !$omp end single nowait
 
  !$omp do schedule (guided, 2)
  over_parts: do i=1,npart

--- a/src/utils/interpolate3D_amr.F90
+++ b/src/utils/interpolate3D_amr.F90
@@ -79,9 +79,7 @@ subroutine interpolate3D_amr(xyzh,weight,pmass,vxyzu,npart, &
  real :: termdat(4+ilendat)
  logical :: iprintprogress
 !$ integer :: omp_get_num_threads,j
-#ifndef _OPENMP
  integer(kind=8) :: iprogress
-#endif
 
  datsmooth = 0.
  !datnorm = 0.
@@ -152,15 +150,15 @@ subroutine interpolate3D_amr(xyzh,weight,pmass,vxyzu,npart, &
  !$omp private(xi,yi,zi,xorigi,yorigi,zorigi,xminnew)            &
  !$omp private(ipix,jpix,kpix,ipixi,jpixi,kpixi,icell,isubmesh)  &
  !$omp private(ipixmin,ipixmax,jpixmin,jpixmax,kpixmin,kpixmax)
- !$omp master
-!$ print "(1x,a,i3,a)",'Using ',omp_get_num_threads(),' cpus'
- !$omp end master
+ !$omp single
+ !$ print "(1x,a,i3,a)",'Using ',omp_get_num_threads(),' cpus'
+ !$omp end single nowait
  !$omp do schedule(guided,10)
  over_parts: do i=1,npart
     !
     !--report on progress
     !
-#ifndef _OPENMP
+!$ if (.false.) then
     if (iprintprogress) then
        iprogress = nint(100.*i/npart)
        if (iprogress >= iprintnext) then
@@ -168,7 +166,7 @@ subroutine interpolate3D_amr(xyzh,weight,pmass,vxyzu,npart, &
           iprintnext = iprintnext + iprintinterval
        endif
     endif
-#endif
+!$ endif
     !
     !--set kernel related quantities
     !

--- a/src/utils/interpolate3D_amr.F90
+++ b/src/utils/interpolate3D_amr.F90
@@ -142,6 +142,7 @@ subroutine interpolate3D_amr(xyzh,weight,pmass,vxyzu,npart, &
  !
  !$omp parallel default(none) &
  !$omp shared(npart,xyzh,vxyzu,dat,datsmooth,datnorm,gridnodes) &
+ !$omp shared(iprintprogress)                                   &
  !$omp firstprivate(const,ilendat,weight)                       &
  !$omp firstprivate(xmin,pmass,imesh,nnodes,level)               &
  !$omp firstprivate(npixx,npixy,npixz,dxmax,dxcell,normalise)    &
@@ -149,7 +150,8 @@ subroutine interpolate3D_amr(xyzh,weight,pmass,vxyzu,npart, &
  !$omp private(xpix,ypix,zpix,dx,dy,dz,dz2,dyz2,qq,q2,wab)       &
  !$omp private(xi,yi,zi,xorigi,yorigi,zorigi,xminnew)            &
  !$omp private(ipix,jpix,kpix,ipixi,jpixi,kpixi,icell,isubmesh)  &
- !$omp private(ipixmin,ipixmax,jpixmin,jpixmax,kpixmin,kpixmax)
+ !$omp private(ipixmin,ipixmax,jpixmin,jpixmax,kpixmin,kpixmax)  &
+ !$omp private(iprogress,iprintnext,iprintinterval)
  !$omp single
  !$ print "(1x,a,i3,a)",'Using ',omp_get_num_threads(),' cpus'
  !$omp end single nowait
@@ -158,7 +160,7 @@ subroutine interpolate3D_amr(xyzh,weight,pmass,vxyzu,npart, &
     !
     !--report on progress
     !
-!$ if (.false.) then
+    !$ iprintprogress = .false.
     if (iprintprogress) then
        iprogress = nint(100.*i/npart)
        if (iprogress >= iprintnext) then
@@ -166,7 +168,6 @@ subroutine interpolate3D_amr(xyzh,weight,pmass,vxyzu,npart, &
           iprintnext = iprintnext + iprintinterval
        endif
     endif
-!$ endif
     !
     !--set kernel related quantities
     !

--- a/src/utils/moddump_radiotde.f90
+++ b/src/utils/moddump_radiotde.f90
@@ -209,11 +209,11 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  if (ignore_radius > 0) then
     npart_old = npart
     call delete_particles_inside_radius((/0.,0.,0./),ignore_radius,npart,npartoftype)
-    write(*,'(i10,1x,a23,1x,e8.2,1x,a14)') npart_old - npart, 'particles inside radius', ignore_radius*udist, 'cm are deleted'
+    write(*,'(i10,1x,a23,1x,es10.2,1x,a14)') npart_old - npart, 'particles inside radius', ignore_radius*udist, 'cm are deleted'
     npart_old = npart
     if (remove_overlap) then
        call delete_particles_outside_sphere((/0.,0.,0./),rad_min,npart)
-       write(*,'(i10,1x,a24,1x,e8.2,1x,a14)') npart_old - npart, 'particles outside radius', rad_min*udist, 'cm are deleted'
+       write(*,'(i10,1x,a24,1x,es10.2,1x,a14)') npart_old - npart, 'particles outside radius', rad_min*udist, 'cm are deleted'
        npart_old = npart
     endif
  else

--- a/src/utils/test_binary.f90
+++ b/src/utils/test_binary.f90
@@ -60,16 +60,16 @@ subroutine test_binary(m1,m2,a,e,inc,o,w,f,jfile,itex)
  utime = sqrt(udist**3/(gg*umass))
  period_yrs = period*utime/years
  if (itex /= 0) then ! write line to orbits.tex file
-    write(itex,"(6(g6.2,1x,'&',1x),f8.1,1x)") a,e,inc,o,w,f,period_yrs
+    write(itex,"(6(g9.2,1x,'&',1x),f8.1,1x)") a,e,inc,o,w,f,period_yrs
  endif
  ! write trajectory of orbit to file
  write(filename,"(a,i3.3,a)") 'orbit',jfile,'.out'
- print "(a,6(f6.2,1x))",'writing to '//trim(filename)//' aeiowf = ',a,e,inc,o,w,f
+ print "(a,6(f9.2,1x))",'writing to '//trim(filename)//' aeiowf = ',a,e,inc,o,w,f
  open(newunit=lu,file=filename,status='replace')
  write(lu,"('#',3(3x,a))") 'x','y','z'
  write(lu,*) xyz(1:3,2) - xyz(1:3,1)
 
- write(*,"(8(a,'=',1pg8.3,1x),a,'=',1pg8.3,1x)") 'a',a,'e',e,'i',inc,'o',o,'w',w,'f',f,'P',period_yrs,'m1',m1,' m2',m2
+ write(*,"(8(a,'=',1pg10.3,1x),a,'=',1pg10.3,1x)") 'a',a,'e',e,'i',inc,'o',o,'w',w,'f',f,'P',period_yrs,'m1',m1,' m2',m2
  !print*,'period = ',period
  call get_f(m1,m2,xyz,fxyz)
  tsep = 0.


### PR DESCRIPTION
Description:
The aim of this pull request is to allow the NOWARN=yes flag to also work with the ifort, ifx and flang compilers, so that for code to be merged onto master there must be no compiler warnings with *any* of the tested compilers

We must disable the unused dummy argument warning for this to work, which with ifort means turning off -warn unused. With ifort we use the following flag to convert warnings and remarks into errors:
```
-diag-error=warn,remark,vec,par,openmp
```

Components modified:
- [x] Setup (src/setup)
- [x] Main code (src/main)

Type of change:
- [x] Other (please describe)

removed compiler warnings with flang

Testing:
Checked that code compiles successfully using flang with NOWARN=yes (adding the -Werror flag) on Mac

Did you run the bots? yes

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? yes

Is there a unit test that could be added for this feature/bug? yes/no

If so, please describe what a unit test might check:
this will be automatically checked in the actions workflow since the buildbot already applies NOWARN=yes when running the build checks
