### PR TITLE
fixes on ptmass merge routines

### DIFF
--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -2216,7 +2216,8 @@ subroutine merge_sinks(time,nptmass,xyzmh_ptmass,pxyz_ptmass,fxyz_ptmass,fxyz_pt
              typ    = 'unconditionally'
           elseif (rr2 < r_merge_cond2) then
              Ekin = 0.5*( (pxi-pxj)**2 + (pyi-pyj)**2 + (pzi-pzj)**2 )
-             Epot = -mj/sqrt(rr2)
+             r = sqrt(rr2)
+             Epot = -mij/sqrt(rr2)
              if (Ekin + Epot < 0.) then
                 if (nint(xyzmh_ptmass(inseed,i))>0 .and. nint(xyzmh_ptmass(inseed,j))>0) then
                    call extract_a(r,mij,2.*Ekin,aij)

--- a/src/main/utils_dumpfiles.f90
+++ b/src/main/utils_dumpfiles.f90
@@ -1746,7 +1746,7 @@ subroutine write_array_int4arr(ib,iarr,my_tag,len1,len2,ikind,ipass,iunit,nums,n
  endif
  ! check if kind matches
  if (ikind==i_int4) then
-    !print*,ipass,' WRITING ',my_tag(istart:iend),' as ',i_int8
+    !print*,ipass,' WRITING ',my_tag(istart:iend),' as ',i_int4
     if (ipass==1) then
        nums(i_int4,ib) = nums(i_int4,ib) + (iend - istart) + 1
     elseif (ipass==2) then
@@ -2234,7 +2234,7 @@ subroutine read_array_int4arr(iarr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag
  integer(kind=4), allocatable :: dummyi4(:)
 
  if (matched) return
- match_datatype = (ikind==i_int8)
+ match_datatype = (ikind==i_int4)
 
  do j=1,min(size(iarr(:,1)),size(arr_tag))
     if (match_tag(tag,arr_tag(j)) .and. .not.matched) then
@@ -2247,7 +2247,7 @@ subroutine read_array_int4arr(iarr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag
           iarr(j,i1:i2) = dummyi4(:)
           deallocate(dummyi4)
        else
-          print*,'ERROR: wrong datatype for '//trim(tag)//' (is not int8)'
+          print*,'ERROR: wrong datatype for '//trim(tag)//' (is not int4)'
           read(iunit,iostat=ierr)
        endif
     endif

--- a/src/tests/test_ptmass.f90
+++ b/src/tests/test_ptmass.f90
@@ -1265,7 +1265,7 @@ subroutine test_createsink(ntests,npass)
        stest = nptmass < n_max
        call checkval(stest,.true.,nfailed(1),'nptmass< nseeds max')
        call checkval(starsmass-coremass,0.,6e-17,nfailed(4),'Mass conservation')
-       call checkval(ke/pe,0.5,5e-16,nfailed(5),'Virialised system')
+       call checkval(ke/pe,0.5,6.e-16,nfailed(5),'Virialised system')
        call checkval(rtest,.true.,nfailed(6),'rmax < h_acc')
     else
        call checkval(nptmass,1,0,nfailed(1),'nptmass=1')
@@ -1537,9 +1537,9 @@ subroutine test_merger(ntests,npass)
     endif
     if (itest==8) then
        if (gr) then
-          call checkval(nsinkF,65,0,nfailed(itest),'final number of sinks')
+          call checkval(nsinkF,54,0,nfailed(itest),'final number of sinks')
        else
-          call checkval(nsinkF,65,0,nfailed(itest),'final number of sinks')
+          call checkval(nsinkF,54,0,nfailed(itest),'final number of sinks')
        endif
     else
        call checkval(merged,merged_expected,nfailed(itest),'merger')

--- a/src/tests/test_ptmass.f90
+++ b/src/tests/test_ptmass.f90
@@ -492,7 +492,7 @@ subroutine test_binary(ntests,npass,string)
     case(2)
        tolen = 1.2e-3
        if (gravity) tolen = 3.1e-3
-       if (use_fourthorder) tolang = 2.5e-11
+       if (use_fourthorder) tolang = 3.e-11
     case default
        if (calc_gravitwaves .and. itest==1) then
           call checkvalbuf_end('grav. wave strain (x)',ncheckgw(1),nfailgw(1),errgw(1),tolgw)

--- a/src/tests/test_ptmass.f90
+++ b/src/tests/test_ptmass.f90
@@ -1537,9 +1537,9 @@ subroutine test_merger(ntests,npass)
     endif
     if (itest==8) then
        if (gr) then
-          call checkval(nsinkF,84,0,nfailed(itest),'final number of sinks')
+          call checkval(nsinkF,65,0,nfailed(itest),'final number of sinks')
        else
-          call checkval(nsinkF,41,0,nfailed(itest),'final number of sinks')
+          call checkval(nsinkF,65,0,nfailed(itest),'final number of sinks')
        endif
     else
        call checkval(merged,merged_expected,nfailed(itest),'merger')


### PR DESCRIPTION
Description:
There were mistakes made in `ptmass_merge_release` that have been fixed. I had corruption in the ptmass array in my sims due to an interference between the subgroup routines and `update_ptmass`, which is fixed now. This routine has also been parallelised. I spotted a typo in `read_array_int4arr`. Nothing dangerous, as it is not used in the code. 
Finally, I refined the conditional sink merging for `icreate_sinks==2`. I added a square root to `Epot` in this condition. Looks like it was forgotten for a while... (I corrected the tests accordingly)

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Setup (src/setup)
- [x] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [ ] Documentation (docs/)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [x] Bug fix
- [x] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [ ] Other (please describe)

Testing:
checked if ptmass tests were all green.

Did you run the bots? no

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? no

Is there a unit test that could be added for this feature/bug? no