### PR TITLE
(Sinktree) Wrong fallback behaviour when sink are not in cache

### DIFF
--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -1266,7 +1266,7 @@ subroutine compute_forces(i,iamgasi,iamdusti,xpartveci,hi,hi1,hi21,hi41,gradhi,g
        yj = xyzcache(n,2)
        zj = xyzcache(n,3)
     else
-       if(iamsinkj) then
+       if (iamsinkj) then
           xj = xyzmh_ptmass(1,j-maxpsph)
           yj = xyzmh_ptmass(2,j-maxpsph)
           zj = xyzmh_ptmass(3,j-maxpsph)
@@ -1286,14 +1286,13 @@ subroutine compute_forces(i,iamgasi,iamdusti,xpartveci,hi,hi1,hi21,hi41,gradhi,g
 #endif
     rij2 = dx*dx + dy*dy + dz*dz
     q2i = rij2*hi21
-
-    !--hj is in the cell cache but not in the neighbour cache
-    !  as not accessed during the density summation
-    if (ifilledcellcache .and. n <= maxcellcache) then
-       hj1 = xyzcache(n,4)
+    if (iamsinkj) then
+       hj1 = 1./xyzmh_ptmass(ihsoft,j-maxpsph)
     else
-       if (iamsinkj) then
-          hj1 = 1./xyzmh_ptmass(ihsoft,j-maxpsph)
+       !--hj is in the cell cache but not in the neighbour cache
+       !  as not accessed during the density summation
+       if (ifilledcellcache .and. n <= maxcellcache) then
+          hj1 = xyzcache(n,4)
        else
           hj1 = 1./xyzh(4,j)
        endif

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -1266,9 +1266,15 @@ subroutine compute_forces(i,iamgasi,iamdusti,xpartveci,hi,hi1,hi21,hi41,gradhi,g
        yj = xyzcache(n,2)
        zj = xyzcache(n,3)
     else
-       xj = xyzh(1,j)
-       yj = xyzh(2,j)
-       zj = xyzh(3,j)
+       if(iamsinkj) then
+          xj = xyzmh_ptmass(1,j-maxpsph)
+          yj = xyzmh_ptmass(2,j-maxpsph)
+          zj = xyzmh_ptmass(3,j-maxpsph)
+       else
+          xj = xyzh(1,j)
+          yj = xyzh(2,j)
+          zj = xyzh(3,j)
+       endif
     endif
     dx = xi - xj
     dy = yi - yj
@@ -1280,13 +1286,14 @@ subroutine compute_forces(i,iamgasi,iamdusti,xpartveci,hi,hi1,hi21,hi41,gradhi,g
 #endif
     rij2 = dx*dx + dy*dy + dz*dz
     q2i = rij2*hi21
-    if (iamsinkj) then
-       hj1 = 1./xyzmh_ptmass(ihsoft,j-maxpsph)
+
+    !--hj is in the cell cache but not in the neighbour cache
+    !  as not accessed during the density summation
+    if (ifilledcellcache .and. n <= maxcellcache) then
+       hj1 = xyzcache(n,4)
     else
-       !--hj is in the cell cache but not in the neighbour cache
-       !  as not accessed during the density summation
-       if (ifilledcellcache .and. n <= maxcellcache) then
-          hj1 = xyzcache(n,4)
+       if (iamsinkj) then
+          hj1 = 1./xyzmh_ptmass(ihsoft,j-maxpsph)
        else
           hj1 = 1./xyzh(4,j)
        endif

--- a/src/main/part.F90
+++ b/src/main/part.F90
@@ -2100,7 +2100,7 @@ subroutine accrete_particles_outside_sphere(radius)
  ! accrete particles outside some outer radius
  !
  !$omp parallel default(none) &
- !$omp shared(npart,nptmass,xyzh,xyzmh_ptmass,radius) &
+ !$omp shared(npart,xyzh,radius) &
  !$omp private(i,r2)
  !$omp do
  do i=1,npart
@@ -2108,14 +2108,6 @@ subroutine accrete_particles_outside_sphere(radius)
     if (r2 > radius**2) xyzh(4,i) = -abs(xyzh(4,i))
  enddo
  !$omp enddo
-
- !$omp do
- do i=1,nptmass
-    r2 = xyzmh_ptmass(1,i)**2 + xyzmh_ptmass(2,i)**2 + xyzmh_ptmass(3,i)**2
-    if (r2 > radius**2) xyzmh_ptmass(4,i) = -abs(xyzmh_ptmass(4,i))
- enddo
-!$omp enddo
-
  !$omp end parallel
 
 end subroutine accrete_particles_outside_sphere


### PR DESCRIPTION
Description:
I discovered a wrong behaviour of the sinktree method while debugging #699.  If we had a cache miss, the fallback was on the wrong array (if the neighbour was a sink). Difficult to detect that with tests, as the number of parts is set to 1000 (same as the cache size) in most cases. 

Also removed the ptmass killing in 'accrete_particles_outside_sphere' as it had unexpected behaviour with the subgrouping module...

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Setup (src/setup)
- [x] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [ ] Documentation (docs/)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [x] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [ ] Other (please describe)

Did you run the bots? no

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? no

Is there a unit test that could be added for this feature/bug? yes

If so, please describe what a unit test might check:
We should increase the number of parts in testgrav 

