### PR TITLE
Refactor accretion checks

### DIFF
--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -846,15 +846,15 @@ end function ptmass_not_obscured
 !  compare with previous candidate if necessary...
 !+
 !----------------------------------------------------------------
-subroutine ptmass_check_acc(i,icand,itypei,nptmass,epartprev,ibin_wakei,accreted,xi,yi,zi,hi,&
+subroutine ptmass_check_acc(i,icand,itypei,nptmass,epartprev,ibin_wakei,nbinmax,accreted,xi,yi,zi,hi,&
                             pxi,pyi,pzi,xyzmh_ptmass,pxyz_ptmass,facc,time,ifail)
  use part,         only:ihacc,itbirth,ndptmass,nvel_ptmass
  use kernel,       only:radkern2
  use io,           only:iprint,iverbose,fatal
- use timestep_ind, only:nbinmax
  integer,           intent(in)    :: i,nptmass,itypei
  integer,           intent(inout) :: icand
  integer(kind=1),   intent(inout) :: ibin_wakei
+ integer(kind=1),   intent(in)    :: nbinmax
  logical,           intent(inout) :: accreted
  real,              intent(in)    :: xi,yi,zi,hi,pxi,pyi,pzi,facc,time
  real,              intent(in)    :: xyzmh_ptmass(nsinkproperties,nptmass)
@@ -1005,11 +1005,13 @@ subroutine ptmass_accrete(is,nptmass,xi,yi,zi,hi,pxi,pyi,pzi,fxi,fyi,fzi, &
  ! check if the gas particle should be accreted on sink i
  !
  do i=is,nptmass
-    call ptmass_check_acc(i,icand,itypei,nptmass,epartprev,ibin_wakei,accreted,&
-                             xi,yi,zi,hi,pxi,pyi,pzi,xyzmh_ptmass,pxyz_ptmass,facc,&
-                             time,ifail)
+    call ptmass_check_acc(i,icand,itypei,nptmass,epartprev,ibin_wakei,nbinmax,accreted,&
+                          xi,yi,zi,hi,pxi,pyi,pzi,xyzmh_ptmass,pxyz_ptmass,facc,&
+                          time,ifail)
     if (ifail == 5 .or. ifail == -1) exit
  enddo
+
+ if (present(nfaili)) nfaili = ifail
 
 !
 ! if accreted==true, then checks all passed => accrete particle

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -63,6 +63,7 @@ module ptmass
  public :: ptmass_boundary_crossing
  public :: set_integration_precision
  public :: get_pressure_on_sinks
+ public :: ptmass_check_acc
 
  ! settings affecting routines in module (read from/written to input file)
  integer, public :: icreate_sinks = 0 ! 1-standard sink creation scheme 2-Star formation scheme using core prescription
@@ -838,6 +839,119 @@ logical function ptmass_not_obscured(xj,yj,zj,xsink,ysink,zsink,r_sink)
  endif
  !
 end function ptmass_not_obscured
+
+!----------------------------------------------------------------
+!+
+!  check if a particle should be accreted on a point mass and
+!  compare with previous candidate if necessary...
+!+
+!----------------------------------------------------------------
+subroutine ptmass_check_acc(i,icand,itypei,nptmass,epartprev,ibin_wakei,accreted,xi,yi,zi,hi,&
+                            pxi,pyi,pzi,xyzmh_ptmass,pxyz_ptmass,facc,time,ifail)
+ use part,         only:ihacc,itbirth,ndptmass,nvel_ptmass
+ use kernel,       only:radkern2
+ use io,           only:iprint,iverbose,fatal
+ use timestep_ind, only:nbinmax
+ integer,           intent(in)    :: i,nptmass,itypei
+ integer,           intent(inout) :: icand
+ integer(kind=1),   intent(inout) :: ibin_wakei
+ logical,           intent(inout) :: accreted
+ real,              intent(in)    :: xi,yi,zi,hi,pxi,pyi,pzi,facc,time
+ real,              intent(in)    :: xyzmh_ptmass(nsinkproperties,nptmass)
+ real,              intent(in)    :: pxyz_ptmass(nvel_ptmass,nptmass)
+ real,              intent(inout) :: epartprev
+ integer,           intent(inout) :: ifail
+ real                   :: mpt,tbirthi,drdv,angmom2,angmomh2,epart
+ real                   :: dx,dy,dz,r2,dvx,dvy,dvz,v2,hacc
+ logical, parameter     :: iofailreason=.false.
+
+
+ !
+ ! Verify particle is 'accretable'
+ !
+ if (.not. is_accretable(itypei) ) then
+    ifail = 5
+    if (iverbose >= 1 .and. iofailreason) &
+       write(iprint,"(/,a)") 'ptmass_accrete: FAILED: particle is not an accretable type'
+    return
+ endif
+
+ hacc = xyzmh_ptmass(ihacc,i)
+ mpt  = xyzmh_ptmass(4,i)
+ tbirthi  = xyzmh_ptmass(itbirth,i)
+ if (mpt < 0.) return
+ if (icreate_sinks==2) then
+    if (hacc < h_acc ) return
+    if (tbirthi + tmax_acc < time) return
+ endif
+ dx = xi - xyzmh_ptmass(1,i)
+ dy = yi - xyzmh_ptmass(2,i)
+ dz = zi - xyzmh_ptmass(3,i)
+ r2 = dx*dx + dy*dy + dz*dz
+ if (r2 < (facc*hacc)**2) then
+    icand = i
+    epartprev = -huge(epartprev) ! will avoid any other conditionnal accretion to override this one !
+    accreted  = .true.
+    ifail     = -1
+ elseif (r2 < hacc**2) then
+    ibin_wakei = nbinmax
+    dvx = pxi - pxyz_ptmass(1,i)
+    dvy = pyi - pxyz_ptmass(2,i)
+    dvz = pzi - pxyz_ptmass(3,i)
+    v2 = dvx*dvx + dvy*dvy + dvz*dvz
+    drdv = dx*dvx + dy*dvy + dz*dvz
+    epart = 0.5*v2 - mpt/sqrt(r2)
+    ! check if bound
+    if (epart < 0.) then
+       ! check to ensure it is most bound to this particle
+       if ( epart < epartprev ) then
+          epartprev = epart ! you're the most bound
+          ! compare specific angular momentum
+          angmom2  = r2*v2 - drdv*drdv
+          angmomh2 = mpt*hacc
+          if (angmom2 < angmomh2) then
+             icand     = i
+             accreted  = .true.
+             ifail     = -2
+          else
+             icand     = 0 ! if most bound but not accretable, no candidate validate
+             accreted = .false.
+             ifail = 2
+          endif
+       else
+          ifail = 4
+       endif
+    else
+       ifail = 3
+    endif
+ else
+    ifail = 1
+    if (r2 < radkern2*hi*hi) ibin_wakei = nbinmax
+ endif
+ if (iverbose >= 1 .and. iofailreason) then
+    !--Forced off since output will be unreasonably large
+    select case(ifail)
+    case(4)
+       write(iprint,"(/,a)") 'ptmass_accrete: FAILED: particle is not most bound to this sink'
+    case(3)
+       write(iprint,"(/,a,Es9.2)") 'ptmass_accrete: FAILED: particle is not bound: e = ',epart
+    case(2)
+       write(iprint,"(/,a,Es9.2,a,Es9.2)") 'ptmass_accrete: FAILED: angular momentum is too large: ' &
+                                              ,angmom2,' > ',angmomh2
+    case(1)
+       write(iprint,"(/,a)") 'ptmass_accrete: FAILED: r2 > hacc**2'
+    case(-1)
+       write(iprint,"(/,a)") 'ptmass_accrete: PASSED indiscriminately: particle will be accreted'
+    case(-2)
+       write(iprint,"(/,a)") 'ptmass_accrete: PASSED: particle will be accreted'
+    case default
+       write(iprint,"(/,a)") 'ptmass_accrete: FAILED: unknown reason'
+    end select
+ endif
+
+
+end subroutine ptmass_check_acc
+
 !----------------------------------------------------------------
 !+
 !  accrete particles onto point masses
@@ -866,11 +980,7 @@ end function ptmass_not_obscured
 subroutine ptmass_accrete(is,nptmass,xi,yi,zi,hi,pxi,pyi,pzi,fxi,fyi,fzi, &
                           itypei,pmassi,xyzmh_ptmass,pxyz_ptmass,accreted, &
                           dptmass,time,facc,nbinmax,ibin_wakei,nfaili)
-
-!$ use omputils, only:ipart_omp_lock
- use part,       only:ihacc,itbirth,ndptmass,nvel_ptmass
- use kernel,     only:radkern2
- use io,         only:iprint,iverbose,fatal
+ use part,       only:nvel_ptmass,ndptmass
  use io_summary, only:iosum_ptmass,maxisink,print_acc
  integer,           intent(in)    :: is,nptmass,itypei
  real,              intent(in)    :: xi,yi,zi,pmassi,pxi,pyi,pzi,fxi,fyi,fzi,time,facc
@@ -882,161 +992,65 @@ subroutine ptmass_accrete(is,nptmass,xi,yi,zi,hi,pxi,pyi,pzi,fxi,fyi,fzi, &
  integer(kind=1),   intent(in)    :: nbinmax
  integer(kind=1),   intent(inout) :: ibin_wakei
  integer, optional, intent(out)   :: nfaili
- integer            :: i,ifail
- real               :: dx,dy,dz,r2,dvx,dvy,dvz,v2,hacc
- logical, parameter :: iofailreason=.false.
- integer            :: j
- real               :: mpt,tbirthi,drdv,angmom2,angmomh2,epart,dxj,dyj,dzj,dvxj,dvyj,dvzj,rj2,vj2,epartj
- logical            :: mostbound
-!$ external         :: omp_set_lock,omp_unset_lock
+ real                   :: epartprev
+ integer                :: ifail,i,icand
 
- accreted = .false.
- ifail    = 0
+
+
+ accreted  = .false.
+ ifail     = 0
+ icand     = 0
+ epartprev = huge(epartprev)
  !
- ! Verify particle is 'accretable'
- if (.not. is_accretable(itypei) ) then
-    if (present(nfaili)) nfaili = 5
-    if (iverbose >= 1 .and. iofailreason) &
-       write(iprint,"(/,a)") 'ptmass_accrete: FAILED: particle is not an accretable type'
-    return
- endif
+ ! check if the gas particle should be accreted on sink i
  !
- sinkloop : do i=is,nptmass
-    hacc = xyzmh_ptmass(ihacc,i)
-    mpt  = xyzmh_ptmass(4,i)
-    tbirthi  = xyzmh_ptmass(itbirth,i)
-    if (mpt < 0.) cycle
-    if (icreate_sinks==2) then
-       if (hacc < h_acc ) cycle
-       if (tbirthi + tmax_acc < time) cycle
-    endif
-    dx = xi - xyzmh_ptmass(1,i)
-    dy = yi - xyzmh_ptmass(2,i)
-    dz = zi - xyzmh_ptmass(3,i)
-    r2 = dx*dx + dy*dy + dz*dz
-    dvx = pxi - pxyz_ptmass(1,i)
-    dvy = pyi - pxyz_ptmass(2,i)
-    dvz = pzi - pxyz_ptmass(3,i)
-    v2 = dvx*dvx + dvy*dvy + dvz*dvz
-!
-!  See if particle passes conditions to be accreted
-!
-    if (r2 < (facc*hacc)**2) then
-       ! accrete indiscriminately
-       accreted = .true.
-       ifail    = -1
-    elseif (r2 < hacc**2) then
-       ibin_wakei = nbinmax
-       drdv = dx*dvx + dy*dvy + dz*dvz
-       ! compare specific angular momentum
-       angmom2  = r2*v2 - drdv*drdv
-       angmomh2 = mpt*hacc
-       if (angmom2 < angmomh2) then
-          ! check if bound
-          epart = 0.5*v2 - mpt/sqrt(r2)
-          if (epart < 0.) then
-             ! check to ensure it is most bound to this particle
-             mostbound = .true.
-             j = 1
-             do while (mostbound .and. j <= nptmass)
-                if (j /= i) then
-                   dxj    = xi - xyzmh_ptmass(1,j)
-                   dyj    = yi - xyzmh_ptmass(2,j)
-                   dzj    = zi - xyzmh_ptmass(3,j)
-                   rj2    = dxj*dxj + dyj*dyj + dzj*dzj
-                   dvxj   = pxi - pxyz_ptmass(1,j)
-                   dvyj   = pyi - pxyz_ptmass(2,j)
-                   dvzj   = pzi - pxyz_ptmass(3,j)
-                   vj2    = dvxj*dvxj + dvyj*dvyj + dvzj*dvzj
-                   epartj = 0.5*vj2 - xyzmh_ptmass(4,j)/sqrt(rj2)
-                   if (epartj < epart) mostbound = .false.
-                endif
-                j = j + 1
-             enddo
-             if ( mostbound ) then
-                accreted = .true.
-                ifail = -2
-             else
-                ifail = 4
-             endif
-          else
-             ifail = 3
-          endif
-       else
-          ifail = 2
-       endif
-    else
-       ifail = 1
-       if (r2 < radkern2*hi*hi) ibin_wakei = nbinmax
-    endif
-    if (iverbose >= 1 .and. iofailreason) then
-       !--Forced off since output will be unreasonably large
-       select case(ifail)
-       case(4)
-          write(iprint,"(/,a)") 'ptmass_accrete: FAILED: particle is not most bound to this sink'
-       case(3)
-          write(iprint,"(/,a,Es9.2)") 'ptmass_accrete: FAILED: particle is not bound: e = ',epart
-       case(2)
-          write(iprint,"(/,a,Es9.2,a,Es9.2)") 'ptmass_accrete: FAILED: angular momentum is too large: ' &
-                                              ,angmom2,' > ',angmomh2
-       case(1)
-          write(iprint,"(/,a)") 'ptmass_accrete: FAILED: r2 > hacc**2'
-       case(-1)
-          write(iprint,"(/,a)") 'ptmass_accrete: PASSED indiscriminately: particle will be accreted'
-       case(-2)
-          write(iprint,"(/,a)") 'ptmass_accrete: PASSED: particle will be accreted'
-       case default
-          write(iprint,"(/,a)") 'ptmass_accrete: FAILED: unknown reason'
-       end select
-    endif
-    if (present(nfaili)) nfaili = ifail
+ do i=is,nptmass
+    call ptmass_check_acc(i,icand,itypei,nptmass,epartprev,ibin_wakei,accreted,&
+                             xi,yi,zi,hi,pxi,pyi,pzi,xyzmh_ptmass,pxyz_ptmass,facc,&
+                             time,ifail)
+    if (ifail == 5 .or. ifail == -1) exit
+ enddo
+
 !
 ! if accreted==true, then checks all passed => accrete particle
 !
-    if ( accreted ) then
-!$     call omp_set_lock(ipart_omp_lock(i))
-
+ if ( accreted ) then
 ! Set new position for the sink particles
-       dptmass(idxmsi,i) = dptmass(idxmsi,i) + xi*pmassi
-       dptmass(idymsi,i) = dptmass(idymsi,i) + yi*pmassi
-       dptmass(idzmsi,i) = dptmass(idzmsi,i) + zi*pmassi
+    dptmass(idxmsi,icand) = dptmass(idxmsi,icand) + xi*pmassi
+    dptmass(idymsi,icand) = dptmass(idymsi,icand) + yi*pmassi
+    dptmass(idzmsi,icand) = dptmass(idzmsi,icand) + zi*pmassi
 
 ! Set new mass and increment accreted mass
-       dptmass(idmsi,i) = dptmass(idmsi,i) + pmassi
+    dptmass(idmsi,icand) = dptmass(idmsi,icand) + pmassi
 
 ! Set new spin angular momentum; this component is the angular momentum
 ! of the accreted particles about the origin
-       dptmass(idspinxsi,i) = dptmass(idspinxsi,i) + pmassi*(yi*pzi - zi*pyi)
-       dptmass(idspinysi,i) = dptmass(idspinysi,i) + pmassi*(zi*pxi - xi*pzi)
-       dptmass(idspinzsi,i) = dptmass(idspinzsi,i) + pmassi*(xi*pyi - yi*pxi)
+    dptmass(idspinxsi,icand) = dptmass(idspinxsi,icand) + pmassi*(yi*pzi - zi*pyi)
+    dptmass(idspinysi,icand) = dptmass(idspinysi,icand) + pmassi*(zi*pxi - xi*pzi)
+    dptmass(idspinzsi,icand) = dptmass(idspinzsi,icand) + pmassi*(xi*pyi - yi*pxi)
 
 ! Set new velocities/specific momenta for the sink particles
-       dptmass(idvxmsi,i) = dptmass(idvxmsi,i) + pxi*pmassi
-       dptmass(idvymsi,i) = dptmass(idvymsi,i) + pyi*pmassi
-       dptmass(idvzmsi,i) = dptmass(idvzmsi,i) + pzi*pmassi
+    dptmass(idvxmsi,icand) = dptmass(idvxmsi,icand) + pxi*pmassi
+    dptmass(idvymsi,icand) = dptmass(idvymsi,icand) + pyi*pmassi
+    dptmass(idvzmsi,icand) = dptmass(idvzmsi,icand) + pzi*pmassi
 
 ! Set new accelerations for the sink particles
-       dptmass(idfxmsi,i) = dptmass(idfxmsi,i) + fxi*pmassi
-       dptmass(idfymsi,i) = dptmass(idfymsi,i) + fyi*pmassi
-       dptmass(idfzmsi,i) = dptmass(idfzmsi,i) + fzi*pmassi
+    dptmass(idfxmsi,icand) = dptmass(idfxmsi,icand) + fxi*pmassi
+    dptmass(idfymsi,icand) = dptmass(idfymsi,icand) + fyi*pmassi
+    dptmass(idfzmsi,icand) = dptmass(idfzmsi,icand) + fzi*pmassi
 
 ! Track values for summary
-       print_acc = .true.
-       if (nptmass > maxisink) then
-          iosum_ptmass(1,1) = iosum_ptmass(1,1) + 1
-          if (ifail == -1) iosum_ptmass(2,1) = iosum_ptmass(2,1) + 1
-       else
-          iosum_ptmass(1,i) = iosum_ptmass(1,i) + 1
-          if (ifail == -1) iosum_ptmass(2,i) = iosum_ptmass(2,i) + 1
-       endif
-
-!$     call omp_unset_lock(ipart_omp_lock(i))
-       hi = -abs(hi)
-
-! avoid possibility that two sink particles try to accrete the same gas particle by exiting the loop
-       exit sinkloop
+    print_acc = .true.
+    if (nptmass > maxisink) then
+       iosum_ptmass(1,1) = iosum_ptmass(1,1) + 1
+       if (ifail == -1) iosum_ptmass(2,1) = iosum_ptmass(2,1) + 1
+    else
+       iosum_ptmass(1,icand) = iosum_ptmass(1,icand) + 1
+       if (ifail == -1) iosum_ptmass(2,icand) = iosum_ptmass(2,icand) + 1
     endif
- enddo sinkloop
+
+    hi = -abs(hi)
+ endif
 
 end subroutine ptmass_accrete
 
@@ -1673,8 +1687,8 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,pxyzu,fxyzu,fext,divcurlv,pote
        fxj = fxyzu(1,j) + fext(1,j)
        fyj = fxyzu(2,j) + fext(2,j)
        fzj = fxyzu(3,j) + fext(3,j)
-       call ptmass_accrete(new_nptmass,new_nptmass,xyzh(1,j),xyzh(2,j),xyzh(3,j),xyzh(4,j),&
-                           pxyzu(1,j),pxyzu(2,j),pxyzu(3,j),fxj,fyj,fzj, &
+       call ptmass_accrete(new_nptmass,new_nptmass,xyzh(1,j),xyzh(2,j),xyzh(3,j),&
+                           xyzh(4,j),pxyzu(1,j),pxyzu(2,j),pxyzu(3,j),fxj,fyj,fzj,&
                            itypej,pmassj,xyzmh_ptmass,pxyzu_ptmass,accreted, &
                            dptmass,time,f_acc_local,ibin_wakei,ibin_wakei)
 

--- a/src/main/substepping.F90
+++ b/src/main/substepping.F90
@@ -180,8 +180,13 @@ subroutine substep_gr(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,pxyz
     ! here we use the same kick routine as Newtonian, but pass in pxyzu instead of vxyzu
     ! this ensures that accretion is done in a conservative way
     call kick(dk(2),dt,npart,nptmass,ntypes,xyzh,pxyzu,xyzmh_ptmass,pxyzu_ptmass,fext, &
-              fxyz_ptmass,dsdt_ptmass,dptmass,ibin_wake,nbinmax,timei, &
-              fxyz_ptmass_sinksink,accreted)
+              fxyz_ptmass,dsdt_ptmass)
+
+    ! test accretion after sync of all parts
+    call accretion(npart,nptmass,ntypes,xyzh,pxyzu,xyzmh_ptmass,pxyzu_ptmass,fext, &
+                   fxyz_ptmass,dsdt_ptmass,dptmass,ibin_wake,nbinmax,timei, &
+                   fxyz_ptmass_sinksink,accreted)
+
     if (accreted) then
        ! cons2prim call needed here
        call get_force(nptmass,npart,nsubsteps,ntypes,time_par,dtextforce,xyzh,vxyzu,fext,xyzmh_ptmass, &
@@ -282,7 +287,7 @@ subroutine substep(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,fext, &
  integer(kind=1), intent(inout) :: ibin_wake(:),nmatrix(nptmass,nptmass)
  logical,         intent(in)    :: isionised(:)
  logical :: extf_vdep_flag,done,last_step,accreted
- integer :: force_count,nsubsteps
+ integer :: force_count,nsubsteps,ikicklast
  real    :: timei,time_par,dt,dtgroup,t_end_step
  real    :: dtextforce_min
 !
@@ -318,7 +323,7 @@ subroutine substep(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,fext, &
 ! Main integration scheme
 !
     call kick(dk(1),dt,npart,nptmass,ntypes,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass, &
-              fext,fxyz_ptmass,dsdt_ptmass,dptmass)
+              fext,fxyz_ptmass,dsdt_ptmass)
 
     call drift(ck(1),dt,time_par,npart,nptmass,ntypes,xyzh,xyzmh_ptmass,&
                vxyzu,vxyz_ptmass,fxyz_ptmass,gtgrad,n_group,n_ingroup,&
@@ -327,7 +332,6 @@ subroutine substep(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,fext, &
     call get_force(nptmass,npart,nsubsteps,ntypes,time_par,dtextforce,xyzh,vxyzu,fext,xyzmh_ptmass, &
                    vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,dt,dk(2),force_count,&
                    extf_vdep_flag,bin_info,group_info,nmatrix,isionised=isionised)
-
     if (use_fourthorder) then !! FSI 4th order scheme
 
        ! FSI extrapolation method (Omelyan 2006)
@@ -336,7 +340,7 @@ subroutine substep(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,fext, &
                       extf_vdep_flag,bin_info,group_info,nmatrix,fsink_old)
 
        call kick(dk(2),dt,npart,nptmass,ntypes,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
-                 fext,fxyz_ptmass,dsdt_ptmass,dptmass)
+                 fext,fxyz_ptmass,dsdt_ptmass)
 
        call drift(ck(2),dt,time_par,npart,nptmass,ntypes,xyzh,xyzmh_ptmass,&
                   vxyzu,vxyz_ptmass,fxyz_ptmass,gtgrad,n_group,n_ingroup,&
@@ -346,33 +350,31 @@ subroutine substep(npart,ntypes,nptmass,dtsph,dtextforce,time,xyzh,vxyzu,fext, &
                       vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,dt,dk(3),force_count,&
                       extf_vdep_flag,bin_info,group_info,nmatrix,isionised=isionised)
 
-       ! the last kick phase of the scheme will perform the accretion loop after velocity update
-
-       call kick(dk(3),dt,npart,nptmass,ntypes,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,fext, &
-                 fxyz_ptmass,dsdt_ptmass,dptmass,ibin_wake,nbinmax,timei, &
-                 fxyz_ptmass_sinksink,accreted)
-
-       if (use_regnbody) then
-          call group_identify(nptmass,n_group,n_ingroup,n_sing,xyzmh_ptmass,vxyz_ptmass,group_info,bin_info,nmatrix,&
-                              dtext=dtgroup)
-          call get_force(nptmass,npart,nsubsteps,ntypes,time_par,dtextforce,xyzh,vxyzu,fext,xyzmh_ptmass, &
-                         vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,dt,dk(3),force_count,&
-                         extf_vdep_flag,bin_info,group_info,nmatrix)
-       elseif (accreted) then
-          call get_force(nptmass,npart,nsubsteps,ntypes,time_par,dtextforce,xyzh,vxyzu,fext,xyzmh_ptmass, &
-                         vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,dt,dk(3),force_count,&
-                         extf_vdep_flag,bin_info,group_info,nmatrix)
-       endif
+       call kick(dk(3),dt,npart,nptmass,ntypes,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
+                 fext,fxyz_ptmass,dsdt_ptmass)
+       ikicklast = 3
     else  !! standard leapfrog scheme
-       ! the last kick phase of the scheme will perform the accretion loop after velocity update
-       call kick(dk(2),dt,npart,nptmass,ntypes,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,fext, &
-                fxyz_ptmass,dsdt_ptmass,dptmass,ibin_wake,nbinmax,timei, &
-                fxyz_ptmass_sinksink,accreted)
-       if (accreted) then
-          call get_force(nptmass,npart,nsubsteps,ntypes,time_par,dtextforce,xyzh,vxyzu,fext,xyzmh_ptmass, &
-                         vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,dt,dk(2),force_count,&
-                         extf_vdep_flag,bin_info,group_info,nmatrix)
-       endif
+       call kick(dk(2),dt,npart,nptmass,ntypes,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,&
+                 fext,fxyz_ptmass,dsdt_ptmass)
+       ikicklast = 2
+    endif
+
+    ! test accretion after sync of all parts
+    call accretion(npart,nptmass,ntypes,xyzh,vxyzu,xyzmh_ptmass,vxyz_ptmass,fext, &
+                      fxyz_ptmass,dsdt_ptmass,dptmass,ibin_wake,nbinmax,timei, &
+                      fxyz_ptmass_sinksink,accreted)
+
+    if (use_regnbody) then ! identify groups after all changes in position
+       call group_identify(nptmass,n_group,n_ingroup,n_sing,xyzmh_ptmass,&
+                           vxyz_ptmass,group_info,bin_info,nmatrix,&
+                           dtext=dtgroup)
+       accreted = .true.
+    endif
+
+    if (accreted) then ! if parts accreted then need to recompute force to conserve angular momentum
+       call get_force(nptmass,npart,nsubsteps,ntypes,time_par,dtextforce,xyzh,vxyzu,fext,xyzmh_ptmass, &
+                      vxyz_ptmass,fxyz_ptmass,fxyz_ptmass_tree,dsdt_ptmass,dt,dk(ikicklast),force_count,&
+                      extf_vdep_flag,bin_info,group_info,nmatrix)
     endif
 
     dtextforce_min = min(dtextforce_min,dtextforce)
@@ -471,8 +473,66 @@ end subroutine drift
  !----------------------------------------------------------------
 
 subroutine kick(dki,dt,npart,nptmass,ntypes,xyzh,pxyzu,xyzmh_ptmass,pxyz_ptmass, &
-                fext,fxyz_ptmass,dsdt_ptmass,dptmass,ibin_wake, &
-                nbinmax,timei,fxyz_ptmass_sinksink,accreted)
+                fext,fxyz_ptmass,dsdt_ptmass)
+ use part,           only:isdead_or_accreted,iamtype,iamboundary,iphase,ispinx,ispiny,ispinz,igas,ndptmass
+ use ptmass,         only:ptmass_kick
+ use io,             only:id,master
+ use mpiutils,       only:bcast_mpi,reduce_in_place_mpi,reduceall_mpi
+ use dim,            only:maxp,maxphase,use_apr
+ real,                      intent(in)    :: dt,dki
+ integer,                   intent(in)    :: npart,nptmass,ntypes
+ real,                      intent(inout) :: xyzh(:,:)
+ real,                      intent(inout) :: pxyzu(:,:),fext(:,:)
+ real,                      intent(inout) :: xyzmh_ptmass(:,:),pxyz_ptmass(:,:),fxyz_ptmass(:,:),dsdt_ptmass(:,:)
+ integer         :: i,itype
+ real            :: dkdt
+
+ itype = igas
+ dkdt = dki*dt
+ !
+ ! Kick sink particles
+ !
+ if (nptmass > 0) then
+    if (id==master) then
+       call ptmass_kick(nptmass,dkdt,pxyz_ptmass,fxyz_ptmass,xyzmh_ptmass,dsdt_ptmass)
+    endif
+    call bcast_mpi(pxyz_ptmass(:,1:nptmass))
+    call bcast_mpi(xyzmh_ptmass(ispinx,1:nptmass))
+    call bcast_mpi(xyzmh_ptmass(ispiny,1:nptmass))
+    call bcast_mpi(xyzmh_ptmass(ispinz,1:nptmass))
+ endif
+ !
+ ! Kick gas particles
+ !
+ !$omp parallel do default(none) &
+ !$omp shared(maxp,maxphase) &
+ !$omp shared(iphase,ntypes) &
+ !$omp shared(npart,fext,xyzh,pxyzu,dkdt) &
+ !$omp firstprivate(itype) &
+ !$omp private(i)
+ do i=1,npart
+    if (.not.isdead_or_accreted(xyzh(4,i))) then
+       if (ntypes > 1 .and. maxphase==maxp) then
+          itype = iamtype(iphase(i))
+          if (iamboundary(itype)) cycle
+       endif
+       pxyzu(1,i) = pxyzu(1,i) + dkdt*fext(1,i)
+       pxyzu(2,i) = pxyzu(2,i) + dkdt*fext(2,i)
+       pxyzu(3,i) = pxyzu(3,i) + dkdt*fext(3,i)
+    endif
+ enddo
+ !$omp end parallel do
+
+end subroutine kick
+
+ !----------------------------------------------------------------
+ !+
+ !  Accretion routine interface, checks and accounts accreted particles
+ !+
+ !----------------------------------------------------------------
+subroutine accretion(npart,nptmass,ntypes,xyzh,pxyzu,xyzmh_ptmass,pxyz_ptmass,&
+                     fext,fxyz_ptmass,dsdt_ptmass,dptmass,ibin_wake,&
+                     nbinmax,timei,fxyz_ptmass_sinksink,accreted)
  use part,           only:isdead_or_accreted,massoftype,iamtype,iamboundary,iphase,ispinx,ispiny,ispinz,igas,ndptmass
  use part,           only:apr_level,aprmassoftype
  use ptmass,         only:f_acc,ptmass_accrete,pt_write_sinkev,update_ptmass,ptmass_kick
@@ -484,7 +544,6 @@ subroutine kick(dki,dt,npart,nptmass,ntypes,xyzh,pxyzu,xyzmh_ptmass,pxyz_ptmass,
  use dim,            only:ind_timesteps,maxp,maxphase,use_apr
  use timestep_sts,   only:sts_it_n
  use timing,         only:get_timings,increment_timer,itimer_acc
- real,                      intent(in)    :: dt,dki
  integer,                   intent(in)    :: npart,nptmass,ntypes
  real,                      intent(inout) :: xyzh(:,:)
  real,                      intent(inout) :: pxyzu(:,:),fext(:,:)
@@ -497,169 +556,122 @@ subroutine kick(dki,dt,npart,nptmass,ntypes,xyzh,pxyzu,xyzmh_ptmass,pxyz_ptmass,
  logical        , optional, intent(inout) :: accreted
  real(kind=4)    :: t1,t2,tcpu1,tcpu2
  integer(kind=1) :: ibin_wakei
- logical         :: is_accretion,was_accreted
+ logical         :: was_accreted
  integer         :: i,itype,nfaili
  integer         :: naccreted,nfail,nlive
- real            :: dkdt,pmassi,fxi,fyi,fzi,accretedmass
+ real            :: pmassi,fxi,fyi,fzi,accretedmass
 
- if (present(timei) .and. present(ibin_wake) .and. present(nbinmax) .and. present(accreted)) then
-    is_accretion = .true.
- else
-    is_accretion = .false.
- endif
-
+ call get_timings(t1,tcpu1)
  itype = igas
  pmassi = massoftype(igas)
-
- dkdt = dki*dt
-
- ! Kick sink particles
- if (nptmass > 0) then
-    if (id==master) then
-       call ptmass_kick(nptmass,dkdt,pxyz_ptmass,fxyz_ptmass,xyzmh_ptmass,dsdt_ptmass)
-    endif
-    call bcast_mpi(pxyz_ptmass(:,1:nptmass))
-    call bcast_mpi(xyzmh_ptmass(ispinx,1:nptmass))
-    call bcast_mpi(xyzmh_ptmass(ispiny,1:nptmass))
-    call bcast_mpi(xyzmh_ptmass(ispinz,1:nptmass))
- endif
-
-
- ! Kick gas particles
-
- if (.not.is_accretion) then
-    !$omp parallel do default(none) &
-    !$omp shared(maxp,maxphase) &
-    !$omp shared(iphase,ntypes) &
-    !$omp shared(npart,fext,xyzh,pxyzu,dkdt) &
-    !$omp firstprivate(itype) &
-    !$omp private(i)
-    do i=1,npart
-       if (.not.isdead_or_accreted(xyzh(4,i))) then
-          if (ntypes > 1 .and. maxphase==maxp) then
-             itype = iamtype(iphase(i))
-             if (iamboundary(itype)) cycle
+ accretedmass = 0.
+ nfail        = 0
+ naccreted    = 0
+ nlive        = 0
+ ibin_wakei   = 0
+ dptmass(:,1:nptmass) = 0.
+ !$omp parallel do default(none) &
+ !$omp shared(maxp,maxphase) &
+ !$omp shared(npart,xyzh,pxyzu,fext,iphase,ntypes,massoftype,timei,nptmass,sts_it_n) &
+ !$omp shared(xyzmh_ptmass,pxyz_ptmass,fxyz_ptmass,f_acc,apr_level,aprmassoftype) &
+ !$omp shared(iexternalforce) &
+ !$omp shared(nbinmax,ibin_wake) &
+ !$omp private(i,was_accreted,nfaili,fxi,fyi,fzi) &
+ !$omp firstprivate(itype,pmassi,ibin_wakei) &
+ !$omp reduction(+:accretedmass) &
+ !$omp reduction(+:nfail) &
+ !$omp reduction(+:naccreted) &
+ !$omp reduction(+:nlive) &
+ !$omp reduction(+:dptmass)
+ accreteloop: do i=1,npart
+    if (.not.isdead_or_accreted(xyzh(4,i))) then
+       if (ntypes > 1 .and. maxphase==maxp) then
+          itype = iamtype(iphase(i))
+          if (iamboundary(itype)) cycle accreteloop
+          if (use_apr) then
+             pmassi = aprmassoftype(itype,apr_level(i))
+          else
+             pmassi = massoftype(itype)
           endif
-          pxyzu(1,i) = pxyzu(1,i) + dkdt*fext(1,i)
-          pxyzu(2,i) = pxyzu(2,i) + dkdt*fext(2,i)
-          pxyzu(3,i) = pxyzu(3,i) + dkdt*fext(3,i)
+       elseif (use_apr) then
+          pmassi = aprmassoftype(igas,apr_level(i))
        endif
-    enddo
-    !$omp end parallel do
 
- else
-    call get_timings(t1,tcpu1)
-    accretedmass = 0.
-    nfail        = 0
-    naccreted    = 0
-    nlive        = 0
-    ibin_wakei   = 0
-    dptmass(:,1:nptmass) = 0.
-    !$omp parallel do default(none) &
-    !$omp shared(maxp,maxphase) &
-    !$omp shared(npart,xyzh,pxyzu,fext,dkdt,iphase,ntypes,massoftype,timei,nptmass,sts_it_n) &
-    !$omp shared(xyzmh_ptmass,pxyz_ptmass,fxyz_ptmass,f_acc,apr_level,aprmassoftype) &
-    !$omp shared(iexternalforce) &
-    !$omp shared(nbinmax,ibin_wake) &
-    !$omp private(i,was_accreted,nfaili,fxi,fyi,fzi) &
-    !$omp firstprivate(itype,pmassi,ibin_wakei) &
-    !$omp reduction(+:accretedmass) &
-    !$omp reduction(+:nfail) &
-    !$omp reduction(+:naccreted) &
-    !$omp reduction(+:nlive) &
-    !$omp reduction(+:dptmass)
-    accreteloop: do i=1,npart
-       if (.not.isdead_or_accreted(xyzh(4,i))) then
-          if (ntypes > 1 .and. maxphase==maxp) then
-             itype = iamtype(iphase(i))
-             if (iamboundary(itype)) cycle accreteloop
-             if (use_apr) then
-                pmassi = aprmassoftype(itype,apr_level(i))
-             else
-                pmassi = massoftype(itype)
-             endif
-          elseif (use_apr) then
-             pmassi = aprmassoftype(igas,apr_level(i))
-          endif
-          !
-          ! correct v to the full step using only the external force
-          !
-          pxyzu(1,i) = pxyzu(1,i) + dkdt*fext(1,i)
-          pxyzu(2,i) = pxyzu(2,i) + dkdt*fext(2,i)
-          pxyzu(3,i) = pxyzu(3,i) + dkdt*fext(3,i)
-
-          was_accreted = .false.
-          if (iexternalforce > 0) then
-             call accrete_particles(iexternalforce,xyzh(1,i),xyzh(2,i), &
+       was_accreted = .false.
+       if (iexternalforce > 0) then
+          call accrete_particles(iexternalforce,xyzh(1,i),xyzh(2,i), &
                                     xyzh(3,i),xyzh(4,i),pmassi,timei,was_accreted)
-             if (was_accreted) accretedmass = accretedmass + pmassi
+          if (was_accreted) then
+             accretedmass = accretedmass + pmassi
+             naccreted = naccreted + 1
+             cycle accreteloop
           endif
-          !
-          ! accretion onto sink particles
-          ! need position, velocities and accelerations of both gas and sinks to be synchronised,
-          ! otherwise will not conserve momentum
-          ! Note: requiring sts_it_n since this is supertimestep with the most active particles
-          !
-          if (nptmass > 0 .and. sts_it_n) then
-             fxi = fext(1,i)
-             fyi = fext(2,i)
-             fzi = fext(3,i)
-             if (ind_timesteps) ibin_wakei = ibin_wake(i)
-
-             call ptmass_accrete(1,nptmass,xyzh(1,i),xyzh(2,i),xyzh(3,i),xyzh(4,i),&
-                                 pxyzu(1,i),pxyzu(2,i),pxyzu(3,i),fxi,fyi,fzi,&
-                                 itype,pmassi,xyzmh_ptmass,pxyz_ptmass,was_accreted, &
-                                 dptmass,timei,f_acc,nbinmax,ibin_wakei,nfaili)
-             if (was_accreted) then
-                naccreted = naccreted + 1
-                cycle accreteloop
-             else
-                if (ind_timesteps) ibin_wake(i) = ibin_wakei
-             endif
-             if (nfaili > 1) nfail = nfail + 1
-          endif
-          nlive = nlive + 1
        endif
-    enddo accreteloop
-    !$omp end parallel do
+       !
+       ! accretion onto sink particles
+       ! need position, velocities and accelerations of both gas and sinks to be synchronised,
+       ! otherwise will not conserve momentum
+       ! Note: requiring sts_it_n since this is supertimestep with the most active particles
+       !
+       if (nptmass > 0 .and. sts_it_n) then
+          fxi = fext(1,i)
+          fyi = fext(2,i)
+          fzi = fext(3,i)
+          if (ind_timesteps) ibin_wakei = ibin_wake(i)
 
-    call get_timings(t2,tcpu2)
-    call increment_timer(itimer_acc,t2-t1,tcpu2-tcpu1)
-
-    if (npart > 2 .and. nlive < 2) then
-       call fatal('step','all particles accreted',var='nlive',ival=nlive)
+          call ptmass_accrete(1,nptmass,xyzh(1,i),xyzh(2,i),xyzh(3,i),xyzh(4,i),&
+                              pxyzu(1,i),pxyzu(2,i),pxyzu(3,i),fxi,fyi,fzi,&
+                              itype,pmassi,xyzmh_ptmass,pxyz_ptmass,was_accreted, &
+                              dptmass,timei,f_acc,nbinmax,ibin_wakei,nfaili)
+          if (was_accreted) then
+             naccreted = naccreted + 1
+             cycle accreteloop
+          else
+             if (ind_timesteps) ibin_wake(i) = ibin_wakei
+          endif
+          if (nfaili > 1) nfail = nfail + 1
+       endif
+       nlive = nlive + 1
     endif
+ enddo accreteloop
+ !$omp end parallel do
+
+ call get_timings(t2,tcpu2)
+ call increment_timer(itimer_acc,t2-t1,tcpu2-tcpu1)
+
+ if (npart > 2 .and. nlive < 2) then
+    call fatal('step','all particles accreted',var='nlive',ival=nlive)
+ endif
 
 !
 ! reduction of sink particle changes across MPI
 !
-    if (present(accreted)) accreted = .false.
-    if (nptmass > 0) then
-       naccreted = int(reduceall_mpi('+',naccreted))
-       nfail = int(reduceall_mpi('+',nfail))
-       if (naccreted > 0) then
-          if (present(accreted)) accreted = .true.
-          call reduce_in_place_mpi('+',dptmass(:,1:nptmass))
-          if (id==master) call update_ptmass(dptmass,xyzmh_ptmass,pxyz_ptmass,fxyz_ptmass,nptmass)
-       endif
-       call bcast_mpi(xyzmh_ptmass(:,1:nptmass))
-       call bcast_mpi(pxyz_ptmass(:,1:nptmass))
-       call bcast_mpi(fxyz_ptmass(:,1:nptmass))
+ if (present(accreted)) accreted = .false.
+ if (nptmass > 0) then
+    naccreted = int(reduceall_mpi('+',naccreted))
+    nfail = int(reduceall_mpi('+',nfail))
+    if (naccreted > 0) then
+       if (present(accreted)) accreted = .true.
+       call reduce_in_place_mpi('+',dptmass(:,1:nptmass))
+       if (id==master) call update_ptmass(dptmass,xyzmh_ptmass,pxyz_ptmass,fxyz_ptmass,nptmass)
     endif
-
-    if (iverbose >= 2 .and. id==master .and. naccreted /= 0) write(iprint,"(a,es10.3,a,i4,a,i4,a)") &
-    'Step: at time ',timei,', ',naccreted,' particles were accreted amongst ',nptmass,' sink(s).'
-
-    if (nptmass > 0) then
-       call summary_accrete_fail(nfail)
-       call summary_accrete(nptmass)
-       ! only write to .ev during substeps if no gas particles present
-       if (npart==0) call pt_write_sinkev(nptmass,timei,xyzmh_ptmass,pxyz_ptmass, &
-                                          fxyz_ptmass,fxyz_ptmass_sinksink)
-    endif
+    call bcast_mpi(xyzmh_ptmass(:,1:nptmass))
+    call bcast_mpi(pxyz_ptmass(:,1:nptmass))
+    call bcast_mpi(fxyz_ptmass(:,1:nptmass))
  endif
 
-end subroutine kick
+ if (iverbose >= 2 .and. id==master .and. naccreted /= 0) write(iprint,"(a,es10.3,a,i4,a,i4,a)") &
+    'Step: at time ',timei,', ',naccreted,' particles were accreted amongst ',nptmass,' sink(s).'
+
+ if (nptmass > 0) then
+    call summary_accrete_fail(nfail)
+    call summary_accrete(nptmass)
+    ! only write to .ev during substeps if no gas particles present
+    if (npart==0) call pt_write_sinkev(nptmass,timei,xyzmh_ptmass,pxyz_ptmass, &
+                                          fxyz_ptmass,fxyz_ptmass_sinksink)
+ endif
+
+end subroutine accretion
 
 !----------------------------------------------------------------
 !+


### PR DESCRIPTION
Description:
The accretion routine has remained unchanged since the public repository was created. It is never a major bottleneck when the number of point masses is low. In my case, this part of the code could easily eat 40 to 60 % of the wall time when this number starts to rise up to a few thousand. I've changed the checks logic (however, the physical tests are identical) in this routine to avoid duplicate tests for nothing (especially in the most bound part tests). It also allowed me to refactor the code. `ptmass_accrete` and `kick` have been split in half, separating checks from accumulation in the first one and kicking and accreting in the latter.
I also simplified the last calls in a substep to be agnostic of one integrator or method to another. 

The perf gain is negligible for now, but this PR should allow simpler optimisations for later. To be continued...

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Setup (src/setup)
- [x] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [ ] Documentation (docs/)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [x] Performance improvements
- [ ] Documentation update
- [ ] Other (please describe)

Testing:
accretion tests in `test_ptmass.f90`

Did you run the bots? no

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? yes

Is there a unit test that could be added for this feature/bug? no