### PR TITLE
Threadprivate array allocation during neighbour finding when OPENMP=yes

### DIFF
--- a/src/utils/utils_getneighbours.F90
+++ b/src/utils/utils_getneighbours.F90
@@ -62,9 +62,6 @@ subroutine generate_neighbour_lists(xyzh,vxyzu,npart,dumpfile,write_neighbour_li
  !$omp threadprivate(xyzcache,listneigh)
  character(len=100) :: neighbourfile
 
- if (.not.allocated(listneigh)) allocate(listneigh(maxp))
- if (.not.allocated(xyzcache)) allocate(xyzcache(maxcellcache,4))
-
  !****************************************
  ! 1. Build kdtree and linklist
  ! --> global (shared) neighbour lists for all particles in tree cell
@@ -101,6 +98,12 @@ subroutine generate_neighbour_lists(xyzh,vxyzu,npart,dumpfile,write_neighbour_li
  !$omp private(nneigh,ineigh_all,rneigh_all) &
  !$omp private(hi1,hi21,hj1,hj21,rij2,q2i,q2j) &
  !$omp private(dx,dy,dz)
+
+ ! Allocate threadprivate arrays within parallel region
+ ! to ensure each thread gets allocated copy
+ if (.not.allocated(listneigh)) allocate(listneigh(maxp))
+ if (.not.allocated(xyzcache)) allocate(xyzcache(maxcellcache,4))
+
  !$omp do schedule(runtime)
  over_cells: do icell=1,int(ncells)
 


### PR DESCRIPTION
Description:
When I compiled phantomanalysis with OPENMP=yes and ran the analysis file, there was a segfault during neighbour finding. With OPENMP=no, things worked OK. I edited utils_getneighbours.F90 to allocate threadprivate arrays within parallel region instead of current way, which seems to have worked. Not sure if it's an adequate fix but I thought I'd offer it up!

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Setup (src/setup)
- [ ] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [X] Analysis utilities (src/utils/analysis)
- [ ] Documentation (docs/)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [X] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [ ] Other (please describe)

Testing:
<!-- Describe how you have tested the change -->

Did you run the bots? no

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? yes

Is there a unit test that could be added for this feature/bug? don't know

If so, please describe what a unit test might check:
-
