### PR TITLE
NaN with subgroup and sinktree

### DIFF
--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -581,7 +581,13 @@ subroutine get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,phitot,dtsinksin
     enddo
     phitot = phitot + 0.5*pmassi*phii  ! total potential (G M_1 M_2/r)
 
-    if (use_regnbody) bin_info(ipert,i) = pert_out
+    if (use_regnbody) then
+       if (pert_out > 0.) then
+          bin_info(ipert,i) = pert_out
+       else ! could happen if only long ranges other than compi during a step.
+          bin_info(ipert,i) = bignumber ! pert to big number will give kappa < 0. -> kappa = 1.
+       endif
+    endif
 
     !
     !--apply external forces

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -581,13 +581,7 @@ subroutine get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,phitot,dtsinksin
     enddo
     phitot = phitot + 0.5*pmassi*phii  ! total potential (G M_1 M_2/r)
 
-    if (use_regnbody) then
-       if (pert_out > 0.) then
-          bin_info(ipert,i) = pert_out
-       else ! could happen if only long ranges other than compi during a step.
-          bin_info(ipert,i) = bignumber ! pert to big number will give kappa < 0. -> kappa = 1.
-       endif
-    endif
+    if (use_regnbody) bin_info(ipert,i) = pert_out
 
     !
     !--apply external forces

--- a/src/main/subgroup.f90
+++ b/src/main/subgroup.f90
@@ -1161,6 +1161,7 @@ subroutine get_kappa(xyzmh_ptmass,vxyz_ptmass,group_info,bin_info,gsize,s_id,e_i
  use part,         only:igarg,icomp,ipert,ikap,iapo,iecc,iorb,isemi,ipertg
  use utils_kepler, only:extract_a,extract_e
  use dim ,         only:use_sinktree
+ use io,           only:fatal
  real   , intent(in)    :: xyzmh_ptmass(:,:),vxyz_ptmass(:,:)
  real   , intent(inout) :: bin_info(:,:)
  integer, intent(in)    :: group_info(:,:)
@@ -1237,6 +1238,9 @@ subroutine get_kappa(xyzmh_ptmass,vxyz_ptmass,group_info,bin_info,gsize,s_id,e_i
 
        kappa_max = max(0.001*timescale/Ti,1.0)
        kappa     = kref/((rapo3/mui)*pouti)
+
+       if (isnan(kappa)) call fatal('get_kappa_bin','NaN in kappa value... perturbation to zero?',i=i,var="pert",val=pouti)
+
        kappa     = min(kappa_max,kappa)
        kappa     = max(1.0,kappa)
        bin_info(ikap,i)     = kappa
@@ -1338,6 +1342,7 @@ end subroutine get_force_TTL_bin
 subroutine get_kappa_bin(xyzmh_ptmass,bin_info,i,j)
  use part, only:ipert,iapo,ikap,isemi,iecc,ipertg
  use dim , only:use_sinktree
+ use io,   only:fatal
  real, intent(inout) :: bin_info(:,:)
  real, intent(in)    :: xyzmh_ptmass(:,:)
  integer, intent(in) :: i,j
@@ -1354,6 +1359,8 @@ subroutine get_kappa_bin(xyzmh_ptmass,bin_info,i,j)
  rapo = bin_info(iapo,i)
  rapo3 = rapo*rapo*rapo
  kappa = kref/((rapo3/mu)*pert)
+
+ if (isnan(kappa)) call fatal('get_kappa_bin','NaN in kappa value... perturbation to zero?',i=i,var="pert",val=pert)
 
  if (kappa > 1. .and. isellip) then
     bin_info(ikap,i) = kappa

--- a/src/main/subgroup.f90
+++ b/src/main/subgroup.f90
@@ -1356,19 +1356,20 @@ subroutine get_kappa_bin(xyzmh_ptmass,bin_info,i,j)
  mu = (m1*m2)/(m1+m2)
  pert = bin_info(ipert,i)
  if (use_sinktree) pert = pert + bin_info(ipertg,i)
- rapo = bin_info(iapo,i)
- rapo3 = rapo*rapo*rapo
- kappa = kref/((rapo3/mu)*pert)
-
- if (isnan(kappa)) call fatal('get_kappa_bin','NaN in kappa value... perturbation to zero?',i=i,var="pert",val=pert)
-
- if (kappa > 1. .and. isellip) then
-    bin_info(ikap,i) = kappa
-    bin_info(ikap,j) = kappa
+ if (pert > 0. .and. isellip) then ! pert == 0. if groups detected during substepping (SINKTREE=yes)
+    rapo = bin_info(iapo,i)
+    rapo3 = rapo*rapo*rapo
+    kappa = kref/((rapo3/mu)*pert)
+    if (kappa < 1.) kappa = 1.
  else
-    bin_info(ikap,i) = 1.
-    bin_info(ikap,j) = 1.
+    kappa = 1.
  endif
+
+ if (isnan(kappa)) call fatal('get_kappa_bin','NaN in kappa value...',i=i,var="pert",val=pert)
+
+ bin_info(ikap,i) = kappa
+ bin_info(ikap,j) = kappa
+
 
 end subroutine get_kappa_bin
 

--- a/src/main/substepping.F90
+++ b/src/main/substepping.F90
@@ -132,7 +132,7 @@ subroutine substep_gr(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,pxyz
  logical,         intent(in)    :: isionised(:)
  logical :: extf_vdep_flag,done,last_step,accreted
  integer :: force_count,nsubsteps
- real    :: timei,time_par,dt,dtgroup,t_end_step
+ real    :: timei,time_par,dt,t_end_step
  real    :: dtextforce_min
 !
 ! determine whether or not to use substepping
@@ -197,7 +197,6 @@ subroutine substep_gr(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,pxyz
        done = .true.
     else
        dt = dtextforce
-       dtgroup = dtextforce
        if (timei + dt > t_end_step) then
           dt = t_end_step - timei
           last_step = .true.
@@ -283,7 +282,7 @@ subroutine substep(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,fext, &
  logical,         intent(in)    :: isionised(:)
  logical :: extf_vdep_flag,done,last_step,accreted
  integer :: force_count,nsubsteps
- real    :: timei,time_par,dt,dtgroup,t_end_step
+ real    :: timei,time_par,dt,t_end_step
  real    :: dtextforce_min
 !
 ! determine whether or not to use substepping
@@ -354,7 +353,7 @@ subroutine substep(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,fext, &
 
        if (use_regnbody) then
           call group_identify(nptmass,n_group,n_ingroup,n_sing,xyzmh_ptmass,vxyz_ptmass,group_info,bin_info,nmatrix,&
-                              dtext=dtgroup)
+                              dtext=dt)
           call get_force(nptmass,npart,nsubsteps,ntypes,time_par,dtextforce,xyzh,vxyzu,fext,xyzmh_ptmass, &
                          vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,dt,dk(3),force_count,&
                          extf_vdep_flag,bin_info,group_info,nmatrix)
@@ -381,7 +380,6 @@ subroutine substep(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,fext, &
        done = .true.
     else
        dt = dtextforce
-       dtgroup = dtextforce
        if (timei + dt > t_end_step) then
           dt = t_end_step - timei
           last_step = .true.


### PR DESCRIPTION
Description:
I found a bug when subgroup and sinktree were used simultaneously. If a binary is formed during a substep, it is possible to find a perturbation equal to zero, which leads to kappa equal to NaN. This could happen if this binary has no short-range interactions when using sinktree. In that case, `get_sink_sink` will cycle every sink giving `pert == 0.`. As we are computing sink/gas interaction during the force routine, perturbation from the gas does not help either.
To patch that, I now check if the external perturbation is equal to zero. If so, I set kappa to 1 as a default value. The right value will then be adjusted during the next step, depending on the perturbation computed in `force.f90`.

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Setup (src/setup)
- [x] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [ ] Documentation (docs/)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [x] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [ ] Other (please describe)

Testing:
test_ptmass works fine

Did you run the bots? no

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? yes

Is there a unit test that could be added for this feature/bug? no

