### PR TITLE
Remove every refs to the deprecated linked list

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -510,7 +510,7 @@ SOURCES= physcon.f90 ${CONFIG} ${SRCKERNEL} io.F90 units.f90 \
          checkoptions.F90 viscosity.f90 damping.f90 options.f90 cons2primsolver.f90 radiation_utils.f90 cons2prim.f90 \
          centreofmass.f90 ${SRCPOT} checkconserved.f90 \
          utils_filenames.f90 utils_summary.F90 ${SRCCHEM} ${SRCDUST} \
-         mpi_memory.f90 mpi_derivs.F90 mpi_tree.F90 kdtree.F90 linklist_kdtree.f90 utils_healpix.f90 utils_raytracer.f90 \
+         mpi_memory.f90 mpi_derivs.F90 mpi_tree.F90 kdtree.F90 neigh_kdtree.f90 utils_healpix.f90 utils_raytracer.f90 \
          partinject.F90 utils_inject.f90 dust_formation.f90 ptmass_radiation.f90 ptmass_heating.f90 \
          utils_deriv.f90 utils_implicit.f90 radiation_implicit.f90 ${SRCTURB} \
          grids_for_setup.f90\
@@ -591,7 +591,7 @@ edit: checksetup
 SRCDUMP= physcon.f90 ${CONFIG} ${SRCKERNEL} utils_omp.F90 io.F90 units.f90 mpi_utils.F90 \
          utils_timing.f90 utils_infiles.f90 dtype_kdtree.f90 utils_allocate.f90 part.F90 \
          ${DOMAIN} mpi_dens.F90 mpi_force.F90 boundary.f90 boundary_dynamic.f90 \
-         mpi_balance.F90 mpi_memory.f90 mpi_derivs.F90 mpi_tree.F90 kdtree.F90 linklist_kdtree.f90 \
+         mpi_balance.F90 mpi_memory.f90 mpi_derivs.F90 mpi_tree.F90 kdtree.F90 neigh_kdtree.f90 \
          utils_dumpfiles.f90 utils_vectors.f90 utils_mathfunc.f90 cubicsolve.f90 \
          utils_datafiles.f90 utils_filenames.f90 utils_system.f90 utils_tables.f90 datafiles.f90 gitinfo.f90 \
          centreofmass.f90 \

--- a/build/Makefile
+++ b/build/Makefile
@@ -667,7 +667,7 @@ SRCTESTS=utils_testsuite.f90 ${TEST_FASTMATH} test_kernel.f90 \
          test_step.F90 test_indtstep.f90 ${SRCSETSTAR} utils_filenames.f90 utils_tables.f90 \
          grids_for_setup.f90 set_disc.f90 test_setdisc.F90 test_setstar.f90 \
          test_hierarchical.f90 test_damping.f90 test_wind.f90 test_iorig.f90 \
-         test_link.F90 test_kdtree.F90 test_part.f90 test_ptmass.f90 test_luminosity.f90\
+         test_neigh.F90 test_kdtree.F90 test_part.f90 test_ptmass.f90 test_luminosity.f90\
          test_gnewton.f90 test_corotate.f90 test_gr.f90 test_geometry.f90 \
          test_mpi.f90 test_sedov.f90 test_poly.f90 test_radiation.F90 test_units.f90 \
          testsuite.F90 setup_params.f90 phantomtest.f90

--- a/docs/api/tests/index.rst
+++ b/docs/api/tests/index.rst
@@ -22,7 +22,7 @@ tests
    test_indtstep
    test_kdtree
    test_kernel
-   test_link
+   test_neigh
    test_luminosity
    test_nonidealmhd
    test_ptmass

--- a/docs/api/tests/test_link.rst
+++ b/docs/api/tests/test_link.rst
@@ -1,6 +1,6 @@
 
-test_link
+test_neigh
 =========================
 
-.. f:autosrcfile:: ../../../src/tests/test_link.f90
+.. f:autosrcfile:: ../../../src/tests/test_neigh.f90
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -226,7 +226,7 @@ fortran_src = [
  '../src/tests/test_indtstep.f90',
  '../src/tests/test_kdtree.f90',
  '../src/tests/test_kernel.f90',
- '../src/tests/test_link.f90',
+ '../src/tests/test_neigh.f90',
  '../src/tests/test_luminosity.f90',
  '../src/tests/test_nonidealmhd.f90',
  '../src/tests/test_ptmass.f90',

--- a/docs/developer-guide/testing.rst
+++ b/docs/developer-guide/testing.rst
@@ -74,7 +74,7 @@ A non-exhaustive list of possible arguments are as follows:
 |                                   | derivatives in a setup with       |
 |                                   | density contrast                  |
 +-----------------------------------+-----------------------------------+
-| neigh                             | tests the neighbour      |
+| neigh                             | tests the neighbour               |
 |                                   | finding modules                   |
 +-----------------------------------+-----------------------------------+
 | step                              | performs checks on the            |

--- a/docs/developer-guide/testing.rst
+++ b/docs/developer-guide/testing.rst
@@ -74,7 +74,7 @@ A non-exhaustive list of possible arguments are as follows:
 |                                   | derivatives in a setup with       |
 |                                   | density contrast                  |
 +-----------------------------------+-----------------------------------+
-| link                              | tests the neighbour      |
+| neigh                             | tests the neighbour      |
 |                                   | finding modules                   |
 +-----------------------------------+-----------------------------------+
 | step                              | performs checks on the            |

--- a/docs/developer-guide/testing.rst
+++ b/docs/developer-guide/testing.rst
@@ -74,7 +74,7 @@ A non-exhaustive list of possible arguments are as follows:
 |                                   | derivatives in a setup with       |
 |                                   | density contrast                  |
 +-----------------------------------+-----------------------------------+
-| link                              | tests the linklist/neighbour      |
+| link                              | tests the neighbour      |
 |                                   | finding modules                   |
 +-----------------------------------+-----------------------------------+
 | step                              | performs checks on the            |

--- a/src/main/H2regions.f90
+++ b/src/main/H2regions.f90
@@ -17,7 +17,7 @@ module HIIRegion
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: dim, eos, infile_utils, io, linklist, part, physcon,
+! :Dependencies: dim, eos, infile_utils, io, neighkdtree, part, physcon,
 !   sortutils, timing, units
 !
  implicit none
@@ -183,12 +183,12 @@ end subroutine update_ionrate
 subroutine HII_feedback(nptmass,npart,xyzh,xyzmh_ptmass,vxyzu,isionised,dt)
  use part,       only:rhoh,massoftype,ihsoft,igas,irateion,isdead_or_accreted,&
                       irstrom
- use linklist,   only:listneigh=>listneigh_global,getneigh_pos,ifirstincell
- use sortutils,  only:Knnfunc,set_r2func_origin,r2func_origin
- use physcon,    only:pc,pi
- use timing,     only:get_timings,increment_timer,itimer_HII
- use dim,        only:maxvxyzu,maxpsph
- use units,      only:utime
+ use neighkdtree, only:listneigh=>listneigh_global,getneigh_pos,ifirstincell
+ use sortutils,   only:Knnfunc,set_r2func_origin,r2func_origin
+ use physcon,     only:pc,pi
+ use timing,      only:get_timings,increment_timer,itimer_HII
+ use dim,         only:maxvxyzu,maxpsph
+ use units,       only:utime
  integer,          intent(in)    :: nptmass,npart
  real,             intent(in)    :: xyzh(:,:)
  real,             intent(inout) :: xyzmh_ptmass(:,:),vxyzu(:,:)

--- a/src/main/H2regions.f90
+++ b/src/main/H2regions.f90
@@ -183,7 +183,7 @@ end subroutine update_ionrate
 subroutine HII_feedback(nptmass,npart,xyzh,xyzmh_ptmass,vxyzu,isionised,dt)
  use part,       only:rhoh,massoftype,ihsoft,igas,irateion,isdead_or_accreted,&
                       irstrom
- use neighkdtree, only:listneigh=>listneigh_global,getneigh_pos,itypecell
+ use neighkdtree, only:listneigh=>listneigh_global,getneigh_pos,leaf_is_active
  use sortutils,   only:Knnfunc,set_r2func_origin,r2func_origin
  use physcon,     only:pc,pi
  use timing,      only:get_timings,increment_timer,itimer_HII
@@ -232,7 +232,7 @@ subroutine HII_feedback(nptmass,npart,xyzh,xyzmh_ptmass,vxyzu,isionised,dt)
           hcheck = Rmax
        endif
        do while(hcheck <= Rmax)
-          call getneigh_pos((/xi,yi,zi/),0.,hcheck,3,listneigh,nneigh,xyzcache,maxcache,itypecell)
+          call getneigh_pos((/xi,yi,zi/),0.,hcheck,3,listneigh,nneigh,xyzcache,maxcache,leaf_is_active)
           call set_r2func_origin(xi,yi,zi)
           call Knnfunc(nneigh,r2func_origin,xyzh,listneigh) !! Here still serial version of the quicksort. Parallel version in prep..
           if (nneigh > 0) exit

--- a/src/main/H2regions.f90
+++ b/src/main/H2regions.f90
@@ -183,7 +183,7 @@ end subroutine update_ionrate
 subroutine HII_feedback(nptmass,npart,xyzh,xyzmh_ptmass,vxyzu,isionised,dt)
  use part,       only:rhoh,massoftype,ihsoft,igas,irateion,isdead_or_accreted,&
                       irstrom
- use neighkdtree, only:listneigh=>listneigh_global,getneigh_pos,ifirstincell
+ use neighkdtree, only:listneigh=>listneigh_global,getneigh_pos,itypecell
  use sortutils,   only:Knnfunc,set_r2func_origin,r2func_origin
  use physcon,     only:pc,pi
  use timing,      only:get_timings,increment_timer,itimer_HII
@@ -232,7 +232,7 @@ subroutine HII_feedback(nptmass,npart,xyzh,xyzmh_ptmass,vxyzu,isionised,dt)
           hcheck = Rmax
        endif
        do while(hcheck <= Rmax)
-          call getneigh_pos((/xi,yi,zi/),0.,hcheck,3,listneigh,nneigh,xyzcache,maxcache,ifirstincell)
+          call getneigh_pos((/xi,yi,zi/),0.,hcheck,3,listneigh,nneigh,xyzcache,maxcache,itypecell)
           call set_r2func_origin(xi,yi,zi)
           call Knnfunc(nneigh,r2func_origin,xyzh,listneigh) !! Here still serial version of the quicksort. Parallel version in prep..
           if (nneigh > 0) exit

--- a/src/main/apr.f90
+++ b/src/main/apr.f90
@@ -429,7 +429,7 @@ end subroutine splitpart
 !-----------------------------------------------------------------------
 subroutine merge_with_special_tree(nmerge,mergelist,xyzh_merge,vxyzu_merge,current_apr,&
                                      xyzh,vxyzu,apr_level,nkilled,nrelax,relaxlist,npartnew)
- use neighkdtree,   only:build_tree,ncells,ifirstincell,get_cell_location
+ use neighkdtree,   only:build_tree,ncells,itypecell,get_cell_location
  use mpiforce,      only:cellforce
  use kdtree,        only:inodeparts,inoderange
  use part,          only:kill_particle,npartoftype,igas
@@ -456,7 +456,7 @@ subroutine merge_with_special_tree(nmerge,mergelist,xyzh_merge,vxyzu_merge,curre
  ! be merged or not
  com = 0.
  over_cells: do icell=1,int(ncells)
-    i = ifirstincell(icell)
+    i = itypecell(icell)
     if (i == 0) cycle over_cells !--skip empty cells
     n_cell = inoderange(2,icell)-inoderange(1,icell)+1
 

--- a/src/main/apr.f90
+++ b/src/main/apr.f90
@@ -15,7 +15,7 @@ module apr
 ! :Runtime parameters: None
 !
 ! :Dependencies: apr_region, dim, get_apr_level, io, io_summary, kdtree,
-!   neighkdtree, mpiforce, part, physcon, quitdump, random, relaxem,
+!   mpiforce, neighkdtree, part, physcon, quitdump, random, relaxem,
 !   timestep_ind, utils_apr, vectorutils
 !
  use dim, only:use_apr

--- a/src/main/apr.f90
+++ b/src/main/apr.f90
@@ -429,7 +429,7 @@ end subroutine splitpart
 !-----------------------------------------------------------------------
 subroutine merge_with_special_tree(nmerge,mergelist,xyzh_merge,vxyzu_merge,current_apr,&
                                      xyzh,vxyzu,apr_level,nkilled,nrelax,relaxlist,npartnew)
- use neighkdtree,   only:build_tree,ncells,itypecell,get_cell_location
+ use neighkdtree,   only:build_tree,ncells,leaf_is_active,get_cell_location
  use mpiforce,      only:cellforce
  use kdtree,        only:inodeparts,inoderange
  use part,          only:kill_particle,npartoftype,igas
@@ -456,8 +456,7 @@ subroutine merge_with_special_tree(nmerge,mergelist,xyzh_merge,vxyzu_merge,curre
  ! be merged or not
  com = 0.
  over_cells: do icell=1,int(ncells)
-    i = itypecell(icell)
-    if (i == 0) cycle over_cells !--skip empty cells
+    if (leaf_is_active(icell) == 0) cycle over_cells !--skip empty cells
     n_cell = inoderange(2,icell)-inoderange(1,icell)+1
 
     call get_cell_location(icell,cell%xpos,cell%xsizei,cell%rcuti)

--- a/src/main/apr.f90
+++ b/src/main/apr.f90
@@ -15,7 +15,7 @@ module apr
 ! :Runtime parameters: None
 !
 ! :Dependencies: apr_region, dim, get_apr_level, io, io_summary, kdtree,
-!   linklist, mpiforce, part, physcon, quitdump, random, relaxem,
+!   neighkdtree, mpiforce, part, physcon, quitdump, random, relaxem,
 !   timestep_ind, utils_apr, vectorutils
 !
  use dim, only:use_apr
@@ -429,12 +429,12 @@ end subroutine splitpart
 !-----------------------------------------------------------------------
 subroutine merge_with_special_tree(nmerge,mergelist,xyzh_merge,vxyzu_merge,current_apr,&
                                      xyzh,vxyzu,apr_level,nkilled,nrelax,relaxlist,npartnew)
- use linklist, only:set_linklist,ncells,ifirstincell,get_cell_location
- use mpiforce, only:cellforce
- use kdtree,   only:inodeparts,inoderange
- use part,     only:kill_particle,npartoftype,igas
- use part,     only:combine_two_particles
- use dim,      only:ind_timesteps,maxvxyzu
+ use neighkdtree,   only:build_tree,ncells,ifirstincell,get_cell_location
+ use mpiforce,      only:cellforce
+ use kdtree,        only:inodeparts,inoderange
+ use part,          only:kill_particle,npartoftype,igas
+ use part,          only:combine_two_particles
+ use dim,           only:ind_timesteps,maxvxyzu
  use get_apr_level, only:get_apr
  integer,         intent(inout) :: nmerge,nkilled,nrelax,relaxlist(:),npartnew
  integer(kind=1), intent(inout) :: apr_level(:)
@@ -450,7 +450,7 @@ subroutine merge_with_special_tree(nmerge,mergelist,xyzh_merge,vxyzu_merge,curre
  remainder = modulo(nmerge,2)
  nmerge = nmerge - remainder
 
- call set_linklist(nmerge,nmerge,xyzh_merge(:,1:nmerge),vxyzu_merge(:,1:nmerge),&
+ call build_tree(nmerge,nmerge,xyzh_merge(:,1:nmerge),vxyzu_merge(:,1:nmerge),&
                       for_apr=.true.)
  ! Now use the centre of mass of each cell to check whether it should
  ! be merged or not

--- a/src/main/apr.f90
+++ b/src/main/apr.f90
@@ -441,7 +441,7 @@ subroutine merge_with_special_tree(nmerge,mergelist,xyzh_merge,vxyzu_merge,curre
  integer,         intent(in)    :: current_apr,mergelist(:)
  real,            intent(inout) :: xyzh(:,:),vxyzu(:,:)
  real,            intent(inout) :: xyzh_merge(:,:),vxyzu_merge(:,:)
- integer :: remainder,icell,i,n_cell,apri,m
+ integer :: remainder,icell,n_cell,apri,m
  integer :: eldest,tuther
  real    :: com(3)
  type(cellforce)        :: cell

--- a/src/main/config.F90
+++ b/src/main/config.F90
@@ -63,7 +63,7 @@ module dim
  logical, parameter :: sink_radiation = .false.
 #endif
 
-! maxmimum storage in linklist
+! maxmimum storage in node list
  integer         :: ncellsmax
  integer(kind=8) :: ncellsmaxglobal
 

--- a/src/main/dens.F90
+++ b/src/main/dens.F90
@@ -15,8 +15,8 @@ module densityforce
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: boundary, dim, io, io_summary, kdtree, kernel, nieghkdtree,
-!   mpidens, mpiderivs, mpimemory, mpiutils, omputils, options, part,
+! :Dependencies: boundary, dim, io, io_summary, kdtree, kernel, mpidens,
+!   mpiderivs, mpimemory, mpiutils, neighkdtree, omputils, options, part,
 !   timestep, timing, viscosity
 !
  use dim,     only:maxdvdx,maxp,maxrhosum,maxdustlarge

--- a/src/main/dens.F90
+++ b/src/main/dens.F90
@@ -120,7 +120,7 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
  use dim,         only:maxp,curlv,ndivcurlB,maxalpha,mhd_nonideal,nalpha,&
                      use_dust,fast_divcurlB,mpi,gr,use_apr
  use io,          only:iprint,fatal,iverbose,id,master,real4,warning,error,nprocs
- use neighkdtree, only:ifirstincell,ncells,get_neighbour_list,get_hmaxcell,&
+ use neighkdtree, only:itypecell,ncells,get_neighbour_list,get_hmaxcell,&
                      listneigh,get_cell_location,set_hmaxcell,sync_hmax_mpi
  use part,        only:mhd,rhoh,dhdrho,rhoanddhdrho,get_partinfo,iactive,&
                        hrho,iphase,igas,idust,iamgas,periodic,all_active,dustfrac
@@ -226,7 +226,7 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
 !$omp parallel default(none) &
 !$omp shared(icall) &
 !$omp shared(ncells) &
-!$omp shared(ifirstincell) &
+!$omp shared(itypecell) &
 !$omp shared(xyzh) &
 !$omp shared(vxyzu) &
 !$omp shared(fxyzu) &
@@ -298,7 +298,7 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
 
  !$omp do schedule(runtime)
  over_cells: do icell=1,int(ncells)
-    i = ifirstincell(icell)
+    i = itypecell(icell)
 
     !--skip empty cells AND inactive cells
     if (i <= 0) cycle over_cells
@@ -1679,7 +1679,7 @@ subroutine store_results(icall,cell,getdv,getdb,realviscosity,stressmax,xyzh,&
 end subroutine store_results
 
 subroutine get_density_at_pos(x,rho,itype)
- use neighkdtree, only:listneigh=>listneigh_global,getneigh_pos,ifirstincell
+ use neighkdtree, only:listneigh=>listneigh_global,getneigh_pos,itypecell
  use kernel,      only:get_kernel,radkern2,cnormk
  use boundary,    only:dxbound,dybound,dzbound
  use dim,         only:periodic,maxphase,maxp,use_apr
@@ -1693,7 +1693,7 @@ subroutine get_density_at_pos(x,rho,itype)
  real :: dx,dy,dz,hj1,rij2,q2j,qj,pmassj,wabi,grkerni
  logical :: same_type
 
- call getneigh_pos(x,0.,0.,3,listneigh,nneigh,xyzcache,maxcache,ifirstincell,get_j=.true.)
+ call getneigh_pos(x,0.,0.,3,listneigh,nneigh,xyzcache,maxcache,itypecell,get_j=.true.)
  same_type=.true.
  rho = 0.
  loop_over_neigh: do n=1,nneigh

--- a/src/main/dens.F90
+++ b/src/main/dens.F90
@@ -102,7 +102,7 @@ module densityforce
  integer, parameter :: maxdensits = 100
 
  !--statistics which can be queried later
- integer, private         :: maxneighact,nrengh
+ integer, private         :: maxneighact,ncalls_neigh
  integer(kind=8), private :: nneightry,maxneightry,nneighact,ncalc
  integer(kind=8), private :: nptot = -1
 
@@ -186,7 +186,7 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
     write(iprint,*) ' cell cache =',isizecellcache,' neigh cache = ',isizeneighcache,' icall = ',icall
 
  if (icall==0 .or. icall==1) then
-    call reset_neighbour_stats(nneightry,nneighact,maxneightry,maxneighact,ncalc,nrengh)
+    call reset_neighbour_stats(nneightry,nneighact,maxneightry,maxneighact,ncalc,ncalls_neigh)
     nwarnup       = 0
     nwarndown     = 0
     nwarnroundoff = 0
@@ -281,7 +281,7 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
 !$omp reduction(max:maxneightry) &
 !$omp reduction(+:nneighact) &
 !$omp reduction(+:nneightry) &
-!$omp reduction(+:nrengh) &
+!$omp reduction(+:ncalls_neigh) &
 !$omp reduction(+:stressmax) &
 !$omp reduction(max:rhomax) &
 !$omp private(i)
@@ -362,7 +362,7 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
                    call reserve_stack(stack_waiting,cell%waiting_index)
                    call send_cell(cell,remote_export,irequestsend,xsendbuf,cell_counters,mpitype)  ! send to remote
                 endif
-                nrengh = nrengh + 1
+                ncalls_neigh = ncalls_neigh + 1
              endif
 
              call compute_cell(cell,listneigh,nneigh,getdv,getdB,Bevol,xyzh,vxyzu,fxyzu,fext,xyzcache,rad,apr_level)
@@ -1151,8 +1151,8 @@ subroutine get_neighbour_stats(trialmean,actualmean,maxtrial,maxactual,nrhocalc,
 
 end subroutine get_neighbour_stats
 
-subroutine reset_neighbour_stats(nneightry,nneighact,maxneightry,maxneighact,ncalc,nrengh)
- integer,         intent(out) :: maxneighact,nrengh
+subroutine reset_neighbour_stats(nneightry,nneighact,maxneightry,maxneighact,ncalc,ncalls_neigh)
+ integer,         intent(out) :: maxneighact,ncalls_neigh
  integer(kind=8), intent(out) :: ncalc,nneightry,nneighact,maxneightry
 
  nneightry = 0
@@ -1161,7 +1161,7 @@ subroutine reset_neighbour_stats(nneightry,nneighact,maxneightry,maxneighact,nca
  maxneighact = 0
  ncalc = 0_8
  nneighact = 0
- nrengh = 0_8
+ ncalls_neigh = 0_8
 
 end subroutine reset_neighbour_stats
 
@@ -1181,7 +1181,7 @@ subroutine reduce_and_print_neighbour_stats(np)
  nneighact   = reduce_mpi('+',nneighact)
  maxneightry = reduce_mpi('max',maxneightry)
  maxneighact = int(reduce_mpi('max',maxneighact))
- nrengh     = int(reduce_mpi('+',nrengh))
+ ncalls_neigh     = int(reduce_mpi('+',ncalls_neigh))
  ncalc       = reduce_mpi('+',ncalc)
 
  if (id==master .and. iverbose >= 2 .and. nptot > 0 .and. nneighact > 0) then
@@ -1189,7 +1189,7 @@ subroutine reduce_and_print_neighbour_stats(np)
                  ', real neigh mean = ',nneighact/real(nptot), &
                  ' ratio try/act= ',nneightry/real(nneighact)
     write(iprint,"(1x,a,i11,a,i8)")   'trial neigh max   :',maxneightry,', max real neigh = ',maxneighact
-    write(iprint,"(1x,a,i11,a,f7.3)") 'n neighbour calls :',nrengh, ', mean per part   = ',nrengh/real(nptot) + 1
+    write(iprint,"(1x,a,i11,a,f7.3)") 'n neighbour calls :',ncalls_neigh, ', mean per part   = ',ncalls_neigh/real(nptot) + 1
     write(iprint,"(1x,a,i11,a,f7.3)") 'n density calcs   :',ncalc,', mean per part   = ',ncalc/real(nptot)
  endif
 

--- a/src/main/dens.F90
+++ b/src/main/dens.F90
@@ -15,7 +15,7 @@ module densityforce
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: boundary, dim, io, io_summary, kdtree, kernel, linklist,
+! :Dependencies: boundary, dim, io, io_summary, kdtree, kernel, nieghkdtree,
 !   mpidens, mpiderivs, mpimemory, mpiutils, omputils, options, part,
 !   timestep, timing, viscosity
 !
@@ -117,26 +117,26 @@ contains
 !----------------------------------------------------------------
 subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol,stressmax,&
                           fxyzu,fext,alphaind,gradh,rad,radprop,dvdx,apr_level)
- use dim,       only:maxp,curlv,ndivcurlB,maxalpha,mhd_nonideal,nalpha,&
+ use dim,         only:maxp,curlv,ndivcurlB,maxalpha,mhd_nonideal,nalpha,&
                      use_dust,fast_divcurlB,mpi,gr,use_apr
- use io,        only:iprint,fatal,iverbose,id,master,real4,warning,error,nprocs
- use linklist,  only:ifirstincell,ncells,get_neighbour_list,get_hmaxcell,&
+ use io,          only:iprint,fatal,iverbose,id,master,real4,warning,error,nprocs
+ use neighkdtree, only:ifirstincell,ncells,get_neighbour_list,get_hmaxcell,&
                      listneigh,get_cell_location,set_hmaxcell,sync_hmax_mpi
- use part,      only:mhd,rhoh,dhdrho,rhoanddhdrho,get_partinfo,iactive,&
-                     hrho,iphase,igas,idust,iamgas,periodic,all_active,dustfrac
- use mpiutils,  only:reduceall_mpi,barrier_mpi,reduce_mpi,reduceall_mpi
- use mpimemory, only:reserve_stack,swap_stacks,reset_stacks,write_cell
- use mpimemory, only:stack_remote  => dens_stack_1
- use mpimemory, only:stack_waiting => dens_stack_2
- use mpimemory, only:stack_redo    => dens_stack_3
- use mpiderivs, only:send_cell,recv_cells,check_send_finished,init_cell_exchange,&
-                     finish_cell_exchange,recv_while_wait,reset_cell_counters,cell_counters
- use timestep,  only:rhomaxnow
- use part,      only:ngradh
- use viscosity, only:irealvisc
- use io_summary,only:summary_variable,iosumhup,iosumhdn
- use timing,    only:increment_timer,get_timings,itimer_dens_local,itimer_dens_remote
- use omputils,  only:omp_thread_num,omp_num_threads
+ use part,        only:mhd,rhoh,dhdrho,rhoanddhdrho,get_partinfo,iactive,&
+                       hrho,iphase,igas,idust,iamgas,periodic,all_active,dustfrac
+ use mpiutils,    only:reduceall_mpi,barrier_mpi,reduce_mpi,reduceall_mpi
+ use mpimemory,   only:reserve_stack,swap_stacks,reset_stacks,write_cell
+ use mpimemory,   only:stack_remote  => dens_stack_1
+ use mpimemory,   only:stack_waiting => dens_stack_2
+ use mpimemory,   only:stack_redo    => dens_stack_3
+ use mpiderivs,   only:send_cell,recv_cells,check_send_finished,init_cell_exchange,&
+                       finish_cell_exchange,recv_while_wait,reset_cell_counters,cell_counters
+ use timestep,    only:rhomaxnow
+ use part,        only:ngradh
+ use viscosity,   only:irealvisc
+ use io_summary,  only:summary_variable,iosumhup,iosumhdn
+ use timing,      only:increment_timer,get_timings,itimer_dens_local,itimer_dens_remote
+ use omputils,    only:omp_thread_num,omp_num_threads
  integer,      intent(in)    :: icall,npart,nactive
  integer(kind=1), intent(in) :: apr_level(:)
  real,         intent(inout) :: xyzh(:,:)
@@ -1517,7 +1517,7 @@ subroutine store_results(icall,cell,getdv,getdb,realviscosity,stressmax,xyzh,&
  use dim,         only:maxp,ndivcurlB,nalpha,use_dust,do_radiation,use_apr,gravity
  use options,     only:use_dustfrac,implicit_radiation
  use viscosity,   only:bulkvisc,shearparam
- use linklist,    only:set_hmaxcell
+ use neighkdtree, only:set_hmaxcell
  use kernel,      only:radkern
  use kdtree,      only:inodeparts
 
@@ -1679,11 +1679,11 @@ subroutine store_results(icall,cell,getdv,getdb,realviscosity,stressmax,xyzh,&
 end subroutine store_results
 
 subroutine get_density_at_pos(x,rho,itype)
- use linklist, only:listneigh=>listneigh_global,getneigh_pos,ifirstincell
- use kernel,   only:get_kernel,radkern2,cnormk
- use boundary, only:dxbound,dybound,dzbound
- use dim,      only:periodic,maxphase,maxp,use_apr
- use part,     only:xyzh,iphase,iamtype,ibasetype,apr_level,massoftype,aprmassoftype
+ use neighkdtree, only:listneigh=>listneigh_global,getneigh_pos,ifirstincell
+ use kernel,      only:get_kernel,radkern2,cnormk
+ use boundary,    only:dxbound,dybound,dzbound
+ use dim,         only:periodic,maxphase,maxp,use_apr
+ use part,        only:xyzh,iphase,iamtype,ibasetype,apr_level,massoftype,aprmassoftype
  real, intent(in) :: x(3)
  integer, intent(in) :: itype
  real, intent(out) :: rho

--- a/src/main/deriv.f90
+++ b/src/main/deriv.f90
@@ -107,7 +107,7 @@ subroutine derivs(icall,npart,nactive,xyzh,vxyzu,fxyzu,fext,divcurlv,divcurlB,&
 !           (ie. only re-evaluates the SPH force term using updated values
 !            of the input variables)
 !
-! build tree to prepare neighour finding
+! build tree to prepare neighbour finding
 !
  if (icall==1 .or. icall==0) then
     call build_tree(npart,nactive,xyzh,vxyzu)

--- a/src/main/deriv.f90
+++ b/src/main/deriv.f90
@@ -103,11 +103,11 @@ subroutine derivs(icall,npart,nactive,xyzh,vxyzu,fxyzu,fext,divcurlv,divcurlB,&
 ! since the last call to derivs.
 !
 ! icall = 1 is the "standard" call to derivs: calculates all derivatives
-! icall = 2 does not remake the link list and does not recalculate density
+! icall = 2 does not remake the tree build and does not recalculate density
 !           (ie. only re-evaluates the SPH force term using updated values
 !            of the input variables)
 !
-! call link list to find neighbours
+! build tree to prepare neighour finding
 !
  if (icall==1 .or. icall==0) then
     call build_tree(npart,nactive,xyzh,vxyzu)
@@ -120,7 +120,7 @@ subroutine derivs(icall,npart,nactive,xyzh,vxyzu,fxyzu,fext,divcurlv,divcurlB,&
     if (nptmass > 0 .and. periodic) call ptmass_boundary_crossing(nptmass,xyzmh_ptmass)
  endif
 
- call do_timing('link',tlast,tcpulast,start=.true.)
+ call do_timing('tree',tlast,tcpulast,start=.true.)
 
 
  !

--- a/src/main/deriv.f90
+++ b/src/main/deriv.f90
@@ -15,7 +15,7 @@ module deriv
 ! :Runtime parameters: None
 !
 ! :Dependencies: cons2prim, densityforce, derivutils, dim, externalforces,
-!   forces, forcing, growth, io, linklist, metric_tools, options, part,
+!   forces, forcing, growth, io, neighkdtree, metric_tools, options, part,
 !   porosity, ptmass, ptmass_radiation, radiation_implicit, timestep,
 !   timestep_ind, timing
 !
@@ -41,7 +41,7 @@ subroutine derivs(icall,npart,nactive,xyzh,vxyzu,fxyzu,fext,divcurlv,divcurlB,&
  use dim,            only:mhd,fast_divcurlB,gr,periodic,do_radiation,driving,&
                           sink_radiation,use_dustgrowth,ind_timesteps,isothermal
  use io,             only:iprint,fatal,error
- use linklist,       only:set_linklist
+ use neighkdtree,    only:build_tree
  use densityforce,   only:densityiterate
  use ptmass,         only:ipart_rhomax,ptmass_calc_enclosed_mass,ptmass_boundary_crossing,get_pressure_on_sinks
  use externalforces, only:externalforce
@@ -110,7 +110,7 @@ subroutine derivs(icall,npart,nactive,xyzh,vxyzu,fxyzu,fext,divcurlv,divcurlB,&
 ! call link list to find neighbours
 !
  if (icall==1 .or. icall==0) then
-    call set_linklist(npart,nactive,xyzh,vxyzu)
+    call build_tree(npart,nactive,xyzh,vxyzu)
 
     if (gr) then
        ! Recalculate the metric after moving particles to their new tasks

--- a/src/main/deriv.f90
+++ b/src/main/deriv.f90
@@ -15,7 +15,7 @@ module deriv
 ! :Runtime parameters: None
 !
 ! :Dependencies: cons2prim, densityforce, derivutils, dim, externalforces,
-!   forces, forcing, growth, io, neighkdtree, metric_tools, options, part,
+!   forces, forcing, growth, io, metric_tools, neighkdtree, options, part,
 !   porosity, ptmass, ptmass_radiation, radiation_implicit, timestep,
 !   timestep_ind, timing
 !

--- a/src/main/evolve.F90
+++ b/src/main/evolve.F90
@@ -687,7 +687,7 @@ end subroutine evol
 subroutine print_timinginfo(iprint,nsteps,nsteplast)
  use io,     only:formatreal
  use timing, only:timer,timers,print_timer,itimer_fromstart,itimer_lastdump,&
-                  itimer_step,itimer_link,itimer_balance,itimer_dens,&
+                  itimer_step,itimer_balance,itimer_dens,&
                   itimer_force,itimer_ev,itimer_io,ntimers
  integer,      intent(in) :: iprint,nsteps,nsteplast
  real                     :: dfrac,fracinstep
@@ -723,7 +723,7 @@ subroutine print_timinginfo(iprint,nsteps,nsteplast)
  dfrac = 1./(timers(itimer_lastdump)%wall + epsilon(0._4))
  fracinstep = timers(itimer_step)%wall*dfrac
  if (fracinstep < 0.99) then
-    write(iprint,"(1x,a,f6.2,a)") 'WARNING: ',100.*(1.-fracinstep),'% of time was in unusual routines (not dens/force/link)'
+    write(iprint,"(1x,a,f6.2,a)") 'WARNING: ',100.*(1.-fracinstep),'% of time was in unusual routines (not dens/force/tree)'
  endif
 
 end subroutine print_timinginfo

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -49,7 +49,7 @@ module forces
  use dim, only:maxfsum,maxxpartveciforce,maxp,ndivcurlB,&
                maxdusttypes,maxdustsmall,do_radiation,maxpsph
  use mpiforce,    only:cellforce,stackforce
- use neighkdtree, only:ifirstincell
+ use neighkdtree, only:itypecell
  use kdtree,      only:inodeparts,inoderange
  use part,        only:iradxi,ifluxx,ifluxy,ifluxz,ikappa,ien_type,ien_entropy,ien_entropy_s
 
@@ -409,7 +409,7 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
 
 !$omp parallel default(none) &
 !$omp shared(maxp) &
-!$omp shared(ncells,ifirstincell) &
+!$omp shared(ncells,itypecell) &
 !$omp shared(xyzh) &
 !$omp shared(dustprop) &
 !$omp shared(dragreg) &
@@ -501,7 +501,7 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
 
  !$omp do schedule(runtime)
  over_cells: do icell=1,int(ncells)
-    i = ifirstincell(icell)
+    i = itypecell(icell)
 
     !--skip empty cells AND inactive cells
     if (i <= 0) cycle over_cells

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -193,7 +193,7 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
 
  use dim,          only:maxvxyzu,mhd,mhd_nonideal,mpi,use_dust,use_apr,use_sinktree
  use io,           only:iprint,fatal,iverbose,id,master,real4,warning,error,nprocs
- use neighkdtree,     only:ncells,get_neighbour_list,get_hmaxcell,get_cell_location,listneigh
+ use neighkdtree,  only:ncells,get_neighbour_list,get_hmaxcell,get_cell_location,listneigh
  use options,      only:iresistive_heating
  use part,         only:rhoh,dhdrho,rhoanddhdrho,alphaind,iactive,gradh,&
                         hrho,iphase,igas,maxgradh,dvdx,eta_nimhd,deltav,poten,iamtype,&
@@ -220,7 +220,7 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
 #ifdef GRAVITY
  use kernel,       only:kernel_softening
  use kdtree,       only:expand_fgrav_in_taylor_series
- use neighkdtree,     only:get_distance_from_centre_of_mass
+ use neighkdtree,  only:get_distance_from_centre_of_mass
  use part,         only:xyzmh_ptmass,nptmass,massoftype,maxphase,is_accretable,ihacc,aprmassoftype
  use ptmass,       only:icreate_sinks,rho_crit,r_crit2,h_acc
  use units,        only:unit_density

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -41,7 +41,7 @@ module forces
 !
 ! :Dependencies: boundary, cooling, dim, dust, eos, eos_shen,
 !   eos_stamatellos, fastmath, growth, io, io_summary, kdtree, kernel,
-!   neighkdtree, metric_tools, mpiderivs, mpiforce, mpimemory, mpiutils,
+!   metric_tools, mpiderivs, mpiforce, mpimemory, mpiutils, neighkdtree,
 !   nicil, omputils, options, part, physcon, ptmass, ptmass_heating,
 !   radiation_utils, timestep, timestep_ind, timestep_sts, timing, units,
 !   utils_gr, viscosity

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -41,17 +41,17 @@ module forces
 !
 ! :Dependencies: boundary, cooling, dim, dust, eos, eos_shen,
 !   eos_stamatellos, fastmath, growth, io, io_summary, kdtree, kernel,
-!   linklist, metric_tools, mpiderivs, mpiforce, mpimemory, mpiutils,
+!   neighkdtree, metric_tools, mpiderivs, mpiforce, mpimemory, mpiutils,
 !   nicil, omputils, options, part, physcon, ptmass, ptmass_heating,
 !   radiation_utils, timestep, timestep_ind, timestep_sts, timing, units,
 !   utils_gr, viscosity
 !
  use dim, only:maxfsum,maxxpartveciforce,maxp,ndivcurlB,&
                maxdusttypes,maxdustsmall,do_radiation,maxpsph
- use mpiforce, only:cellforce,stackforce
- use linklist, only:ifirstincell
- use kdtree,   only:inodeparts,inoderange
- use part,     only:iradxi,ifluxx,ifluxy,ifluxz,ikappa,ien_type,ien_entropy,ien_entropy_s
+ use mpiforce,    only:cellforce,stackforce
+ use neighkdtree, only:ifirstincell
+ use kdtree,      only:inodeparts,inoderange
+ use part,        only:iradxi,ifluxx,ifluxy,ifluxz,ikappa,ien_type,ien_entropy,ien_entropy_s
 
  implicit none
 
@@ -193,7 +193,7 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
 
  use dim,          only:maxvxyzu,mhd,mhd_nonideal,mpi,use_dust,use_apr,use_sinktree
  use io,           only:iprint,fatal,iverbose,id,master,real4,warning,error,nprocs
- use linklist,     only:ncells,get_neighbour_list,get_hmaxcell,get_cell_location,listneigh
+ use neighkdtree,     only:ncells,get_neighbour_list,get_hmaxcell,get_cell_location,listneigh
  use options,      only:iresistive_heating
  use part,         only:rhoh,dhdrho,rhoanddhdrho,alphaind,iactive,gradh,&
                         hrho,iphase,igas,maxgradh,dvdx,eta_nimhd,deltav,poten,iamtype,&
@@ -220,7 +220,7 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
 #ifdef GRAVITY
  use kernel,       only:kernel_softening
  use kdtree,       only:expand_fgrav_in_taylor_series
- use linklist,     only:get_distance_from_centre_of_mass
+ use neighkdtree,     only:get_distance_from_centre_of_mass
  use part,         only:xyzmh_ptmass,nptmass,massoftype,maxphase,is_accretable,ihacc,aprmassoftype
  use ptmass,       only:icreate_sinks,rho_crit,r_crit2,h_acc
  use units,        only:unit_density
@@ -2666,7 +2666,7 @@ subroutine finish_cell_and_store_results(icall,cell,fxyzu,xyzh,vxyzu,poten,dt,dv
 #endif
  use viscosity,      only:bulkvisc,dt_viscosity,irealvisc,shearfunc
  use kernel,         only:kernel_softening
- use linklist,       only:get_distance_from_centre_of_mass
+ use neighkdtree,    only:get_distance_from_centre_of_mass
  use kdtree,         only:expand_fgrav_in_taylor_series
  use nicil,          only:nicil_get_dudt_nimhd,nicil_get_dt_nimhd
  use timestep,       only:C_cour,C_cool,C_force,C_rad,C_ent,bignumber,dtmax

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -49,7 +49,7 @@ module forces
  use dim, only:maxfsum,maxxpartveciforce,maxp,ndivcurlB,&
                maxdusttypes,maxdustsmall,do_radiation,maxpsph
  use mpiforce,    only:cellforce,stackforce
- use neighkdtree, only:itypecell
+ use neighkdtree, only:leaf_is_active
  use kdtree,      only:inodeparts,inoderange
  use part,        only:iradxi,ifluxx,ifluxy,ifluxz,ikappa,ien_type,ien_entropy,ien_entropy_s
 
@@ -409,7 +409,7 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
 
 !$omp parallel default(none) &
 !$omp shared(maxp) &
-!$omp shared(ncells,itypecell) &
+!$omp shared(ncells,leaf_is_active) &
 !$omp shared(xyzh) &
 !$omp shared(dustprop) &
 !$omp shared(dragreg) &
@@ -501,10 +501,9 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
 
  !$omp do schedule(runtime)
  over_cells: do icell=1,int(ncells)
-    i = itypecell(icell)
 
     !--skip empty cells AND inactive cells
-    if (i <= 0) cycle over_cells
+    if (leaf_is_active(icell) <= 0) cycle over_cells
 
     cell%icell = icell
 

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -19,7 +19,7 @@ module initial
 !   cooling, cpuinfo, damping, densityforce, deriv, dim, dust,
 !   dust_formation, energies, eos, evwrite, extern_gr, externalforces,
 !   fastmath, fileutils, forcing, growth, inject, io, io_summary,
-!   krome_interface, linklist, metric, metric_et_utils, metric_tools,
+!   krome_interface, neighkdtree, metric, metric_et_utils, metric_tools,
 !   mf_write, mpibalance, mpidomain, mpimemory, mpitree, mpiutils, nicil,
 !   nicil_sup, omputils, options, part, partinject, porosity, ptmass,
 !   radiation_utils, readwrite_dumps, readwrite_infile, subgroup, timestep,
@@ -144,7 +144,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
 
  use part,             only:pxyzu,dens,metrics,rad,radprop,drad,ithick
  use densityforce,     only:densityiterate
- use linklist,         only:set_linklist
+ use neighkdtree,      only:build_tree
  use boundary_dyn,     only:dynamic_bdy,init_dynamic_bdy
  use part,             only:metricderivs,metricderivs_ptmass
  use cons2prim,        only:prim2consall
@@ -378,7 +378,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
 !
  if (mhd .or. use_dustfrac) then
     if (npart > 0) then
-       call set_linklist(npart,npart,xyzh,vxyzu)
+       call build_tree(npart,npart,xyzh,vxyzu)
        fxyzu = 0.
        call densityiterate(2,npart,npart,xyzh,vxyzu,divcurlv,divcurlB,Bevol,stressmax,&
                               fxyzu,fext,alphaind,gradh,rad,radprop,dvdx,apr_level)
@@ -459,7 +459,7 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
     endif
     ! --- Need rho computed by sum to do primitive to conservative, since dens is not read from file
     if (npart > 0) then
-       call set_linklist(npart,npart,xyzh,vxyzu)
+       call build_tree(npart,npart,xyzh,vxyzu)
        fxyzu = 0.
        call densityiterate(2,npart,npart,xyzh,vxyzu,divcurlv,divcurlB,Bevol,stressmax,&
                               fxyzu,fext,alphaind,gradh,rad,radprop,dvdx,apr_level)

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -19,11 +19,11 @@ module initial
 !   cooling, cpuinfo, damping, densityforce, deriv, dim, dust,
 !   dust_formation, energies, eos, evwrite, extern_gr, externalforces,
 !   fastmath, fileutils, forcing, growth, inject, io, io_summary,
-!   krome_interface, neighkdtree, metric, metric_et_utils, metric_tools,
-!   mf_write, mpibalance, mpidomain, mpimemory, mpitree, mpiutils, nicil,
-!   nicil_sup, omputils, options, part, partinject, porosity, ptmass,
-!   radiation_utils, readwrite_dumps, readwrite_infile, subgroup, timestep,
-!   timestep_ind, timestep_sts, timing, units, writeheader
+!   krome_interface, metric, metric_et_utils, metric_tools, mf_write,
+!   mpibalance, mpidomain, mpimemory, mpitree, mpiutils, neighkdtree,
+!   nicil, nicil_sup, omputils, options, part, partinject, porosity,
+!   ptmass, radiation_utils, readwrite_dumps, readwrite_infile, subgroup,
+!   timestep, timestep_ind, timestep_sts, timing, units, writeheader
 !
 
  implicit none

--- a/src/main/kdtree.F90
+++ b/src/main/kdtree.F90
@@ -99,7 +99,7 @@ end subroutine deallocate_kdtree
 !  Notes/To do:
 !  -openMP parallelisation of maketree_stack (done - April 2013)
 !  -test centre of mass vs. geometric centre based cell sizes (done - 2013)
-!  -need analysis module that times (and checks) set_linklist and tree walk
+!  -need analysis module that times (and checks) build_tree and tree walk
 !   for a given dump
 !  -test bottom-up vs. top-down neighbour search
 !  -should we try to store tree structure with particle arrays?

--- a/src/main/kdtree.F90
+++ b/src/main/kdtree.F90
@@ -173,7 +173,7 @@ subroutine maketree(node, xyzh, np, ndim, itypecell, ncells, apr_tree, refinelev
  ! and is decreased afterwards according to the maximum depth actually reached
  ncells = 2**(maxlevel_indexed+1) - 1
 
- ! need to number of particles in node during build to allocate space for local link list
+ ! need to number of particles in node during build
  ! this is counted above to remove dead/accreted particles
  call push_onto_stack(queue(istack),irootnode,0,0,npcounter,xmini,xmaxi,ndim)
 
@@ -812,8 +812,7 @@ subroutine construct_node(nodeentry, nnode, mymum, level, xmini, xmaxi, npnode, 
     nodeentry%rightchild = 0
     maxlevel = max(level,maxlevel)
     minlevel = min(level,minlevel)
-    !--filling link list here is unnecessary (already filled)
-    !  except with individual timesteps where we mark leaf node as active/inactive
+    ! individual timesteps where we mark leaf node as active/inactive
 #ifdef IND_TIMESTEPS
     !
     !--mark leaf node as active (contains some active particles)

--- a/src/main/memory.f90
+++ b/src/main/memory.f90
@@ -29,7 +29,7 @@ subroutine allocate_memory(ntot, part_only)
  use dim,         only:update_max_sizes,maxp,mpi
  use allocutils,  only:nbytes_allocated,bytes2human
  use part,        only:allocate_part
- use neighkdtree, only:allocate_neigh,itypecell
+ use neighkdtree, only:allocate_neigh,leaf_is_active
  use mpimemory,   only:allocate_mpi_memory
  use mpibalance,  only:allocate_balance_arrays
  use mpiderivs,   only:allocate_cell_comms_arrays
@@ -56,7 +56,7 @@ subroutine allocate_memory(ntot, part_only)
     ! but make sure additional arrays are allocated
     ! (this catches the case where first call was made with part_only=.true.)
     !
-    if (.not.part_only_ .and. .not. allocated(itypecell)) then
+    if (.not.part_only_ .and. .not. allocated(leaf_is_active)) then
        !write(iprint, '(a)') '--> ALLOCATING KDTREE ARRAYS' ! no need to broadcast this
        call allocate_neigh()
     endif

--- a/src/main/memory.f90
+++ b/src/main/memory.f90
@@ -14,8 +14,8 @@ module memory
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: allocutils, dim, io, neighkdtree, mpibalance, mpiderivs,
-!   mpimemory, mpitree, part
+! :Dependencies: allocutils, dim, io, mpibalance, mpiderivs, mpimemory,
+!   mpitree, neighkdtree, part
 !
  implicit none
 

--- a/src/main/memory.f90
+++ b/src/main/memory.f90
@@ -29,7 +29,7 @@ subroutine allocate_memory(ntot, part_only)
  use dim,         only:update_max_sizes,maxp,mpi
  use allocutils,  only:nbytes_allocated,bytes2human
  use part,        only:allocate_part
- use neighkdtree, only:allocate_neigh,ifirstincell
+ use neighkdtree, only:allocate_neigh,itypecell
  use mpimemory,   only:allocate_mpi_memory
  use mpibalance,  only:allocate_balance_arrays
  use mpiderivs,   only:allocate_cell_comms_arrays
@@ -56,7 +56,7 @@ subroutine allocate_memory(ntot, part_only)
     ! but make sure additional arrays are allocated
     ! (this catches the case where first call was made with part_only=.true.)
     !
-    if (.not.part_only_ .and. .not. allocated(ifirstincell)) then
+    if (.not.part_only_ .and. .not. allocated(itypecell)) then
        !write(iprint, '(a)') '--> ALLOCATING KDTREE ARRAYS' ! no need to broadcast this
        call allocate_neigh()
     endif

--- a/src/main/memory.f90
+++ b/src/main/memory.f90
@@ -14,7 +14,7 @@ module memory
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: allocutils, dim, io, linklist, mpibalance, mpiderivs,
+! :Dependencies: allocutils, dim, io, neighkdtree, mpibalance, mpiderivs,
 !   mpimemory, mpitree, part
 !
  implicit none
@@ -25,15 +25,15 @@ contains
  !--Allocate all allocatable arrays: mostly part arrays, and tree structures
  !
 subroutine allocate_memory(ntot, part_only)
- use io,         only:iprint,warning,nprocs,id,master
- use dim,        only:update_max_sizes,maxp,mpi
- use allocutils, only:nbytes_allocated,bytes2human
- use part,       only:allocate_part
- use linklist,   only:allocate_linklist,ifirstincell
- use mpimemory,  only:allocate_mpi_memory
- use mpibalance, only:allocate_balance_arrays
- use mpiderivs,  only:allocate_cell_comms_arrays
- use mpitree,    only:allocate_tree_comms_arrays
+ use io,          only:iprint,warning,nprocs,id,master
+ use dim,         only:update_max_sizes,maxp,mpi
+ use allocutils,  only:nbytes_allocated,bytes2human
+ use part,        only:allocate_part
+ use neighkdtree, only:allocate_linklist,ifirstincell
+ use mpimemory,   only:allocate_mpi_memory
+ use mpibalance,  only:allocate_balance_arrays
+ use mpiderivs,   only:allocate_cell_comms_arrays
+ use mpitree,     only:allocate_tree_comms_arrays
 
  integer(kind=8),   intent(in) :: ntot
  logical, optional, intent(in) :: part_only
@@ -104,14 +104,14 @@ subroutine allocate_memory(ntot, part_only)
 end subroutine allocate_memory
 
 subroutine deallocate_memory(part_only)
- use dim, only:update_max_sizes,mpi
- use part, only:deallocate_part
- use linklist, only:deallocate_linklist
- use mpimemory,  only:deallocate_mpi_memory
- use mpibalance, only:deallocate_balance_arrays
- use mpiderivs,  only:deallocate_cell_comms_arrays
- use mpitree,    only:deallocate_tree_comms_arrays
- use allocutils, only:nbytes_allocated
+ use dim,         only:update_max_sizes,mpi
+ use part,        only:deallocate_part
+ use neighkdtree, only:deallocate_linklist
+ use mpimemory,   only:deallocate_mpi_memory
+ use mpibalance,  only:deallocate_balance_arrays
+ use mpiderivs,   only:deallocate_cell_comms_arrays
+ use mpitree,     only:deallocate_tree_comms_arrays
+ use allocutils,  only:nbytes_allocated
 
  logical, optional, intent(in) :: part_only
  logical :: part_only_

--- a/src/main/memory.f90
+++ b/src/main/memory.f90
@@ -29,7 +29,7 @@ subroutine allocate_memory(ntot, part_only)
  use dim,         only:update_max_sizes,maxp,mpi
  use allocutils,  only:nbytes_allocated,bytes2human
  use part,        only:allocate_part
- use neighkdtree, only:allocate_linklist,ifirstincell
+ use neighkdtree, only:allocate_neigh,ifirstincell
  use mpimemory,   only:allocate_mpi_memory
  use mpibalance,  only:allocate_balance_arrays
  use mpiderivs,   only:allocate_cell_comms_arrays
@@ -58,7 +58,7 @@ subroutine allocate_memory(ntot, part_only)
     !
     if (.not.part_only_ .and. .not. allocated(ifirstincell)) then
        !write(iprint, '(a)') '--> ALLOCATING KDTREE ARRAYS' ! no need to broadcast this
-       call allocate_linklist()
+       call allocate_neigh()
     endif
     ! skip remaining memory allocation (arrays already big enough)
     return
@@ -82,7 +82,7 @@ subroutine allocate_memory(ntot, part_only)
  call update_max_sizes(n,ntot)
  call allocate_part
  if (.not. part_only_) then
-    call allocate_linklist
+    call allocate_neigh
     if (mpi) then
        call allocate_mpi_memory(npart=n)
        call allocate_balance_arrays
@@ -106,7 +106,7 @@ end subroutine allocate_memory
 subroutine deallocate_memory(part_only)
  use dim,         only:update_max_sizes,mpi
  use part,        only:deallocate_part
- use neighkdtree, only:deallocate_linklist
+ use neighkdtree, only:deallocate_neigh
  use mpimemory,   only:deallocate_mpi_memory
  use mpibalance,  only:deallocate_balance_arrays
  use mpiderivs,   only:deallocate_cell_comms_arrays
@@ -124,7 +124,7 @@ subroutine deallocate_memory(part_only)
 
  call deallocate_part
  if (.not. part_only_) then
-    call deallocate_linklist
+    call deallocate_neigh
  endif
 
  if (mpi) then

--- a/src/main/neigh_kdtree.f90
+++ b/src/main/neigh_kdtree.f90
@@ -25,18 +25,18 @@ module neighkdtree
  use dtypekdtree,  only:kdnode
  implicit none
 
- integer,                  allocatable :: cellatid(:)
- integer,         public,  allocatable :: itypecell(:) ! : 0 internal node or empty cell, : 1 active cell, :- inactive cell
- type(kdnode),             allocatable :: nodeglobal(:)
- type(kdnode),    public,  allocatable :: node(:)
- integer,                  allocatable :: nodemap(:)
- integer,         public , allocatable :: listneigh(:)
- integer,         public , allocatable :: listneigh_global(:)
+ integer,               allocatable :: cellatid(:)
+ integer,               allocatable :: nodemap(:)
+ type(kdnode),          allocatable :: nodeglobal(:)
+ type(kdnode), public,  allocatable :: node(:)
+ integer,      public,  allocatable :: itypecell(:) ! : 0 internal node or empty cell, : 1 active cell, :- inactive cell
+ integer,      public , allocatable :: listneigh(:)
+ integer,      public , allocatable :: listneigh_global(:)
 !$omp threadprivate(listneigh)
- integer(kind=8), public               :: ncells
- real, public                          :: dxcell
- real, public                          :: dcellx = 0.,dcelly = 0.,dcellz = 0.
- integer                               :: globallevel,refinelevels
+ integer(kind=8), public            :: ncells
+ real, public                       :: dxcell
+ real, public                       :: dcellx = 0.,dcelly = 0.,dcellz = 0.
+ integer                            :: globallevel,refinelevels
 
  public :: allocate_neigh, deallocate_neigh
  public :: build_tree, get_neighbour_list, write_inopts_tree, read_inopts_tree
@@ -54,11 +54,11 @@ subroutine allocate_neigh
  use kdtree,     only:allocate_kdtree
  use dim,        only:maxp
 
- call allocate_array('cellatid',     cellatid,     ncellsmaxglobal+1 )
- call allocate_array('itypecell', itypecell, ncellsmax+1       )
- call allocate_array('nodeglobal',   nodeglobal,   ncellsmaxglobal+1 )
- call allocate_array('node',         node,         ncellsmax+1       )
- call allocate_array('nodemap',      nodemap,      ncellsmax+1       )
+ call allocate_array('cellatid',   cellatid,  ncellsmaxglobal+1 )
+ call allocate_array('itypecell',  itypecell, ncellsmax+1       )
+ call allocate_array('nodeglobal', nodeglobal,ncellsmaxglobal+1 )
+ call allocate_array('node',       node,      ncellsmax+1       )
+ call allocate_array('nodemap',    nodemap,   ncellsmax+1       )
  call allocate_kdtree()
 !$omp parallel
  call allocate_array('listneigh',listneigh,maxp)

--- a/src/main/neigh_kdtree.f90
+++ b/src/main/neigh_kdtree.f90
@@ -7,7 +7,7 @@
 module neighkdtree
 !
 ! This module contains all routines required for
-!  link-list based neighbour-finding
+!  tree based neighbour-finding
 !
 !  THIS VERSION USES A K-D TREE
 !
@@ -40,7 +40,7 @@ module neighkdtree
  integer              :: globallevel,refinelevels
 
  public :: allocate_neigh, deallocate_neigh
- public :: build_tree, get_neighbour_list, write_inopts_link, read_inopts_link
+ public :: build_tree, get_neighbour_list, write_inopts_tree, read_inopts_tree
  public :: get_distance_from_centre_of_mass, getneigh_pos
  public :: set_hmaxcell,get_hmaxcell,update_hmax_remote
  public :: get_cell_location
@@ -300,7 +300,7 @@ end subroutine getneigh_pos
 !  writes input options to the input file
 !+
 !-----------------------------------------------------------------------
-subroutine write_inopts_link(iunit)
+subroutine write_inopts_tree(iunit)
  use kdtree,       only:tree_accuracy
  use infile_utils, only:write_inopt
  use part,         only:gravity
@@ -310,14 +310,14 @@ subroutine write_inopts_link(iunit)
     call write_inopt(tree_accuracy,'tree_accuracy','tree opening criterion (0.0-1.0)',iunit)
  endif
 
-end subroutine write_inopts_link
+end subroutine write_inopts_tree
 
 !-----------------------------------------------------------------------
 !+
 !  reads input options from the input file
 !+
 !-----------------------------------------------------------------------
-subroutine read_inopts_link(name,valstring,imatch,igotall,ierr)
+subroutine read_inopts_tree(name,valstring,imatch,igotall,ierr)
  use kdtree, only:tree_accuracy
  use part,   only:gravity
  use io,     only:fatal
@@ -344,7 +344,7 @@ subroutine read_inopts_link(name,valstring,imatch,igotall,ierr)
     if (ngot >= 1) igotall = .true.
  endif
 
-end subroutine read_inopts_link
+end subroutine read_inopts_tree
 
 subroutine get_cell_location(inode,xpos,xsizei,rcuti)
  use kernel, only:radkern

--- a/src/main/neigh_kdtree.f90
+++ b/src/main/neigh_kdtree.f90
@@ -26,7 +26,7 @@ module neighkdtree
  implicit none
 
  integer,               allocatable :: cellatid(:)
- integer,     public,   allocatable :: ifirstincell(:)
+ integer,     public,   allocatable :: itypecell(:) ! : 0 internal node or empty cell, : 1 active cell, :- inactive cell
  type(kdnode),          allocatable :: nodeglobal(:)
  type(kdnode), public,  allocatable :: node(:)
  integer,               allocatable :: nodemap(:)
@@ -56,7 +56,7 @@ subroutine allocate_neigh
  use dim,        only:maxp
 
  call allocate_array('cellatid',     cellatid,     ncellsmaxglobal+1 )
- call allocate_array('ifirstincell', ifirstincell, ncellsmax+1       )
+ call allocate_array('itypecell', itypecell, ncellsmax+1       )
  call allocate_array('nodeglobal',   nodeglobal,   ncellsmaxglobal+1 )
  call allocate_array('node',         node,         ncellsmax+1       )
  call allocate_array('nodemap',      nodemap,      ncellsmax+1       )
@@ -72,7 +72,7 @@ subroutine deallocate_neigh
  use kdtree,   only:deallocate_kdtree
 
  if (allocated(cellatid)) deallocate(cellatid)
- if (allocated(ifirstincell)) deallocate(ifirstincell)
+ if (allocated(itypecell)) deallocate(itypecell)
  if (allocated(nodeglobal)) deallocate(nodeglobal)
  if (allocated(node)) deallocate(node)
  if (allocated(nodemap)) deallocate(nodemap)
@@ -116,9 +116,9 @@ subroutine update_hmax_remote(ncells)
  integer :: n,j
  real :: hmaxcell
 
- ! could do only active cells by checking ifirstincell >= 0
+ ! could do only active cells by checking itypecell >= 0
  do n=1,int(ncells)
-    if (ifirstincell(n) > 0) then
+    if (itypecell(n) > 0) then
        ! reduce on leaf nodes
        node(n)%hmax = reduceall_mpi('max',node(n)%hmax)
 
@@ -180,17 +180,17 @@ subroutine build_tree(npart,nactive,xyzh,vxyzu,for_apr)
 
  if (mpi .and. nprocs > 1) then
     if (use_sinktree) then
-       call maketreeglobal(nodeglobal,node,nodemap,globallevel,refinelevels,xyzh,npart,ndimtree,cellatid,ifirstincell,ncells,&
+       call maketreeglobal(nodeglobal,node,nodemap,globallevel,refinelevels,xyzh,npart,ndimtree,cellatid,itypecell,ncells,&
                            apr_tree,nptmass,xyzmh_ptmass)
     else
-       call maketreeglobal(nodeglobal,node,nodemap,globallevel,refinelevels,xyzh,npart,ndimtree,cellatid,ifirstincell,ncells,&
+       call maketreeglobal(nodeglobal,node,nodemap,globallevel,refinelevels,xyzh,npart,ndimtree,cellatid,itypecell,ncells,&
                            apr_tree)
     endif
  else
     if (use_sinktree) then
-       call maketree(node,xyzh,npart,ndimtree,ifirstincell,ncells,apr_tree,nptmass=nptmass,xyzmh_ptmass=xyzmh_ptmass)
+       call maketree(node,xyzh,npart,ndimtree,itypecell,ncells,apr_tree,nptmass=nptmass,xyzmh_ptmass=xyzmh_ptmass)
     else
-       call maketree(node,xyzh,npart,ndimtree,ifirstincell,ncells,apr_tree)
+       call maketree(node,xyzh,npart,ndimtree,itypecell,ncells,apr_tree)
     endif
  endif
 
@@ -270,13 +270,13 @@ subroutine get_neighbour_list(inode,mylistneigh,nneigh,xyzh,xyzcache,ixyzcachesi
 
  ! Find neighbours of this cell on this node
  call getneigh(node,xpos,xsizei,rcuti,3,mylistneigh,nneigh,xyzcache,ixyzcachesize,&
-              ifirstincell,get_j,get_f,fgrav)
+              itypecell,get_j,get_f,fgrav)
 
  if (get_f) f = fgrav + fgrav_global
 
 end subroutine get_neighbour_list
 
-subroutine getneigh_pos(xpos,xsizei,rcuti,ndim,mylistneigh,nneigh,xyzcache,ixyzcachesize,ifirstincell,get_j)
+subroutine getneigh_pos(xpos,xsizei,rcuti,ndim,mylistneigh,nneigh,xyzcache,ixyzcachesize,itypecell,get_j)
  use kdtree, only:getneigh
  integer, intent(in)  :: ndim,ixyzcachesize
  real,    intent(in)  :: xpos(ndim)
@@ -284,14 +284,14 @@ subroutine getneigh_pos(xpos,xsizei,rcuti,ndim,mylistneigh,nneigh,xyzcache,ixyzc
  integer, intent(out) :: mylistneigh(:)
  integer, intent(out) :: nneigh
  real,    intent(out) :: xyzcache(:,:)
- integer, intent(in)  :: ifirstincell(:) !ncellsmax+1)
+ integer, intent(in)  :: itypecell(:) !ncellsmax+1)
  logical, intent(in), optional :: get_j
  logical :: getj
 
  getj = .false.
  if (present(get_j)) getj=get_j
  call getneigh(node,xpos,xsizei,rcuti,ndim,mylistneigh,nneigh,xyzcache,ixyzcachesize, &
-               ifirstincell,getj,.false.)
+               itypecell,getj,.false.)
 
 end subroutine getneigh_pos
 

--- a/src/main/neigh_kdtree.f90
+++ b/src/main/neigh_kdtree.f90
@@ -25,19 +25,18 @@ module neighkdtree
  use dtypekdtree,  only:kdnode
  implicit none
 
- integer,               allocatable :: cellatid(:)
- integer,     public,   allocatable :: itypecell(:) ! : 0 internal node or empty cell, : 1 active cell, :- inactive cell
- type(kdnode),          allocatable :: nodeglobal(:)
- type(kdnode), public,  allocatable :: node(:)
- integer,               allocatable :: nodemap(:)
- integer,      public ,            allocatable :: listneigh(:)
- integer,      public ,            allocatable :: listneigh_global(:)
+ integer,                  allocatable :: cellatid(:)
+ integer,         public,  allocatable :: itypecell(:) ! : 0 internal node or empty cell, : 1 active cell, :- inactive cell
+ type(kdnode),             allocatable :: nodeglobal(:)
+ type(kdnode),    public,  allocatable :: node(:)
+ integer,                  allocatable :: nodemap(:)
+ integer,         public , allocatable :: listneigh(:)
+ integer,         public , allocatable :: listneigh_global(:)
 !$omp threadprivate(listneigh)
- integer(kind=8), public :: ncells
- real, public            :: dxcell
- real, public :: dcellx = 0.,dcelly = 0.,dcellz = 0.
-
- integer              :: globallevel,refinelevels
+ integer(kind=8), public               :: ncells
+ real, public                          :: dxcell
+ real, public                          :: dcellx = 0.,dcelly = 0.,dcellz = 0.
+ integer                               :: globallevel,refinelevels
 
  public :: allocate_neigh, deallocate_neigh
  public :: build_tree, get_neighbour_list, write_inopts_tree, read_inopts_tree

--- a/src/main/neigh_kdtree.f90
+++ b/src/main/neigh_kdtree.f90
@@ -4,7 +4,7 @@
 ! See LICENCE file for usage and distribution conditions                   !
 ! http://phantomsph.github.io/                                             !
 !--------------------------------------------------------------------------!
-module linklist
+module neighkdtree
 !
 ! This module contains all routines required for
 !  link-list based neighbour-finding
@@ -22,7 +22,6 @@ module linklist
 !   kdtree, kernel, mpiutils, part
 !
  use dim,          only:ncellsmax,ncellsmaxglobal
- use part,         only:ll
  use dtypekdtree,  only:kdnode
  implicit none
 
@@ -40,8 +39,8 @@ module linklist
 
  integer              :: globallevel,refinelevels
 
- public :: allocate_linklist, deallocate_linklist
- public :: set_linklist, get_neighbour_list, write_inopts_link, read_inopts_link
+ public :: allocate_neigh, deallocate_neigh
+ public :: build_tree, get_neighbour_list, write_inopts_link, read_inopts_link
  public :: get_distance_from_centre_of_mass, getneigh_pos
  public :: set_hmaxcell,get_hmaxcell,update_hmax_remote
  public :: get_cell_location
@@ -51,7 +50,7 @@ module linklist
 
 contains
 
-subroutine allocate_linklist
+subroutine allocate_neigh
  use allocutils, only:allocate_array
  use kdtree,     only:allocate_kdtree
  use dim,        only:maxp
@@ -67,9 +66,9 @@ subroutine allocate_linklist
 !$omp end parallel
  call allocate_array('listneigh_global',listneigh_global,maxp)
 
-end subroutine allocate_linklist
+end subroutine allocate_neigh
 
-subroutine deallocate_linklist
+subroutine deallocate_neigh
  use kdtree,   only:deallocate_kdtree
 
  if (allocated(cellatid)) deallocate(cellatid)
@@ -83,7 +82,7 @@ subroutine deallocate_linklist
  if (allocated(listneigh_global)) deallocate(listneigh_global)
  call deallocate_kdtree()
 
-end subroutine deallocate_linklist
+end subroutine deallocate_neigh
 
 subroutine get_hmaxcell(inode,hmaxcell)
  integer, intent(in)  :: inode
@@ -153,7 +152,7 @@ subroutine get_distance_from_centre_of_mass(inode,xi,yi,zi,dx,dy,dz,xcen)
 
 end subroutine get_distance_from_centre_of_mass
 
-subroutine set_linklist(npart,nactive,xyzh,vxyzu,for_apr)
+subroutine build_tree(npart,nactive,xyzh,vxyzu,for_apr)
  use io,           only:nprocs
  use dtypekdtree,  only:ndimtree
  use kdtree,       only:maketree,maketreeglobal
@@ -195,7 +194,7 @@ subroutine set_linklist(npart,nactive,xyzh,vxyzu,for_apr)
     endif
  endif
 
-end subroutine set_linklist
+end subroutine build_tree
 
 !-----------------------------------------------------------------------
 !+
@@ -391,4 +390,4 @@ subroutine sync_hmax_mpi
 
 end subroutine sync_hmax_mpi
 
-end module linklist
+end module neighkdtree

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -1146,7 +1146,7 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,pxyzu,fxyzu,fext,divcurlv,pote
  use boundary,      only:dxbound,dybound,dzbound
 #endif
  use part,          only:ibin,ibin_wake
- use neighkdtree,   only:getneigh_pos,ifirstincell,listneigh=>listneigh_global
+ use neighkdtree,   only:getneigh_pos,itypecell,listneigh=>listneigh_global
  use eos,           only:gamma
  use eos_barotropic,only:gamma_barotropic
  use eos_piecewise, only:gamma_pwp
@@ -1303,7 +1303,7 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,pxyzu,fxyzu,fext,divcurlv,pote
 
  ! CHECK 3: all neighbours are all active ( & perform math for checks 4-6)
  ! find neighbours within the checking radius of hcheck
- call getneigh_pos((/xi,yi,zi/),0.,hcheck,3,listneigh,nneigh,xyzcache,maxcache,ifirstincell)
+ call getneigh_pos((/xi,yi,zi/),0.,hcheck,3,listneigh,nneigh,xyzcache,maxcache,itypecell)
  ! determine if we should approximate epot
  calc_exact_epot = .true.
  if ((nneigh_thresh > 0 .and. nneigh > nneigh_thresh) .or. (nprocs > 1)) calc_exact_epot = .false.

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -39,7 +39,7 @@ module ptmass
 ! :Dependencies: HIIRegion, boundary, densityforce, dim, eos,
 !   eos_barotropic, eos_piecewise, extern_geopot, extern_gr,
 !   externalforces, fastmath, infile_utils, io, io_summary, kdtree, kernel,
-!   neighkdtree, metric_tools, mpidomain, mpiutils, options, part, physcon,
+!   metric_tools, mpidomain, mpiutils, neighkdtree, options, part, physcon,
 !   ptmass_heating, random, subgroup, timestep, units, utils_kepler,
 !   vectorutils
 !

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -39,7 +39,7 @@ module ptmass
 ! :Dependencies: HIIRegion, boundary, densityforce, dim, eos,
 !   eos_barotropic, eos_piecewise, extern_geopot, extern_gr,
 !   externalforces, fastmath, infile_utils, io, io_summary, kdtree, kernel,
-!   linklist, metric_tools, mpidomain, mpiutils, options, part, physcon,
+!   neighkdtree, metric_tools, mpidomain, mpiutils, options, part, physcon,
 !   ptmass_heating, random, subgroup, timestep, units, utils_kepler,
 !   vectorutils
 !
@@ -1146,7 +1146,7 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,pxyzu,fxyzu,fext,divcurlv,pote
  use boundary,      only:dxbound,dybound,dzbound
 #endif
  use part,          only:ibin,ibin_wake
- use linklist,      only:getneigh_pos,ifirstincell,listneigh=>listneigh_global
+ use neighkdtree,   only:getneigh_pos,ifirstincell,listneigh=>listneigh_global
  use eos,           only:gamma
  use eos_barotropic,only:gamma_barotropic
  use eos_piecewise, only:gamma_pwp

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -1146,7 +1146,7 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,pxyzu,fxyzu,fext,divcurlv,pote
  use boundary,      only:dxbound,dybound,dzbound
 #endif
  use part,          only:ibin,ibin_wake
- use neighkdtree,   only:getneigh_pos,itypecell,listneigh=>listneigh_global
+ use neighkdtree,   only:getneigh_pos,leaf_is_active,listneigh=>listneigh_global
  use eos,           only:gamma
  use eos_barotropic,only:gamma_barotropic
  use eos_piecewise, only:gamma_pwp
@@ -1303,7 +1303,7 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,pxyzu,fxyzu,fext,divcurlv,pote
 
  ! CHECK 3: all neighbours are all active ( & perform math for checks 4-6)
  ! find neighbours within the checking radius of hcheck
- call getneigh_pos((/xi,yi,zi/),0.,hcheck,3,listneigh,nneigh,xyzcache,maxcache,itypecell)
+ call getneigh_pos((/xi,yi,zi/),0.,hcheck,3,listneigh,nneigh,xyzcache,maxcache,leaf_is_active)
  ! determine if we should approximate epot
  calc_exact_epot = .true.
  if ((nneigh_thresh > 0 .and. nneigh > nneigh_thresh) .or. (nprocs > 1)) calc_exact_epot = .false.

--- a/src/main/radiation_implicit.f90
+++ b/src/main/radiation_implicit.f90
@@ -271,7 +271,7 @@ end subroutine do_radiation_onestep
 !---------------------------------------------------------
 subroutine get_compacted_neighbour_list(xyzh,ivar,ijvar,ncompact,ncompactlocal)
  use dim,         only:periodic,maxphase,maxp,maxpsph
- use neighkdtree, only:ncells,get_neighbour_list,listneigh,itypecell
+ use neighkdtree, only:ncells,get_neighbour_list,listneigh,leaf_is_active
  use kdtree,      only:inodeparts,inoderange
  use boundary,    only:dxbound,dybound,dzbound
  use part,        only:iphase,igas,iboundary,get_partinfo,isdead_or_accreted
@@ -300,16 +300,15 @@ subroutine get_compacted_neighbour_list(xyzh,ivar,ijvar,ncompact,ncompactlocal)
  icompact = 0
  icompactmax = size(ijvar)
  !$omp parallel do default(none) schedule(runtime)&
- !$omp shared(ncells,xyzh,inodeparts,inoderange,iphase,dxbound,dybound,dzbound,itypecell)&
+ !$omp shared(ncells,xyzh,inodeparts,inoderange,iphase,dxbound,dybound,dzbound,leaf_is_active)&
  !$omp shared(ivar,ijvar,ncompact,icompact,icompactmax,maxphase,maxp,maxpsph)&
  !$omp private(icell,i,j,k,n,ip,iactivei,iamgasi,iamdusti,iamtypei,dx,dy,dz,rij2,q2i,q2j)&
  !$omp private(hi,xi,yi,zi,hi21,hj1,ncompact_private,icompact_private,nneigh_trial,nneigh)
 
  over_cells: do icell=1,int(ncells)
-    i = itypecell(icell)
 
     !--skip empty cells AND inactive cells
-    if (i <= 0) cycle over_cells
+    if (leaf_is_active(icell) <= 0) cycle over_cells
 
     !
     !--get the neighbour list and fill the cell cache

--- a/src/main/radiation_implicit.f90
+++ b/src/main/radiation_implicit.f90
@@ -19,7 +19,7 @@ module radiation_implicit
 ! :Runtime parameters: None
 !
 ! :Dependencies: boundary, derivutils, dim, eos, implicit, io, kdtree,
-!   kernel, linklist, options, part, physcon, quartic, radiation_utils,
+!   kernel, neighkdtree, options, part, physcon, quartic, radiation_utils,
 !   timing, units
 !
  use part,            only:ikappa,ilambda,iedd,idkappa,iradxi,icv,ifluxx,ifluxy,ifluxz,igas,rhoh,massoftype,imu
@@ -181,7 +181,7 @@ subroutine do_radiation_onestep(dt,npart,rad,xyzh,vxyzu,radprop,origEU,EU0,faile
 
  ! check for errors
  if (ncompact <= 0 .or. ncompactlocal <= 0) then
-    call error('radiation_implicit','empty neighbour list - need to call set_linklist first?')
+    call error('radiation_implicit','empty neighbour list - need to call build_tree first?')
     ierr = ierr_neighbourlist_empty
     return
  endif
@@ -270,13 +270,13 @@ end subroutine do_radiation_onestep
 !+
 !---------------------------------------------------------
 subroutine get_compacted_neighbour_list(xyzh,ivar,ijvar,ncompact,ncompactlocal)
- use dim,      only:periodic,maxphase,maxp,maxpsph
- use linklist, only:ncells,get_neighbour_list,listneigh,ifirstincell
- use kdtree,   only:inodeparts,inoderange
- use boundary, only:dxbound,dybound,dzbound
- use part,     only:iphase,igas,iboundary,get_partinfo,isdead_or_accreted
- use kernel,   only:radkern2
- use io,       only:fatal
+ use dim,         only:periodic,maxphase,maxp,maxpsph
+ use neighkdtree, only:ncells,get_neighbour_list,listneigh,ifirstincell
+ use kdtree,      only:inodeparts,inoderange
+ use boundary,    only:dxbound,dybound,dzbound
+ use part,        only:iphase,igas,iboundary,get_partinfo,isdead_or_accreted
+ use kernel,      only:radkern2
+ use io,          only:fatal
  real, intent(in)                  :: xyzh(:,:)
  integer, intent(out)              :: ivar(:,:),ijvar(:)
  integer, intent(out)              :: ncompact,ncompactlocal

--- a/src/main/radiation_implicit.f90
+++ b/src/main/radiation_implicit.f90
@@ -271,7 +271,7 @@ end subroutine do_radiation_onestep
 !---------------------------------------------------------
 subroutine get_compacted_neighbour_list(xyzh,ivar,ijvar,ncompact,ncompactlocal)
  use dim,         only:periodic,maxphase,maxp,maxpsph
- use neighkdtree, only:ncells,get_neighbour_list,listneigh,ifirstincell
+ use neighkdtree, only:ncells,get_neighbour_list,listneigh,itypecell
  use kdtree,      only:inodeparts,inoderange
  use boundary,    only:dxbound,dybound,dzbound
  use part,        only:iphase,igas,iboundary,get_partinfo,isdead_or_accreted
@@ -300,13 +300,13 @@ subroutine get_compacted_neighbour_list(xyzh,ivar,ijvar,ncompact,ncompactlocal)
  icompact = 0
  icompactmax = size(ijvar)
  !$omp parallel do default(none) schedule(runtime)&
- !$omp shared(ncells,xyzh,inodeparts,inoderange,iphase,dxbound,dybound,dzbound,ifirstincell)&
+ !$omp shared(ncells,xyzh,inodeparts,inoderange,iphase,dxbound,dybound,dzbound,itypecell)&
  !$omp shared(ivar,ijvar,ncompact,icompact,icompactmax,maxphase,maxp,maxpsph)&
  !$omp private(icell,i,j,k,n,ip,iactivei,iamgasi,iamdusti,iamtypei,dx,dy,dz,rij2,q2i,q2j)&
  !$omp private(hi,xi,yi,zi,hi21,hj1,ncompact_private,icompact_private,nneigh_trial,nneigh)
 
  over_cells: do icell=1,int(ncells)
-    i = ifirstincell(icell)
+    i = itypecell(icell)
 
     !--skip empty cells AND inactive cells
     if (i <= 0) cycle over_cells

--- a/src/main/readwrite_infile.f90
+++ b/src/main/readwrite_infile.f90
@@ -105,7 +105,7 @@ subroutine write_infile(infile,logfile,evfile,dumpfile,iwritein,iprint)
  use forcing,         only:write_options_forcing
  use externalforces,  only:write_options_externalforces
  use damping,         only:write_options_damping
- use neighkdtree,     only:write_inopts_link
+ use neighkdtree,     only:write_inopts_tree
  use dust,            only:write_options_dust
  use growth,          only:write_options_growth
  use porosity,        only:write_options_porosity
@@ -188,7 +188,7 @@ subroutine write_infile(infile,logfile,evfile,dumpfile,iwritein,iprint)
     call write_inopt(ptol,'ptol','tolerance on pmom iterations',iwritein)
  endif
 
- call write_inopts_link(iwritein)
+ call write_inopts_tree(iwritein)
 
  write(iwritein,"(/,a)") '# options controlling hydrodynamics, shock capturing'
  if (maxalpha==maxp .and. nalpha > 0) then
@@ -335,7 +335,7 @@ subroutine read_infile(infile,logfile,evfile,dumpfile)
  use infile_utils,    only:read_next_inopt,contains_loop,write_infile_series
  use forcing,         only:read_options_forcing,write_options_forcing
  use externalforces,  only:read_options_externalforces
- use neighkdtree,     only:read_inopts_link
+ use neighkdtree,     only:read_inopts_tree
  use dust,            only:read_options_dust
  use growth,          only:read_options_growth
  use options,         only:use_porosity
@@ -365,7 +365,7 @@ subroutine read_infile(infile,logfile,evfile,dumpfile)
  character(len=120) :: valstring
  integer :: ierr,ireaderr,line,idot,ngot,nlinesread
  real    :: ratio
- logical :: imatch,igotallrequired,igotallturb,igotalllink,igotloops
+ logical :: imatch,igotallrequired,igotallturb,igotalltree,igotloops
  logical :: igotallbowen,igotallcooling,igotalldust,igotallextern,igotallinject,igotallgrowth,igotallporosity
  logical :: igotallionise,igotallnonideal,igotalleos,igotallptmass,igotalldamping,igotallapr
  logical :: igotallprad,igotalldustform,igotallgw,igotallgr,igotallbdy,igotallH2R
@@ -384,7 +384,7 @@ subroutine read_infile(infile,logfile,evfile,dumpfile)
  igotalldust     = .true.
  igotallgrowth   = .true.
  igotallporosity = .true.
- igotalllink     = .true.
+ igotalltree     = .true.
  igotallextern   = .true.
  igotallinject   = .true.
  igotallapr      = .true.
@@ -557,7 +557,7 @@ subroutine read_infile(infile,logfile,evfile,dumpfile)
        imatch = .false.
        if (.not.imatch) call read_options_externalforces(name,valstring,imatch,igotallextern,ierr,iexternalforce)
        if (.not.imatch .and. driving) call read_options_forcing(name,valstring,imatch,igotallturb,ierr)
-       if (.not.imatch) call read_inopts_link(name,valstring,imatch,igotalllink,ierr)
+       if (.not.imatch) call read_inopts_tree(name,valstring,imatch,igotalltree,ierr)
        !--Extract if one-fluid dust is used from the fileid
        if (.not.imatch .and. use_dust) call read_options_dust(name,valstring,imatch,igotalldust,ierr)
        if (.not.imatch .and. use_dustgrowth) call read_options_growth(name,valstring,imatch,igotallgrowth,ierr)
@@ -594,7 +594,7 @@ subroutine read_infile(infile,logfile,evfile,dumpfile)
  enddo
  close(unit=ireadin)
 
- igotallrequired = (ngot  >=  nrequired) .and. igotalllink   .and. igotallbowen   .and. igotalldust &
+ igotallrequired = (ngot  >=  nrequired) .and. igotalltree   .and. igotallbowen   .and. igotalldust &
                     .and. igotalleos    .and. igotallcooling .and. igotallextern  .and. igotallturb &
                     .and. igotallptmass .and. igotallinject  .and. igotallionise  .and. igotallnonideal &
                     .and. igotallgrowth  .and. igotallporosity .and. igotalldamping .and. igotallprad &
@@ -612,7 +612,7 @@ subroutine read_infile(infile,logfile,evfile,dumpfile)
           if (.not.igotalleos) write(*,*) 'missing equation of state options'
           if (.not.igotallcooling) write(*,*) 'missing cooling options'
           if (.not.igotalldamping) write(*,*) 'missing damping options'
-          if (.not.igotalllink) write(*,*) 'missing link options'
+          if (.not.igotalltree) write(*,*) 'missing tree options'
           if (.not.igotallbowen) write(*,*) 'missing Bowen dust options'
           if (.not.igotalldust) write(*,*) 'missing dust options'
           if (.not.igotallgr) write(*,*) 'missing metric parameters (eg, spin, mass)'

--- a/src/main/readwrite_infile.f90
+++ b/src/main/readwrite_infile.f90
@@ -70,7 +70,7 @@ module readwrite_infile
 !
 ! :Dependencies: HIIRegion, boundary_dyn, cooling, damping, dim, dust,
 !   dust_formation, eos, externalforces, forcing, gravwaveutils, growth,
-!   infile_utils, inject, io, linklist, metric, nicil_sup, options, part,
+!   infile_utils, inject, io, neighkdtree, metric, nicil_sup, options, part,
 !   porosity, ptmass, ptmass_radiation, radiation_implicit,
 !   radiation_utils, timestep, utils_apr, viscosity
 !
@@ -105,7 +105,7 @@ subroutine write_infile(infile,logfile,evfile,dumpfile,iwritein,iprint)
  use forcing,         only:write_options_forcing
  use externalforces,  only:write_options_externalforces
  use damping,         only:write_options_damping
- use linklist,        only:write_inopts_link
+ use neighkdtree,     only:write_inopts_link
  use dust,            only:write_options_dust
  use growth,          only:write_options_growth
  use porosity,        only:write_options_porosity
@@ -335,7 +335,7 @@ subroutine read_infile(infile,logfile,evfile,dumpfile)
  use infile_utils,    only:read_next_inopt,contains_loop,write_infile_series
  use forcing,         only:read_options_forcing,write_options_forcing
  use externalforces,  only:read_options_externalforces
- use linklist,        only:read_inopts_link
+ use neighkdtree,     only:read_inopts_link
  use dust,            only:read_options_dust
  use growth,          only:read_options_growth
  use options,         only:use_porosity

--- a/src/main/readwrite_infile.f90
+++ b/src/main/readwrite_infile.f90
@@ -70,8 +70,8 @@ module readwrite_infile
 !
 ! :Dependencies: HIIRegion, boundary_dyn, cooling, damping, dim, dust,
 !   dust_formation, eos, externalforces, forcing, gravwaveutils, growth,
-!   infile_utils, inject, io, neighkdtree, metric, nicil_sup, options, part,
-!   porosity, ptmass, ptmass_radiation, radiation_implicit,
+!   infile_utils, inject, io, metric, neighkdtree, nicil_sup, options,
+!   part, porosity, ptmass, ptmass_radiation, radiation_implicit,
 !   radiation_utils, timestep, utils_apr, viscosity
 !
  use timestep,  only:dtmax_dratio,dtmax_max,dtmax_min

--- a/src/main/sort_particles.f90
+++ b/src/main/sort_particles.f90
@@ -14,7 +14,7 @@ module sort_particles
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: io, linklist, part, sortutils
+! :Dependencies: io, neighkdtree, part, sortutils
 !
  implicit none
  public :: sort_part_radius, sort_part_id, sort_part
@@ -30,17 +30,17 @@ contains
 !+
 !----------------------------------------------------------------
 subroutine sort_part
- use io,       only:iprint,fatal
- use part,     only:reorder_particles,npart,ll,xyzh,vxyzu,isdead
- use linklist, only:set_linklist,ncells,ifirstincell
+ use io,          only:iprint,fatal
+ use part,        only:reorder_particles,npart,ll,xyzh,vxyzu,isdead
+ use neighkdtree, only:build_tree,ncells,ifirstincell
  integer         :: i,ipart,iprev,ifirst
  integer(kind=8) :: icell
  real            :: t0,t1,t2
 
  call cpu_time(t0)
- call set_linklist(npart,npart,xyzh,vxyzu)  ! don't include MPI ghosts
+ call build_tree(npart,npart,xyzh,vxyzu)  ! don't include MPI ghosts
  call cpu_time(t1)
- write(iprint,*) '> sorting particles...',t1-t0,'s for linklist'
+ write(iprint,*) '> sorting particles...',t1-t0,'s for neighkdtree'
 
  ipart = 0
  iprev = 0

--- a/src/main/sort_particles.f90
+++ b/src/main/sort_particles.f90
@@ -17,98 +17,11 @@ module sort_particles
 ! :Dependencies: io, neighkdtree, part, sortutils
 !
  implicit none
- public :: sort_part_radius, sort_part_id, sort_part
+ public :: sort_part_radius, sort_part_id
 
  private
 
 contains
-
-! do not even compile with this routine if not sorting
-!----------------------------------------------------------------
-!+
-!  this version sorts the particles using the neighbour lists
-!+
-!----------------------------------------------------------------
-subroutine sort_part
- use io,          only:iprint,fatal
- use part,        only:reorder_particles,npart,ll,xyzh,vxyzu,isdead
- use neighkdtree, only:build_tree,ncells,itypecell
- integer         :: i,ipart,iprev,ifirst
- integer(kind=8) :: icell
- real            :: t0,t1,t2
-
- call cpu_time(t0)
- call build_tree(npart,npart,xyzh,vxyzu)  ! don't include MPI ghosts
- call cpu_time(t1)
- write(iprint,*) '> sorting particles...',t1-t0,'s for neighkdtree'
-
- ipart = 0
- iprev = 0
- ifirst = itypecell(1)
-
- do icell=1,ncells
-!    call get_neighbour_list(icell,listneigh,nneigh,xyzh,xyzcache,0)
-
-    i = itypecell(icell)
-    if (ifirst==0) ifirst = i
-    !
-    !--link end of last cell to start of this cell
-    !
-    if (iprev /= 0) ll(iprev) = i
-    !
-    !--loop to the end of this cell
-    !
-    do while (i /= 0 .and. ipart < npart)
-       ipart = ipart + 1
-       !print*,'ipart = ',ipart,'iprev = ',iprev
-       if (i <= 0) call fatal('sort','internal error: i<=0',i)
-       iprev = i
-       i = ll(i)
-    enddo
- enddo
-
- print*,'finished',ipart,npart
- print*,'setting',iprev,ifirst
-!
-!--make sure we haven't missed any particles
-!
- if (ipart /= npart) then
-    write(iprint,*) ' shifting ',npart-ipart,' particles not in neighbour list to end of arrays'
-    do i=1,npart
-       if (isdead(i)) then
-          ipart = ipart + 1
-          ll(iprev) = i
-          iprev = i
-       endif
-    enddo
- endif
- if (ipart /= npart) call fatal('sort','ipart /= npart')
-!
-!--complete the loop by linking the last particle of the last cell
-!  to the first of the first cell
-!
- ll(iprev) = ifirst
-
- if (any(ll(1:npart) <= 0)) then
-    ipart = 0
-    do i=1,npart
-       if (ll(i)==0) ipart = ipart + 1
-    enddo
-    print*,'number of errors = ',ipart
-    call fatal('sort','errors in index array')
- endif
-
-! print*,' ncells = ',ncells,' ipart = ',ipart,' npart = ',npart
- write(iprint,*) ' copying arrays...'
-!
-!--copy arrays into correct order
-!
- call reorder_particles(ll,npart)
-
- call cpu_time(t2)
- write(iprint,*) '> sort completed in ',t2-t1,'s'
-
-end subroutine sort_part
 
 !----------------------------------------------------------------
 !+

--- a/src/main/sort_particles.f90
+++ b/src/main/sort_particles.f90
@@ -32,7 +32,7 @@ contains
 subroutine sort_part
  use io,          only:iprint,fatal
  use part,        only:reorder_particles,npart,ll,xyzh,vxyzu,isdead
- use neighkdtree, only:build_tree,ncells,ifirstincell
+ use neighkdtree, only:build_tree,ncells,itypecell
  integer         :: i,ipart,iprev,ifirst
  integer(kind=8) :: icell
  real            :: t0,t1,t2
@@ -44,12 +44,12 @@ subroutine sort_part
 
  ipart = 0
  iprev = 0
- ifirst = ifirstincell(1)
+ ifirst = itypecell(1)
 
  do icell=1,ncells
 !    call get_neighbour_list(icell,listneigh,nneigh,xyzh,xyzcache,0)
 
-    i = ifirstincell(icell)
+    i = itypecell(icell)
     if (ifirst==0) ifirst = i
     !
     !--link end of last cell to start of this cell

--- a/src/main/utils_deriv.f90
+++ b/src/main/utils_deriv.f90
@@ -16,7 +16,7 @@ module derivutils
 !
 ! :Dependencies: io, mpiutils, timing
 !
- use timing, only: timers,itimer_dens,itimer_force,itimer_link,itimer_balance,itimer_cons2prim,&
+ use timing, only: timers,itimer_dens,itimer_force,itimer_tree,itimer_balance,itimer_cons2prim,&
                    itimer_radiation,itimer_rad_save,itimer_rad_neighlist,itimer_rad_arrays,itimer_rad_its,&
                    itimer_rad_flux,itimer_rad_diff,itimer_rad_update,itimer_rad_store
 
@@ -53,8 +53,8 @@ subroutine do_timing(label,tlast,tcpulast,start,lunit)
     itimer = itimer_dens
  case ('force')
     itimer = itimer_force
- case ('link')
-    itimer = itimer_link
+ case ('tree')
+    itimer = itimer_tree
  case ('cons2prim')
     itimer = itimer_cons2prim
  case ('radiation')

--- a/src/main/utils_raytracer.f90
+++ b/src/main/utils_raytracer.f90
@@ -475,7 +475,7 @@ end function hasNext
  !+
  !--------------------------------------------------------------------------
 subroutine find_next(inpoint, h, ray, xyzh, kappa, dtaudr, distance, inext)
- use neighkdtree, only:getneigh_pos,ifirstincell,listneigh
+ use neighkdtree, only:getneigh_pos,itypecell,listneigh
  use kernel,      only:radkern,cnormk,wkern
  use part,        only:hfact,rhoh,massoftype,igas
  use dim,         only:maxpsph
@@ -494,7 +494,7 @@ subroutine find_next(inpoint, h, ray, xyzh, kappa, dtaudr, distance, inext)
  distance = 0.
 
  !for a given point (inpoint), returns the list of neighbouring particles (listneigh) within a radius h*radkern
- call getneigh_pos(inpoint,0.,h*radkern,3,listneigh,nneigh,xyzcache,nmaxcache,ifirstincell)
+ call getneigh_pos(inpoint,0.,h*radkern,3,listneigh,nneigh,xyzcache,nmaxcache,itypecell)
 
  dtaudr = 0.
  dmin = huge(0.)

--- a/src/main/utils_raytracer.f90
+++ b/src/main/utils_raytracer.f90
@@ -20,7 +20,7 @@ module raytracer
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: dim, healpix, kernel, linklist, part, units
+! :Dependencies: dim, healpix, kernel, neighkdtree, part, units
 !
  use healpix
 
@@ -475,10 +475,10 @@ end function hasNext
  !+
  !--------------------------------------------------------------------------
 subroutine find_next(inpoint, h, ray, xyzh, kappa, dtaudr, distance, inext)
- use linklist, only:getneigh_pos,ifirstincell,listneigh
- use kernel,   only:radkern,cnormk,wkern
- use part,     only:hfact,rhoh,massoftype,igas
- use dim,      only:maxpsph
+ use neighkdtree, only:getneigh_pos,ifirstincell,listneigh
+ use kernel,      only:radkern,cnormk,wkern
+ use part,        only:hfact,rhoh,massoftype,igas
+ use dim,         only:maxpsph
  real,    intent(in)    :: xyzh(:,:), kappa(:), inpoint(:), ray(:), h
  integer, intent(inout) :: inext
  real,    intent(out)   :: distance, dtaudr

--- a/src/main/utils_raytracer.f90
+++ b/src/main/utils_raytracer.f90
@@ -475,7 +475,7 @@ end function hasNext
  !+
  !--------------------------------------------------------------------------
 subroutine find_next(inpoint, h, ray, xyzh, kappa, dtaudr, distance, inext)
- use neighkdtree, only:getneigh_pos,itypecell,listneigh
+ use neighkdtree, only:getneigh_pos,leaf_is_active,listneigh
  use kernel,      only:radkern,cnormk,wkern
  use part,        only:hfact,rhoh,massoftype,igas
  use dim,         only:maxpsph
@@ -494,7 +494,7 @@ subroutine find_next(inpoint, h, ray, xyzh, kappa, dtaudr, distance, inext)
  distance = 0.
 
  !for a given point (inpoint), returns the list of neighbouring particles (listneigh) within a radius h*radkern
- call getneigh_pos(inpoint,0.,h*radkern,3,listneigh,nneigh,xyzcache,nmaxcache,itypecell)
+ call getneigh_pos(inpoint,0.,h*radkern,3,listneigh,nneigh,xyzcache,nmaxcache,leaf_is_active)
 
  dtaudr = 0.
  dmin = huge(0.)

--- a/src/main/utils_shuffleparticles.F90
+++ b/src/main/utils_shuffleparticles.F90
@@ -192,7 +192,7 @@ subroutine shuffleparticles(iprint,npart,xyzh,pmass,duniform,rsphere,dsphere,dme
        use_ref_h = .true.
     endif
 #ifdef SPLITTING
-    !--Ensure maxp_hard is large enough to push the primary & reference simultansously in the tree
+    !--Ensure maxp_hard is large enough to push the primary & reference simultaneously in the tree
     n_part = npart + n_ref
     if (n_part > maxp_hard) call fatal('shuffling','npart + n_ref > maxp_hard',var='n_part',ival=n_part)
 

--- a/src/main/utils_shuffleparticles.F90
+++ b/src/main/utils_shuffleparticles.F90
@@ -89,7 +89,7 @@ subroutine shuffleparticles(iprint,npart,xyzh,pmass,duniform,rsphere,dsphere,dme
  real,    optional, intent(inout) :: xyzh_ref(:,:)
  logical, optional, intent(in)    :: is_setup
  character(len=*) , optional, intent(in)    :: prefix
- integer      :: i,j,k,jm1,p,ip,icell,ineigh,idebug,ishift,nshiftmax,iprofile,nparterr,nneigh,ncross,ntree,n_part
+ integer      :: i,j,jm1,p,ip,icell,ineigh,idebug,ishift,nshiftmax,iprofile,nparterr,nneigh,ncross,ntree,n_part
  real         :: stressmax,redge,dedge,dmed
  real         :: max_shift2,max_shift_thresh,max_shift_thresh2,tree_shift,treebuild_thresh,radkern12
  real         :: xi,yi,zi,hi,hi12,hi14,radi,radinew,coefi,rhoi,rhoi1,rij2,qi2,qj2,denom,rhoe,drhoe,err
@@ -326,7 +326,7 @@ subroutine shuffleparticles(iprint,npart,xyzh,pmass,duniform,rsphere,dsphere,dme
 #ifdef SPLITTING
 !$omp shared(grrhoonrhoe_ref) &
 #endif
-!$omp private(i,j,k,ip,ineigh,icell,jm1,xi,yi,zi,hi,hi12,rij,rij2,runi,qi2,qj2,hi14,rhoi,rhoi1,coefi) &
+!$omp private(i,j,ip,ineigh,icell,jm1,xi,yi,zi,hi,hi12,rij,rij2,runi,qi2,qj2,hi14,rhoi,rhoi1,coefi) &
 !$omp private(xj,yj,zj,hj,hj1,termi) &
 !$omp private(grrhoonrhoe,grrhoonrhoi,rhoe,drhoe,denom,nneigh) &
 !$omp private(err,maggradi,maggrade,magshift,at_interface) &

--- a/src/main/utils_shuffleparticles.F90
+++ b/src/main/utils_shuffleparticles.F90
@@ -71,7 +71,7 @@ subroutine shuffleparticles(iprint,npart,xyzh,pmass,duniform,rsphere,dsphere,dme
  use part,         only:vxyzu,divcurlv,divcurlB,Bevol,fxyzu,fext,alphaind,iphase,igas
  use part,         only:gradh,rad,radprop,dvdx,rhoh,hrho,apr_level
  use densityforce, only:densityiterate
- use neighkdtree,  only:ncells,ifirstincell,build_tree,get_neighbour_list,allocate_linklist,listneigh
+ use neighkdtree,  only:ncells,ifirstincell,build_tree,get_neighbour_list,allocate_neigh,listneigh
  use kernel,       only:cnormk,wkern,grkern,radkern2
 #ifdef PERIODIC
  use boundary,     only:dxbound,dybound,dzbound,cross_boundary
@@ -280,7 +280,7 @@ subroutine shuffleparticles(iprint,npart,xyzh,pmass,duniform,rsphere,dsphere,dme
 
  !--initialise memory for neighkdtree
  if (present(is_setup)) then
-    if (is_setup) call allocate_linklist()
+    if (is_setup) call allocate_neigh()
  endif
 
  !--Shuffle particles

--- a/src/main/utils_shuffleparticles.F90
+++ b/src/main/utils_shuffleparticles.F90
@@ -71,7 +71,7 @@ subroutine shuffleparticles(iprint,npart,xyzh,pmass,duniform,rsphere,dsphere,dme
  use part,         only:vxyzu,divcurlv,divcurlB,Bevol,fxyzu,fext,alphaind,iphase,igas
  use part,         only:gradh,rad,radprop,dvdx,rhoh,hrho,apr_level
  use densityforce, only:densityiterate
- use neighkdtree,  only:ncells,ifirstincell,build_tree,get_neighbour_list,allocate_neigh,listneigh
+ use neighkdtree,  only:ncells,itypecell,build_tree,get_neighbour_list,allocate_neigh,listneigh
  use kernel,       only:cnormk,wkern,grkern,radkern2
 #ifdef PERIODIC
  use boundary,     only:dxbound,dybound,dzbound,cross_boundary
@@ -319,7 +319,7 @@ subroutine shuffleparticles(iprint,npart,xyzh,pmass,duniform,rsphere,dsphere,dme
 !$omp parallel default (none) &
 !$omp shared(xyzh,npart,pmass,dx_shift,gradh,max_shift_thresh2,redge,iprofile,dedge,dmed,idebug) &
 !$omp shared(use_ref_h,n_ref,xyzh_ref,totalshift,pmass_ref,radkern12,ishift) &
-!$omp shared(rtab,dtab,ntab,rinner,router,inodeparts,inoderange,ifirstincell,ncells,ncall) &
+!$omp shared(rtab,dtab,ntab,rinner,router,inodeparts,inoderange,itypecell,ncells,ncall) &
 #ifdef PERIODIC
 !$omp shared(dxbound,dybound,dzbound) &
 #endif
@@ -337,7 +337,7 @@ subroutine shuffleparticles(iprint,npart,xyzh,pmass,duniform,rsphere,dsphere,dme
 !$omp reduction(+:   errave,stddev,nparterr)
 !$omp do schedule(runtime)
     over_cells: do icell=1,int(ncells)
-       k = ifirstincell(icell)
+       k = itypecell(icell)
 
        ! Skip empty cells AND inactive cells
        if (k <= 0) cycle over_cells

--- a/src/main/utils_shuffleparticles.F90
+++ b/src/main/utils_shuffleparticles.F90
@@ -22,7 +22,7 @@ module utils_shuffleparticles
 ! :Runtime parameters: None
 !
 ! :Dependencies: allocutils, boundary, densityforce, io, kdtree, kernel,
-!   neighkdtree, mpidomain, part
+!   mpidomain, neighkdtree, part
 !
  implicit none
  public :: shuffleparticles

--- a/src/main/utils_shuffleparticles.F90
+++ b/src/main/utils_shuffleparticles.F90
@@ -71,7 +71,7 @@ subroutine shuffleparticles(iprint,npart,xyzh,pmass,duniform,rsphere,dsphere,dme
  use part,         only:vxyzu,divcurlv,divcurlB,Bevol,fxyzu,fext,alphaind,iphase,igas
  use part,         only:gradh,rad,radprop,dvdx,rhoh,hrho,apr_level
  use densityforce, only:densityiterate
- use neighkdtree,  only:ncells,itypecell,build_tree,get_neighbour_list,allocate_neigh,listneigh
+ use neighkdtree,  only:ncells,leaf_is_active,build_tree,get_neighbour_list,allocate_neigh,listneigh
  use kernel,       only:cnormk,wkern,grkern,radkern2
 #ifdef PERIODIC
  use boundary,     only:dxbound,dybound,dzbound,cross_boundary
@@ -319,7 +319,7 @@ subroutine shuffleparticles(iprint,npart,xyzh,pmass,duniform,rsphere,dsphere,dme
 !$omp parallel default (none) &
 !$omp shared(xyzh,npart,pmass,dx_shift,gradh,max_shift_thresh2,redge,iprofile,dedge,dmed,idebug) &
 !$omp shared(use_ref_h,n_ref,xyzh_ref,totalshift,pmass_ref,radkern12,ishift) &
-!$omp shared(rtab,dtab,ntab,rinner,router,inodeparts,inoderange,itypecell,ncells,ncall) &
+!$omp shared(rtab,dtab,ntab,rinner,router,inodeparts,inoderange,leaf_is_active,ncells,ncall) &
 #ifdef PERIODIC
 !$omp shared(dxbound,dybound,dzbound) &
 #endif
@@ -337,10 +337,9 @@ subroutine shuffleparticles(iprint,npart,xyzh,pmass,duniform,rsphere,dsphere,dme
 !$omp reduction(+:   errave,stddev,nparterr)
 !$omp do schedule(runtime)
     over_cells: do icell=1,int(ncells)
-       k = itypecell(icell)
 
        ! Skip empty cells AND inactive cells
-       if (k <= 0) cycle over_cells
+       if (leaf_is_active(icell) <= 0) cycle over_cells
 
        ! Get the neighbour list and fill the cell cache
        call get_neighbour_list(icell,listneigh,nneigh,xyzh,xyzcache,maxcellcache,getj=.true.)

--- a/src/main/utils_shuffleparticles.F90
+++ b/src/main/utils_shuffleparticles.F90
@@ -114,11 +114,11 @@ subroutine shuffleparticles(iprint,npart,xyzh,pmass,duniform,rsphere,dsphere,dme
  idebug            =    1  ! 0 = off; 1=errors; 2=initial & final distribution + (1); 3=print every step + (2)
  nshiftmax         =  200 !600 ! maximum number of shuffles/iterations
  max_shift_thresh  = 0. !4.d-3 ! will stop shuffling once (maximum shift)/h is less than this value
- treebuild_thresh = 0.01  ! will rebuild the tree when the cumulative maximum relative shift surpasses this limit (=0 will call every loop)
+ treebuild_thresh  = 0.01  ! will rebuild the tree when the cumulative maximum relative shift surpasses this limit (=0 will call every loop)
  !--Initialise remaining parameters
  rthree            = 0.
  use_ref_h         = .true. ! to prevent compiler warnings
- call_treebuild     = .true.
+ call_treebuild    = .true.
  max_shift_thresh2 = max_shift_thresh*max_shift_thresh
  n_part            = npart
  is_ref            = .false.

--- a/src/main/utils_timing.f90
+++ b/src/main/utils_timing.f90
@@ -42,7 +42,7 @@ module timing
  integer, public, parameter ::   itimer_fromstart     = 1,  &
                                  itimer_lastdump      = 2,  &
                                  itimer_step          = 3,  &
-                                 itimer_link          = 4,  &
+                                 itimer_tree          = 4,  &
                                  itimer_balance       = 5,  &
                                  itimer_dens          = 6,  &
                                  itimer_dens_local    = 7,  &
@@ -91,8 +91,8 @@ subroutine setup_timers
  call init_timer(itimer_lastdump    , 'last',        0            )
  call init_timer(itimer_step        , 'step',        0            )
  call init_timer(itimer_HII         , 'HII_regions', 0            )
- call init_timer(itimer_link        , 'tree',        itimer_step  )
- call init_timer(itimer_balance     , 'balance',     itimer_link  )
+ call init_timer(itimer_tree        , 'tree',        itimer_step  )
+ call init_timer(itimer_balance     , 'balance',     itimer_tree  )
  call init_timer(itimer_dens        , 'density',     itimer_step  )
  call init_timer(itimer_dens_local  , 'local',       itimer_dens  )
  call init_timer(itimer_dens_remote , 'remote',      itimer_dens  )

--- a/src/setup/phantomsetup.F90
+++ b/src/setup/phantomsetup.F90
@@ -86,7 +86,7 @@ program phantomsetup
 !--In general, setup routines do not know the number of particles until they
 !  are written. Need to allocate up to the hard limit. Legacy setup routines may
 !  also rely on maxp being set to the number of desired particles. Allocate only
-!  part, not kdtree or linklist
+!  part, not kdtree or neighbour list
 !
  n_alloc = get_command_option('maxp',default=int(maxp_alloc))
  call allocate_memory(n_alloc, part_only=.true.)

--- a/src/setup/relax_star.f90
+++ b/src/setup/relax_star.f90
@@ -19,7 +19,7 @@ module relaxstar
 !
 ! :Dependencies: apr, checksetup, damping, deriv, dim, dump_utils,
 !   energies, eos, externalforces, fileutils, infile_utils, initial, io,
-!   io_summary, neighkdtree, memory, options, part, physcon, ptmass,
+!   io_summary, memory, neighkdtree, options, part, physcon, ptmass,
 !   readwrite_dumps, setstar_utils, step_lf_global, table_utils, units
 !
  implicit none

--- a/src/setup/relax_star.f90
+++ b/src/setup/relax_star.f90
@@ -19,7 +19,7 @@ module relaxstar
 !
 ! :Dependencies: apr, checksetup, damping, deriv, dim, dump_utils,
 !   energies, eos, externalforces, fileutils, infile_utils, initial, io,
-!   io_summary, linklist, memory, options, part, physcon, ptmass,
+!   io_summary, neighkdtree, memory, options, part, physcon, ptmass,
 !   readwrite_dumps, setstar_utils, step_lf_global, table_utils, units
 !
  implicit none
@@ -75,7 +75,7 @@ subroutine relax_star(nt,rho,pr,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,&
  use io_summary,      only:summary_initialise
  use setstar_utils,   only:set_star_thermalenergy,set_star_composition
  use apr,             only:init_apr,update_apr
- use linklist,        only:allocate_linklist
+ use neighkdtree,     only:allocate_linklist
  integer, intent(in)    :: nt,iptmass_core
  integer, intent(inout) :: npart
  real,    intent(in)    :: rho(nt),pr(nt),r(nt)

--- a/src/setup/relax_star.f90
+++ b/src/setup/relax_star.f90
@@ -75,7 +75,7 @@ subroutine relax_star(nt,rho,pr,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,&
  use io_summary,      only:summary_initialise
  use setstar_utils,   only:set_star_thermalenergy,set_star_composition
  use apr,             only:init_apr,update_apr
- use neighkdtree,     only:allocate_linklist
+ use neighkdtree,     only:allocate_neigh
  integer, intent(in)    :: nt,iptmass_core
  integer, intent(inout) :: npart
  real,    intent(in)    :: rho(nt),pr(nt),r(nt)
@@ -156,7 +156,7 @@ subroutine relax_star(nt,rho,pr,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,&
 
  ! if using apr, options set in setup file but needs to be initialised here
  if (use_apr) then
-    call allocate_linklist
+    call allocate_neigh
     call init_apr(apr_level,ierr)
     call update_apr(npart,xyzh,vxyzu,fxyzu,apr_level)
  endif

--- a/src/setup/set_star_utils.f90
+++ b/src/setup/set_star_utils.f90
@@ -424,7 +424,7 @@ end subroutine get_mass_coord
 !-----------------------------------------------------------------------
 subroutine set_star_composition(use_var_comp,use_mu,npart,xyzh,Xfrac,Yfrac,&
            mu,mtab,Mstar,eos_vars,npin,x0)
- use part,        only:iX,iZ,imu  ! borrow the unused linklist array for the sort
+ use part,        only:iX,iZ,imu
  use table_utils, only:yinterp
  logical, intent(in)  :: use_var_comp,use_mu
  integer, intent(in)  :: npart

--- a/src/tests/test_derivs.f90
+++ b/src/tests/test_derivs.f90
@@ -15,7 +15,7 @@ module testderivs
 ! :Runtime parameters: None
 !
 ! :Dependencies: boundary, cullendehnen, densityforce, deriv, dim, dust,
-!   eos, io, kernel, linklist, mpidomain, mpiutils, nicil, options, part,
+!   eos, io, kernel, neighkdtree, mpidomain, mpiutils, nicil, options, part,
 !   physcon, testutils, timestep_ind, timing, unifdis, units, viscosity
 !
  use part, only:massoftype,ien_type,ien_entropy
@@ -49,7 +49,7 @@ subroutine test_derivs(ntests,npass,string)
  use physcon,      only:pi,au,solarm
  use deriv,        only:get_derivs_global
  use densityforce, only:get_neighbour_stats
- use linklist,     only:set_linklist
+ use neighkdtree,  only:build_tree
  use timing,       only:getused,printused
  use viscosity,    only:bulkvisc,shearparam,irealvisc
  use part,         only:iphase,isetphase,igas
@@ -898,7 +898,7 @@ subroutine test_cullendehnen(hzero,mask,ntests,npass)
  use timestep_ind, only:nactive
  use densityforce, only:densityiterate
  use timing,       only:getused,printused
- use linklist,     only:set_linklist
+ use neighkdtree,  only:build_tree
  use testutils,    only:checkvalf,update_test_scores
  integer, intent(inout) :: ntests,npass
  real,    intent(in)    :: hzero
@@ -926,7 +926,7 @@ subroutine test_cullendehnen(hzero,mask,ntests,npass)
 
     call getused(tused)
     ! ONLY call density, since we do not want accelerations being reset
-    call set_linklist(npart,nactive,xyzh,vxyzu)
+    call build_tree(npart,nactive,xyzh,vxyzu)
     call densityiterate(1,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,&
                         Bevol,stressmax,fxyzu,fext,alphaind,gradh,&
                         rad,radprop,dvdx,apr_level)

--- a/src/tests/test_derivs.f90
+++ b/src/tests/test_derivs.f90
@@ -15,8 +15,9 @@ module testderivs
 ! :Runtime parameters: None
 !
 ! :Dependencies: boundary, cullendehnen, densityforce, deriv, dim, dust,
-!   eos, io, kernel, neighkdtree, mpidomain, mpiutils, nicil, options, part,
-!   physcon, testutils, timestep_ind, timing, unifdis, units, viscosity
+!   eos, io, kernel, mpidomain, mpiutils, neighkdtree, nicil, options,
+!   part, physcon, testutils, timestep_ind, timing, unifdis, units,
+!   viscosity
 !
  use part, only:massoftype,ien_type,ien_entropy
  use dim,  only:isothermal,ind_timesteps

--- a/src/tests/test_gravity.f90
+++ b/src/tests/test_gravity.f90
@@ -15,7 +15,7 @@ module testgravity
 ! :Runtime parameters: None
 !
 ! :Dependencies: deriv, dim, directsum, energies, eos, io, kdtree,
-!   linklist, mpibalance, mpiutils, options, part, physcon, ptmass,
+!   neighkdtree, mpibalance, mpiutils, options, part, physcon, ptmass,
 !   setup_params, sort_particles, spherical, testapr, testutils, timing
 !
  use io, only:id,master
@@ -252,7 +252,7 @@ subroutine test_directsum(ntests,npass)
  use testutils,       only:checkval,checkvalbuf_end,update_test_scores
  use ptmass,          only:get_accel_sink_sink,get_accel_sink_gas,h_soft_sinksink
  use mpiutils,        only:reduceall_mpi,bcast_mpi
- use linklist,        only:set_linklist
+ use neighkdtree,     only:build_tree
  use sort_particles,  only:sort_part_id
  use mpibalance,      only:balancedomains
  use testapr,         only:setup_apr_region_for_test

--- a/src/tests/test_gravity.f90
+++ b/src/tests/test_gravity.f90
@@ -15,7 +15,7 @@ module testgravity
 ! :Runtime parameters: None
 !
 ! :Dependencies: deriv, dim, directsum, energies, eos, io, kdtree,
-!   neighkdtree, mpibalance, mpiutils, options, part, physcon, ptmass,
+!   mpibalance, mpiutils, neighkdtree, options, part, physcon, ptmass,
 !   setup_params, sort_particles, spherical, testapr, testutils, timing
 !
  use io, only:id,master

--- a/src/tests/test_kdtree.F90
+++ b/src/tests/test_kdtree.F90
@@ -16,7 +16,7 @@ module testkdtree
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: dim, io, kdtree, kernel, linklist, mpidomain, part,
+! :Dependencies: dim, io, kdtree, kernel, neighkdtree, mpidomain, part,
 !   testutils, timing, unifdis
 !
  implicit none
@@ -31,16 +31,16 @@ contains
 !+
 !-----------------------------------------------------------------------
 subroutine test_kdtree(ntests,npass)
- use dim,       only:maxp,periodic
- use io,        only:id,master,iverbose
- use linklist,  only:ifirstincell,ncells,node
- use part,      only:npart,xyzh,hfact,massoftype,igas,maxphase,iphase,isetphase
- use kernel,    only:hfact_default
- use kdtree,    only:maketree,revtree,kdnode,empty_tree
- use unifdis,   only:set_unifdis
- use testutils, only:checkvalbuf,checkvalbuf_end,update_test_scores
- use timing,    only:print_time,getused
- use mpidomain, only:i_belong
+ use dim,         only:maxp,periodic
+ use io,          only:id,master,iverbose
+ use neighkdtree, only:ifirstincell,ncells,node
+ use part,        only:npart,xyzh,hfact,massoftype,igas,maxphase,iphase,isetphase
+ use kernel,      only:hfact_default
+ use kdtree,      only:maketree,revtree,kdnode,empty_tree
+ use unifdis,     only:set_unifdis
+ use testutils,   only:checkvalbuf,checkvalbuf_end,update_test_scores
+ use timing,      only:print_time,getused
+ use mpidomain,   only:i_belong
  integer, intent(inout) :: ntests,npass
  logical :: test_revtree, test_all
  integer :: i,nfailed(12),nchecked(12)

--- a/src/tests/test_kdtree.F90
+++ b/src/tests/test_kdtree.F90
@@ -16,7 +16,7 @@ module testkdtree
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: dim, io, kdtree, kernel, neighkdtree, mpidomain, part,
+! :Dependencies: dim, io, kdtree, kernel, mpidomain, neighkdtree, part,
 !   testutils, timing, unifdis
 !
  implicit none

--- a/src/tests/test_kdtree.F90
+++ b/src/tests/test_kdtree.F90
@@ -33,7 +33,7 @@ contains
 subroutine test_kdtree(ntests,npass)
  use dim,         only:maxp,periodic
  use io,          only:id,master,iverbose
- use neighkdtree, only:itypecell,ncells,node
+ use neighkdtree, only:leaf_is_active,ncells,node
  use part,        only:npart,xyzh,hfact,massoftype,igas,maxphase,iphase,isetphase
  use kernel,      only:hfact_default
  use kdtree,      only:maketree,revtree,kdnode,empty_tree
@@ -72,7 +72,7 @@ subroutine test_kdtree(ntests,npass)
     !
     call empty_tree(node)
     call cpu_time(t1)
-    call maketree(node,xyzh,npart,3,itypecell,ncells,apr_tree=.false.)
+    call maketree(node,xyzh,npart,3,leaf_is_active,ncells,apr_tree=.false.)
     call cpu_time(t2)
     call print_time(t2-t1,'maketree completed in')
     !
@@ -100,7 +100,7 @@ subroutine test_kdtree(ntests,npass)
     ! call revtree to rebuild
     !
     call cpu_time(t1)
-    call revtree(node,xyzh,itypecell,ncells)
+    call revtree(node,xyzh,leaf_is_active,ncells)
     call cpu_time(t2)
     call print_time(t2-t1,'revtree completed in')
 
@@ -112,7 +112,7 @@ subroutine test_kdtree(ntests,npass)
     errmax(:)   = 0.
     tol = 1.8e-13 !epsilon(0.)
     do i=1,int(ncells)
-       ! if (itypecell(i) /= 0) then
+       ! if (leaf_is_active(i) /= 0) then
        call checkvalbuf(node(i)%xcen(1),old_tree(i)%xcen(1),tol,'x0',nfailed(1),nchecked(1),errmax(1))
        call checkvalbuf(node(i)%xcen(2),old_tree(i)%xcen(2),tol,'y0',nfailed(2),nchecked(2),errmax(2))
        call checkvalbuf(node(i)%xcen(3),old_tree(i)%xcen(3),tol,'z0',nfailed(3),nchecked(3),errmax(3))

--- a/src/tests/test_kdtree.F90
+++ b/src/tests/test_kdtree.F90
@@ -8,7 +8,7 @@ module testkdtree
 !
 ! This module performs unit tests of the kdtree module
 !   The tests here are specific to the tree, some general
-!   tests of neighbour finding are done in test_link
+!   tests of neighbour finding are done in test_neigh
 !
 ! :References: None
 !

--- a/src/tests/test_kdtree.F90
+++ b/src/tests/test_kdtree.F90
@@ -33,7 +33,7 @@ contains
 subroutine test_kdtree(ntests,npass)
  use dim,         only:maxp,periodic
  use io,          only:id,master,iverbose
- use neighkdtree, only:ifirstincell,ncells,node
+ use neighkdtree, only:itypecell,ncells,node
  use part,        only:npart,xyzh,hfact,massoftype,igas,maxphase,iphase,isetphase
  use kernel,      only:hfact_default
  use kdtree,      only:maketree,revtree,kdnode,empty_tree
@@ -72,7 +72,7 @@ subroutine test_kdtree(ntests,npass)
     !
     call empty_tree(node)
     call cpu_time(t1)
-    call maketree(node,xyzh,npart,3,ifirstincell,ncells,apr_tree=.false.)
+    call maketree(node,xyzh,npart,3,itypecell,ncells,apr_tree=.false.)
     call cpu_time(t2)
     call print_time(t2-t1,'maketree completed in')
     !
@@ -100,7 +100,7 @@ subroutine test_kdtree(ntests,npass)
     ! call revtree to rebuild
     !
     call cpu_time(t1)
-    call revtree(node,xyzh,ifirstincell,ncells)
+    call revtree(node,xyzh,itypecell,ncells)
     call cpu_time(t2)
     call print_time(t2-t1,'revtree completed in')
 
@@ -112,7 +112,7 @@ subroutine test_kdtree(ntests,npass)
     errmax(:)   = 0.
     tol = 1.8e-13 !epsilon(0.)
     do i=1,int(ncells)
-       ! if (ifirstincell(i) /= 0) then
+       ! if (itypecell(i) /= 0) then
        call checkvalbuf(node(i)%xcen(1),old_tree(i)%xcen(1),tol,'x0',nfailed(1),nchecked(1),errmax(1))
        call checkvalbuf(node(i)%xcen(2),old_tree(i)%xcen(2),tol,'y0',nfailed(2),nchecked(2),errmax(2))
        call checkvalbuf(node(i)%xcen(3),old_tree(i)%xcen(3),tol,'z0',nfailed(3),nchecked(3),errmax(3))

--- a/src/tests/test_link.F90
+++ b/src/tests/test_link.F90
@@ -14,7 +14,7 @@ module testlink
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: boundary, dim, io, kdtree, kernel, linklist, mpidomain,
+! :Dependencies: boundary, dim, io, kdtree, kernel, neighkdtree, mpidomain,
 !   mpiutils, part, random, testutils, timing, unifdis
 !
  implicit none
@@ -29,23 +29,23 @@ contains
 !+
 !-----------------------------------------------------------------------
 subroutine test_link(ntests,npass)
- use dim,      only:maxp,periodic
- use io,       only:id,master,nprocs!,iverbose
- use mpiutils, only:reduceall_mpi
- use part,     only:npart,npartoftype,massoftype,xyzh,vxyzu,hfact,igas,kill_particle
- use kernel,   only:radkern2,radkern
- use unifdis,  only:set_unifdis
- use timing,   only:getused
- use random,   only:ran2
- use mpidomain,only:i_belong
- use part,            only:maxphase,iphase,isetphase,igas,iactive
- use testutils,       only:checkval,checkvalbuf_start,checkvalbuf,checkvalbuf_end,update_test_scores
- use linklist,        only:set_linklist,get_neighbour_list,ncells,ifirstincell
- use kdtree,          only:inodeparts,inoderange
- use mpidomain,       only:i_belong
+ use dim,         only:maxp,periodic
+ use io,          only:id,master,nprocs!,iverbose
+ use mpiutils,    only:reduceall_mpi
+ use part,        only:npart,npartoftype,massoftype,xyzh,vxyzu,hfact,igas,kill_particle
+ use kernel,      only:radkern2,radkern
+ use unifdis,     only:set_unifdis
+ use timing,      only:getused
+ use random,      only:ran2
+ use mpidomain,   only:i_belong
+ use part,        only:maxphase,iphase,isetphase,igas,iactive
+ use testutils,   only:checkval,checkvalbuf_start,checkvalbuf,checkvalbuf_end,update_test_scores
+ use neighkdtree, only:build_tree,get_neighbour_list,ncells,ifirstincell
+ use kdtree,      only:inodeparts,inoderange
+ use mpidomain,   only:i_belong
 #ifdef PERIODIC
- use boundary, only:xmin,xmax,ymin,ymax,zmin,zmax,dybound,dzbound
- use linklist, only:dcellx,dcelly,dcellz
+ use boundary,    only:xmin,xmax,ymin,ymax,zmin,zmax,dybound,dzbound
+ use neighkdtree, only:dcellx,dcelly,dcellz
 #endif
  use boundary, only:dxbound
  use part,     only:isdead_or_accreted
@@ -73,7 +73,7 @@ subroutine test_link(ntests,npass)
  integer, allocatable :: listneigh(:)
  character(len=1), dimension(3), parameter :: xlabel = (/'x','y','z'/)
 
- if (id==master) write(*,"(a,/)") '--> TESTING LINKLIST / NEIGHBOUR FINDING'
+ if (id==master) write(*,"(a,/)") '--> TESTING NEIGHBOUR FINDING'
 !
 !--allocate memory for neighbour list
 !
@@ -170,7 +170,7 @@ subroutine test_link(ntests,npass)
 !--setup the link list
 !
     if (id==master) write(*,"(/,1x,2(a,i1),a,/)") 'Test ',itest,' of ',nlinktest,': building linked list...'
-    call set_linklist(npart,npart,xyzh,vxyzu)
+    call build_tree(npart,npart,xyzh,vxyzu)
 !
 !--count dead particles
 !
@@ -430,7 +430,7 @@ subroutine test_link(ntests,npass)
     npartoftype(:) = 0
     npartoftype(igas) = npart
 
-    call set_linklist(npart,npart,xyzh,vxyzu)
+    call build_tree(npart,npart,xyzh,vxyzu)
     !
     !--check that the number of cells is non-zero
     !
@@ -442,7 +442,7 @@ subroutine test_link(ntests,npass)
  if (allocated(xyzcache)) deallocate(xyzcache)
  deallocate(listneigh)
 
- if (id==master) write(*,"(/,a,/)") '<-- LINKLIST TEST COMPLETE'
+ if (id==master) write(*,"(/,a,/)") '<-- NEIGHBOUR TEST COMPLETE'
 
 end subroutine test_link
 

--- a/src/tests/test_link.F90
+++ b/src/tests/test_link.F90
@@ -40,7 +40,7 @@ subroutine test_link(ntests,npass)
  use mpidomain,   only:i_belong
  use part,        only:maxphase,iphase,isetphase,igas,iactive
  use testutils,   only:checkval,checkvalbuf_start,checkvalbuf,checkvalbuf_end,update_test_scores
- use neighkdtree, only:build_tree,get_neighbour_list,ncells,ifirstincell
+ use neighkdtree, only:build_tree,get_neighbour_list,ncells,itypecell
  use kdtree,      only:inodeparts,inoderange
  use mpidomain,   only:i_belong
 #ifdef PERIODIC
@@ -195,18 +195,18 @@ subroutine test_link(ntests,npass)
        nfailed = 0
        call checkvalbuf_start('active/inactive cells')
        !!$omp parallel do default(none) &
-       !!$omp shared(ncells,ifirstincell,iphase,ll) &
+       !!$omp shared(ncells,itypecell,iphase,ll) &
        !!$omp private(i,activecell,hasactive,iactivei,npartincell) &
        !!$omp reduction(+:nfail,ncheck1,ncheck2)
        do icell=1,int(ncells)
-          if (ifirstincell(icell) < 0) then
+          if (itypecell(icell) < 0) then
              activecell = .false.
           else
              activecell = .true.
           endif
           npartincell = 0
           hasactive   = .false.
-          not_empty: if (ifirstincell(icell) /= 0) then
+          not_empty: if (itypecell(icell) /= 0) then
              do i = inoderange(1,icell), inoderange(2,icell)
                 npartincell = npartincell + 1
                 iactivei = iactive(iphase_soa(i))
@@ -253,7 +253,7 @@ subroutine test_link(ntests,npass)
        listneigh(:) = 0
 
        over_cells: do icell=1,int(ncells)
-          i = ifirstincell(icell)
+          i = itypecell(icell)
           if (i==0) cycle over_cells
 
           if (i < 0) then

--- a/src/tests/test_neigh.F90
+++ b/src/tests/test_neigh.F90
@@ -4,9 +4,9 @@
 ! See LICENCE file for usage and distribution conditions                   !
 ! http://phantomsph.github.io/                                             !
 !--------------------------------------------------------------------------!
-module testlink
+module testneigh
 !
-! This module performs unit tests of the link list routines
+! This module performs unit tests of the neighbour finding routines
 !
 ! :References: None
 !
@@ -18,7 +18,7 @@ module testlink
 !   mpiutils, part, random, testutils, timing, unifdis
 !
  implicit none
- public :: test_link
+ public :: test_neigh
 
  private
 
@@ -28,7 +28,7 @@ contains
 !   Unit tests of neighbour finding routines
 !+
 !-----------------------------------------------------------------------
-subroutine test_link(ntests,npass)
+subroutine test_neigh(ntests,npass)
  use dim,         only:maxp,periodic
  use io,          only:id,master,nprocs!,iverbose
  use mpiutils,    only:reduceall_mpi
@@ -444,6 +444,6 @@ subroutine test_link(ntests,npass)
 
  if (id==master) write(*,"(/,a,/)") '<-- NEIGHBOUR TEST COMPLETE'
 
-end subroutine test_link
+end subroutine test_neigh
 
-end module testlink
+end module testneigh

--- a/src/tests/test_neigh.F90
+++ b/src/tests/test_neigh.F90
@@ -65,7 +65,7 @@ subroutine test_neigh(ntests,npass)
  integer                :: npartincell,ierrmax
  logical                :: hasactive
 #endif
- integer                :: maxneighi,minneigh,iseed,nlinktest,itest,ndead
+ integer                :: maxneighi,minneigh,iseed,nneightest,itest,ndead
  integer(kind=8)        :: meanneigh,i8
  integer :: nfailed(8)
  logical                :: iactivei,iactivej,activecell
@@ -120,12 +120,12 @@ subroutine test_neigh(ntests,npass)
  hmax = 0.2/dxboundp !0.25/dxboundp
 
 #ifdef IND_TIMESTEPS
- nlinktest = 3
+ nneightest = 3
 #else
- nlinktest = 2
+ nneightest = 2
 #endif
 
- over_tests: do itest=1,nlinktest
+ over_tests: do itest=1,nneightest
 
     iseed = -24358
     ip = 0
@@ -167,9 +167,9 @@ subroutine test_neigh(ntests,npass)
     if (maxphase==maxp) iphase(1:npart) = isetphase(igas,iactive=.true.)
 #endif
 !
-!--setup the link list
+!--setup the tree
 !
-    if (id==master) write(*,"(/,1x,2(a,i1),a,/)") 'Test ',itest,' of ',nlinktest,': building linked list...'
+    if (id==master) write(*,"(/,1x,2(a,i1),a,/)") 'Test ',itest,' of ',nneightest,': building tree...'
     call build_tree(npart,npart,xyzh,vxyzu)
 !
 !--count dead particles
@@ -408,8 +408,8 @@ subroutine test_neigh(ntests,npass)
 !
 !--check neighbour finding with some pathological configurations
 !
- nlinktest = nlinktest + 1
- if (id==master) write(*,"(/,1x,a,i2,a,/)") 'Test ',nlinktest,': building linked list...'
+ nneightest = nneightest + 1
+ if (id==master) write(*,"(/,1x,a,i2,a,/)") 'Test ',nneightest,': building tree...'
  do maxpen=1,3
     if (id==master) write(*,"(a)") ' particles in a line in '//xlabel(maxpen)//' direction '
 

--- a/src/tests/test_neigh.F90
+++ b/src/tests/test_neigh.F90
@@ -40,7 +40,7 @@ subroutine test_neigh(ntests,npass)
  use mpidomain,   only:i_belong
  use part,        only:maxphase,iphase,isetphase,igas,iactive
  use testutils,   only:checkval,checkvalbuf_start,checkvalbuf,checkvalbuf_end,update_test_scores
- use neighkdtree, only:build_tree,get_neighbour_list,ncells,itypecell
+ use neighkdtree, only:build_tree,get_neighbour_list,ncells,leaf_is_active
  use kdtree,      only:inodeparts,inoderange
  use mpidomain,   only:i_belong
 #ifdef PERIODIC
@@ -195,18 +195,18 @@ subroutine test_neigh(ntests,npass)
        nfailed = 0
        call checkvalbuf_start('active/inactive cells')
        !!$omp parallel do default(none) &
-       !!$omp shared(ncells,itypecell,iphase,ll) &
+       !!$omp shared(ncells,leaf_is_active,iphase,ll) &
        !!$omp private(i,activecell,hasactive,iactivei,npartincell) &
        !!$omp reduction(+:nfail,ncheck1,ncheck2)
        do icell=1,int(ncells)
-          if (itypecell(icell) < 0) then
+          if (leaf_is_active(icell) < 0) then
              activecell = .false.
           else
              activecell = .true.
           endif
           npartincell = 0
           hasactive   = .false.
-          not_empty: if (itypecell(icell) /= 0) then
+          not_empty: if (leaf_is_active(icell) /= 0) then
              do i = inoderange(1,icell), inoderange(2,icell)
                 npartincell = npartincell + 1
                 iactivei = iactive(iphase_soa(i))
@@ -253,7 +253,7 @@ subroutine test_neigh(ntests,npass)
        listneigh(:) = 0
 
        over_cells: do icell=1,int(ncells)
-          i = itypecell(icell)
+          i = leaf_is_active(icell)
           if (i==0) cycle over_cells
 
           if (i < 0) then

--- a/src/tests/test_neigh.F90
+++ b/src/tests/test_neigh.F90
@@ -14,8 +14,8 @@ module testneigh
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: boundary, dim, io, kdtree, kernel, neighkdtree, mpidomain,
-!   mpiutils, part, random, testutils, timing, unifdis
+! :Dependencies: boundary, dim, io, kdtree, kernel, mpidomain, mpiutils,
+!   neighkdtree, part, random, testutils, timing, unifdis
 !
  implicit none
  public :: test_neigh

--- a/src/tests/test_radiation.f90
+++ b/src/tests/test_radiation.f90
@@ -17,8 +17,8 @@ module testradiation
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: boundary, deriv, dim, eos, io, kernel, neighkdtree,
-!   mpidomain, mpiutils, options, part, physcon, radiation_implicit,
+! :Dependencies: boundary, deriv, dim, eos, io, kernel, mpidomain,
+!   mpiutils, neighkdtree, options, part, physcon, radiation_implicit,
 !   radiation_utils, readwrite_dumps, step_lf_global, testutils, timestep,
 !   unifdis, units
 !

--- a/src/tests/test_radiation.f90
+++ b/src/tests/test_radiation.f90
@@ -17,7 +17,7 @@ module testradiation
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: boundary, deriv, dim, eos, io, kernel, linklist,
+! :Dependencies: boundary, deriv, dim, eos, io, kernel, neighkdtree,
 !   mpidomain, mpiutils, options, part, physcon, radiation_implicit,
 !   radiation_utils, readwrite_dumps, step_lf_global, testutils, timestep,
 !   unifdis, units
@@ -97,7 +97,7 @@ subroutine test_exchange_terms(ntests,npass,use_implicit)
  use mpiutils,   only:reduceall_mpi
  use mpidomain,  only:i_belong
  use radiation_implicit, only:do_radiation_implicit
- use linklist,   only:set_linklist
+ use neighkdtree,        only:build_tree
  real :: psep,hfact
  real :: pmassi,rhozero,totmass
  integer, intent(inout) :: ntests,npass
@@ -142,7 +142,7 @@ subroutine test_exchange_terms(ntests,npass,use_implicit)
  npartoftype(1) = npart
  pmassi = massoftype(igas)
 
- if (use_implicit) call set_linklist(npart,npart,xyzh,vxyzu)
+ if (use_implicit) call build_tree(npart,npart,xyzh,vxyzu)
  !
  ! first version of the test: set gas temperature high and radiation temperature low
  ! so that gas cools towards radiation temperature (itest=1)

--- a/src/tests/testsuite.F90
+++ b/src/tests/testsuite.F90
@@ -76,7 +76,7 @@ subroutine testsuite(string,first,last,ntests,npass,nfail)
  character(len=*), intent(in)    :: string
  logical,          intent(in)    :: first,last
  integer,          intent(inout) :: ntests,npass,nfail
- logical :: testall,dolink,dokdtree,doderivs,dokernel,dostep,dorwdump,dosmol
+ logical :: testall,doneigh,dokdtree,doderivs,dokernel,dostep,dorwdump,dosmol
  logical :: doptmass,dognewton,dosedov,doexternf,doindtstep,dogravity,dogeom
  logical :: dosetdisc,dosetstar,doeos,docooling,dodust,donimhd,docorotate,doany,dogrowth
  logical :: dogr,doradiation,dopart,dopoly,dompi,dohier,dodamp,dowind
@@ -107,7 +107,7 @@ subroutine testsuite(string,first,last,ntests,npass,nfail)
  call get_timings(twall1,tcpu1)
  testall    = .false.
  dokernel   = .false.
- dolink     = .false.
+ doneigh     = .false.
  dopart     = .false.
  dokdtree   = .false.
  doderivs   = .false.
@@ -172,8 +172,8 @@ subroutine testsuite(string,first,last,ntests,npass,nfail)
  select case(trim(string))
  case('kernel','kern')
     dokernel = .true.
- case('link','tree')
-    dolink = .true.
+ case('neigh','tree')
+    doneigh = .true.
  case('kdtree','revtree')
     dokdtree = .true.
  case('step')
@@ -249,7 +249,7 @@ subroutine testsuite(string,first,last,ntests,npass,nfail)
 !
 !--test of neighbour finding module
 !
- if (dolink.or.testall) then
+ if (doneigh.or.testall) then
     call test_neigh(ntests,npass)
     call set_default_options_testsuite(iverbose) ! restore defaults
  endif

--- a/src/tests/testsuite.F90
+++ b/src/tests/testsuite.F90
@@ -18,10 +18,11 @@ module test
 ! :Dependencies: dim, io, io_summary, mpiutils, options, testapr,
 !   testcooling, testcorotate, testdamping, testderivs, testdust, testeos,
 !   testexternf, testgeometry, testgnewton, testgr, testgravity,
-!   testgrowth, testindtstep, testiorig, testkdtree, testkernel, testneigh,
-!   testlum, testmath, testmpi, testnimhd, testpart, testpoly, testptmass,
-!   testradiation, testrwdump, testsedov, testsetdisc, testsethier,
-!   testsetstar, testsmol, teststep, testunits, testwind, timing
+!   testgrowth, testindtstep, testiorig, testkdtree, testkernel, testlum,
+!   testmath, testmpi, testneigh, testnimhd, testpart, testpoly,
+!   testptmass, testradiation, testrwdump, testsedov, testsetdisc,
+!   testsethier, testsetstar, testsmol, teststep, testunits, testwind,
+!   timing
 !
  implicit none
  public :: testsuite

--- a/src/tests/testsuite.F90
+++ b/src/tests/testsuite.F90
@@ -18,7 +18,7 @@ module test
 ! :Dependencies: dim, io, io_summary, mpiutils, options, testapr,
 !   testcooling, testcorotate, testdamping, testderivs, testdust, testeos,
 !   testexternf, testgeometry, testgnewton, testgr, testgravity,
-!   testgrowth, testindtstep, testiorig, testkdtree, testkernel, testlink,
+!   testgrowth, testindtstep, testiorig, testkdtree, testkernel, testneigh,
 !   testlum, testmath, testmpi, testnimhd, testpart, testpoly, testptmass,
 !   testradiation, testrwdump, testsedov, testsetdisc, testsethier,
 !   testsetstar, testsmol, teststep, testunits, testwind, timing
@@ -35,7 +35,7 @@ subroutine testsuite(string,first,last,ntests,npass,nfail)
  use io_summary,   only:summary_initialise
  use testderivs,   only:test_derivs
  use teststep,     only:test_step
- use testlink,     only:test_link
+ use testneigh,    only:test_neigh
  use testkdtree,   only:test_kdtree
  use testsedov,    only:test_sedov
  use testgravity,  only:test_gravity
@@ -250,7 +250,7 @@ subroutine testsuite(string,first,last,ntests,npass,nfail)
 !--test of neighbour finding module
 !
  if (dolink.or.testall) then
-    call test_link(ntests,npass)
+    call test_neigh(ntests,npass)
     call set_default_options_testsuite(iverbose) ! restore defaults
  endif
 !

--- a/src/tests/testsuite.F90
+++ b/src/tests/testsuite.F90
@@ -247,7 +247,7 @@ subroutine testsuite(string,first,last,ntests,npass,nfail)
     call test_kernel(ntests,npass)
  endif
 !
-!--test of linklist/neighbour finding module
+!--test of neighbour finding module
 !
  if (dolink.or.testall) then
     call test_link(ntests,npass)

--- a/src/utils/analysis_kdtree.F90
+++ b/src/utils/analysis_kdtree.F90
@@ -87,7 +87,7 @@ end subroutine viz_kdtree
 recursive subroutine plot_nodes(inode,level,ndim,tree)
  use kdtree,      only:labelax
  use giza
- use neighkdtree, only:ifirstincell
+ use neighkdtree, only:itypecell
  !use part, only:xyzh,ll
  integer,      intent(in) :: inode,level,ndim
  type(kdnode), intent(in) :: tree(:)
@@ -103,7 +103,7 @@ recursive subroutine plot_nodes(inode,level,ndim,tree)
  call giza_set_fill(giza_fill_hollow)
  !print*,' level = ',level
  if (inode <= 0) return
- if (ifirstincell(inode) /= 0) then
+ if (itypecell(inode) /= 0) then
     !print*,' node ',inode,' is on level ',level,' kids = ',tree(inode)%leftchild,tree(inode)%rightchild,&
     !    ' max h = ',tree(inode)%hmax
     if (plot_leaf_node_sizes) then
@@ -133,7 +133,7 @@ recursive subroutine plot_nodes(inode,level,ndim,tree)
 
  ! plot the line where this node is split, or else full rectangle
  if (plot_pivot_lines_only) then
-    if (ifirstincell(inode)==0) then  ! only if node is NOT a leaf node
+    if (itypecell(inode)==0) then  ! only if node is NOT a leaf node
        xpts(iaxis,1:2) = xpivot
        call giza_line(2,xpts(1,:),xpts(2,:))
     endif
@@ -161,7 +161,7 @@ end subroutine plot_nodes
 
 subroutine check_neighbours(xyzh,tree)
  use dim,         only:maxp
- use neighkdtree, only:ncells,get_neighbour_list,ifirstincell
+ use neighkdtree, only:ncells,get_neighbour_list,itypecell
  use giza
  use kernel,      only:radkern
  real,         intent(in) :: xyzh(:,:)
@@ -172,7 +172,7 @@ subroutine check_neighbours(xyzh,tree)
 
  allocate(listneigh(maxp))
  over_cells: do inode=1,ncells
-    if ((norm2(tree(inode)%xcen(1:3) - (/-0.25,0.,0./)) < 5.e-2) .and. ifirstincell(inode) > 0) then
+    if ((norm2(tree(inode)%xcen(1:3) - (/-0.25,0.,0./)) < 5.e-2) .and. itypecell(inode) > 0) then
        call get_neighbour_list(inode,listneigh,nneigh,xyzh,xyzcache,0)
 
        ! plot all trial neighbours

--- a/src/utils/analysis_kdtree.F90
+++ b/src/utils/analysis_kdtree.F90
@@ -14,7 +14,7 @@ module analysis
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: dim, giza, io, kdtree, kernel, linklist
+! :Dependencies: dim, giza, io, kdtree, kernel, neighkdtree
 !
  use kdtree, only:kdnode
  implicit none
@@ -26,9 +26,9 @@ module analysis
 contains
 
 subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
- use kdtree,   only:node,minpart
- use linklist, only:set_linklist,ncells
- use io,  only:iverbose
+ use kdtree,      only:node,minpart
+ use neighkdtree, only:build_tree,ncells
+ use io,          only:iverbose
  character(len=*), intent(in) :: dumpfile
  integer,          intent(in) :: num,npart,iunit
  real,             intent(inout) :: xyzh(:,:),vxyzu(:,:)
@@ -36,7 +36,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
 
  iverbose= 3
  print*,'> Building 2D kd-tree... minpart = ',minpart
- call set_linklist(npart,npart,xyzh,vxyzu)
+ call build_tree(npart,npart,xyzh,vxyzu)
 
  !print*,'> Printing kd-tree '
  !do i=1,numnodes
@@ -85,9 +85,9 @@ end subroutine viz_kdtree
 
 #ifdef TREEVIZ
 recursive subroutine plot_nodes(inode,level,ndim,tree)
- use kdtree, only:labelax
+ use kdtree,      only:labelax
  use giza
- use linklist, only:ifirstincell
+ use neighkdtree, only:ifirstincell
  !use part, only:xyzh,ll
  integer,      intent(in) :: inode,level,ndim
  type(kdnode), intent(in) :: tree(:)
@@ -160,10 +160,10 @@ end subroutine plot_nodes
 #endif
 
 subroutine check_neighbours(xyzh,tree)
- use dim,      only:maxp
- use linklist, only:ncells,get_neighbour_list,ifirstincell
+ use dim,         only:maxp
+ use neighkdtree, only:ncells,get_neighbour_list,ifirstincell
  use giza
- use kernel,   only:radkern
+ use kernel,      only:radkern
  real,         intent(in) :: xyzh(:,:)
  type(kdnode), intent(in) :: tree(:)
  integer, allocatable :: listneigh(:)

--- a/src/utils/analysis_kdtree.F90
+++ b/src/utils/analysis_kdtree.F90
@@ -87,7 +87,7 @@ end subroutine viz_kdtree
 recursive subroutine plot_nodes(inode,level,ndim,tree)
  use kdtree,      only:labelax
  use giza
- use neighkdtree, only:itypecell
+ use neighkdtree, only:leaf_is_active
  !use part, only:xyzh,ll
  integer,      intent(in) :: inode,level,ndim
  type(kdnode), intent(in) :: tree(:)
@@ -103,7 +103,7 @@ recursive subroutine plot_nodes(inode,level,ndim,tree)
  call giza_set_fill(giza_fill_hollow)
  !print*,' level = ',level
  if (inode <= 0) return
- if (itypecell(inode) /= 0) then
+ if (leaf_is_active(inode) /= 0) then
     !print*,' node ',inode,' is on level ',level,' kids = ',tree(inode)%leftchild,tree(inode)%rightchild,&
     !    ' max h = ',tree(inode)%hmax
     if (plot_leaf_node_sizes) then
@@ -133,7 +133,7 @@ recursive subroutine plot_nodes(inode,level,ndim,tree)
 
  ! plot the line where this node is split, or else full rectangle
  if (plot_pivot_lines_only) then
-    if (itypecell(inode)==0) then  ! only if node is NOT a leaf node
+    if (leaf_is_active(inode)==0) then  ! only if node is NOT a leaf node
        xpts(iaxis,1:2) = xpivot
        call giza_line(2,xpts(1,:),xpts(2,:))
     endif
@@ -161,7 +161,7 @@ end subroutine plot_nodes
 
 subroutine check_neighbours(xyzh,tree)
  use dim,         only:maxp
- use neighkdtree, only:ncells,get_neighbour_list,itypecell
+ use neighkdtree, only:ncells,get_neighbour_list,leaf_is_active
  use giza
  use kernel,      only:radkern
  real,         intent(in) :: xyzh(:,:)
@@ -172,7 +172,7 @@ subroutine check_neighbours(xyzh,tree)
 
  allocate(listneigh(maxp))
  over_cells: do inode=1,ncells
-    if ((norm2(tree(inode)%xcen(1:3) - (/-0.25,0.,0./)) < 5.e-2) .and. itypecell(inode) > 0) then
+    if ((norm2(tree(inode)%xcen(1:3) - (/-0.25,0.,0./)) < 5.e-2) .and. leaf_is_active(inode) > 0) then
        call get_neighbour_list(inode,listneigh,nneigh,xyzh,xyzcache,0)
 
        ! plot all trial neighbours

--- a/src/utils/analysis_krome.f90
+++ b/src/utils/analysis_krome.f90
@@ -14,7 +14,7 @@ module analysis
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: eos, io, krome_main, krome_user, linklist, part, physcon,
+! :Dependencies: eos, io, krome_main, krome_user, neighkdtree, part, physcon,
 !   raytracer, units
 !
  use krome_user, only: krome_nmols
@@ -35,14 +35,14 @@ module analysis
 contains
 
 subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
- use part,       only: isdead_or_accreted, iorig, rhoh, nptmass, xyzmh_ptmass, iReff
- use linklist,   only: set_linklist
- use units,      only: utime,unit_density
- use eos,        only: get_temperature, ieos, gamma,gmw, init_eos
- use io,         only: fatal
- use krome_main, only: krome_init, krome
- use krome_user, only: krome_get_names,krome_set_user_Auv,krome_set_user_xi,&
-                       krome_set_user_alb,krome_set_user_AuvAv
+ use part,        only: isdead_or_accreted, iorig, rhoh, nptmass, xyzmh_ptmass, iReff
+ use neighkdtree, only: build_tree
+ use units,       only: utime,unit_density
+ use eos,         only: get_temperature, ieos, gamma,gmw, init_eos
+ use io,          only: fatal
+ use krome_main,  only: krome_init, krome
+ use krome_user,  only: krome_get_names,krome_set_user_Auv,krome_set_user_xi,&
+                        krome_set_user_alb,krome_set_user_AuvAv
  character(len=*), intent(in) :: dumpfile
  integer,          intent(in) :: num,npart,iunit
  real,             intent(in) :: xyzh(:,:),vxyzu(:,:)
@@ -91,7 +91,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
     xyzmh_ptmass(iReff,1) = 2.
     npart_copy = npart
     xyzh_copy = xyzh(:,:npart)
-    call set_linklist(npart_copy,npart_copy,xyzh_copy,vxyzu)
+    call build_tree(npart_copy,npart_copy,xyzh_copy,vxyzu)
     call get_all_tau(npart, nptmass, xyzmh_ptmass, xyzh, one, 5, .false., column_density)
     !$omp parallel do default(none) &
     !$omp shared(npart,xyzh,vxyzu,dt_cgs,nprev,iorig,iorig_old,iprev) &

--- a/src/utils/analysis_krome.f90
+++ b/src/utils/analysis_krome.f90
@@ -14,8 +14,8 @@ module analysis
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: eos, io, krome_main, krome_user, neighkdtree, part, physcon,
-!   raytracer, units
+! :Dependencies: eos, io, krome_main, krome_user, neighkdtree, part,
+!   physcon, raytracer, units
 !
  use krome_user, only: krome_nmols
  use part,       only: maxp

--- a/src/utils/analysis_pairing.f90
+++ b/src/utils/analysis_pairing.f90
@@ -15,7 +15,7 @@ module analysis
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: linklist, part
+! :Dependencies: neighkdtree, part
 !
  implicit none
  character(len=20), parameter, public :: analysistype = 'pairing'
@@ -26,8 +26,8 @@ module analysis
 contains
 
 subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
- use linklist, only:set_linklist,getneigh_pos,ifirstincell,listneigh=>listneigh_global
- use part,     only:isdead_or_accreted
+ use neighkdtree, only:build_tree,getneigh_pos,ifirstincell,listneigh=>listneigh_global
+ use part,        only:isdead_or_accreted
  character(len=*), intent(in) :: dumpfile
  integer,          intent(in) :: num,npart,iunit
  real,             intent(inout) :: xyzh(:,:),vxyzu(:,:)
@@ -40,7 +40,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
  real, parameter :: sep_hist(7) = (/0.0001,0.001,0.01,0.1,0.3,1.0,2.0/)
 
  print*,'> Building tree... '
- call set_linklist(npart,npart,xyzh,vxyzu)
+ call build_tree(npart,npart,xyzh,vxyzu)
 
  nwarn = 0
  nbin = 0

--- a/src/utils/analysis_pairing.f90
+++ b/src/utils/analysis_pairing.f90
@@ -26,7 +26,7 @@ module analysis
 contains
 
 subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
- use neighkdtree, only:build_tree,getneigh_pos,ifirstincell,listneigh=>listneigh_global
+ use neighkdtree, only:build_tree,getneigh_pos,itypecell,listneigh=>listneigh_global
  use part,        only:isdead_or_accreted
  character(len=*), intent(in) :: dumpfile
  integer,          intent(in) :: num,npart,iunit
@@ -48,7 +48,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
  nneightot = 0
  do i=1,npart
     if (.not.isdead_or_accreted(xyzh(4,i))) then
-       call getneigh_pos(xyzh(1:3,i),0.,xyzh(4,i),3,listneigh,nneigh,xyzh,xyzcache,maxcache,ifirstincell)
+       call getneigh_pos(xyzh(1:3,i),0.,xyzh(4,i),3,listneigh,nneigh,xyzh,xyzcache,maxcache,itypecell)
        h2 = xyzh(4,i)**2
        ncheck = ncheck + 1
        do n = 1,nneigh

--- a/src/utils/analysis_pairing.f90
+++ b/src/utils/analysis_pairing.f90
@@ -26,7 +26,7 @@ module analysis
 contains
 
 subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
- use neighkdtree, only:build_tree,getneigh_pos,itypecell,listneigh=>listneigh_global
+ use neighkdtree, only:build_tree,getneigh_pos,leaf_is_active,listneigh=>listneigh_global
  use part,        only:isdead_or_accreted
  character(len=*), intent(in) :: dumpfile
  integer,          intent(in) :: num,npart,iunit
@@ -48,7 +48,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
  nneightot = 0
  do i=1,npart
     if (.not.isdead_or_accreted(xyzh(4,i))) then
-       call getneigh_pos(xyzh(1:3,i),0.,xyzh(4,i),3,listneigh,nneigh,xyzh,xyzcache,maxcache,itypecell)
+       call getneigh_pos(xyzh(1:3,i),0.,xyzh(4,i),3,listneigh,nneigh,xyzh,xyzcache,maxcache,leaf_is_active)
        h2 = xyzh(4,i)**2
        ncheck = ncheck + 1
        do n = 1,nneigh

--- a/src/utils/analysis_raytracer.f90
+++ b/src/utils/analysis_raytracer.f90
@@ -25,7 +25,7 @@ module analysis
                                  neighcount,neighb,neighmax
  use dust_formation,   only:calc_kappa_bowen
  use physcon,          only:kboltz,mass_proton_cgs,au,solarm
- use neighkdtree,      only:build_tree,allocate_linklist,deallocate_linklist
+ use neighkdtree,      only:build_tree,allocate_neigh,deallocate_neigh
  use part,             only:itauL_alloc
 
  implicit none
@@ -497,8 +497,8 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
        close(iu4)
        do i=1, omp_get_max_threads()
           call omp_set_num_threads(i)
-          call deallocate_linklist
-          call allocate_linklist
+          call deallocate_neigh
+          call allocate_neigh
           call build_tree(npart2,npart2,xyzh2,vxyzu)
           if (primsec(1,2) == 0. .and. primsec(2,2) == 0. .and. primsec(3,2) == 0.) then
              call system_clock(start)

--- a/src/utils/analysis_raytracer.f90
+++ b/src/utils/analysis_raytracer.f90
@@ -14,7 +14,7 @@ module analysis
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: dump_utils, dust_formation, getneighbours, linklist,
+! :Dependencies: dump_utils, dust_formation, getneighbours, neighkdtree,
 !   omp_lib, part, physcon, raytracer, raytracer_all
 !
  use raytracer_all,    only:get_all_tau_inwards, get_all_tau_outwards, get_all_tau_adaptive
@@ -25,7 +25,7 @@ module analysis
                                  neighcount,neighb,neighmax
  use dust_formation,   only:calc_kappa_bowen
  use physcon,          only:kboltz,mass_proton_cgs,au,solarm
- use linklist,         only:set_linklist,allocate_linklist,deallocate_linklist
+ use neighkdtree,      only:build_tree,allocate_linklist,deallocate_linklist
  use part,             only:itauL_alloc
 
  implicit none
@@ -100,7 +100,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
     endif
  enddo
  npart2 = j-1
- call set_linklist(npart2,npart2,xyzh2,vxyzu)
+ call build_tree(npart2,npart2,xyzh2,vxyzu)
  print*,'npart = ',npart2
  allocate(tau(npart2))
 
@@ -499,7 +499,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
           call omp_set_num_threads(i)
           call deallocate_linklist
           call allocate_linklist
-          call set_linklist(npart2,npart2,xyzh2,vxyzu)
+          call build_tree(npart2,npart2,xyzh2,vxyzu)
           if (primsec(1,2) == 0. .and. primsec(2,2) == 0. .and. primsec(3,2) == 0.) then
              call system_clock(start)
              call get_all_tau(npart2, 1, xyzmh_ptmass, xyzh2, kappa, order, tau)

--- a/src/utils/analysis_write_kdtree.F90
+++ b/src/utils/analysis_write_kdtree.F90
@@ -14,7 +14,7 @@ module analysis
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: kdtree, linklist, part
+! :Dependencies: kdtree, neighkdtree, part
 !
  implicit none
  character(len=20), parameter, public :: analysistype = 'write_kdtree'
@@ -27,8 +27,8 @@ contains
 
 subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
 
- use part, only: iphase
- use linklist, only: set_linklist
+ use part,        only: iphase
+ use neighkdtree, only: build_tree
 
  implicit none
 
@@ -49,7 +49,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
 
  allocate(dumxyzh(4,npart))
  dumxyzh = xyzh
- call set_linklist(npart,npart,dumxyzh,vxyzu)
+ call build_tree(npart,npart,dumxyzh,vxyzu)
 
  print*, '- Done'
 
@@ -68,8 +68,8 @@ end subroutine do_analysis
 !--------------------------------------------------------------------
 subroutine write_kdtree_file(dumpfile)
 
- use linklist, only: ncells
- use kdtree, only: node
+ use neighkdtree, only: ncells
+ use kdtree,      only: node
 
  implicit none
 
@@ -123,8 +123,8 @@ end subroutine write_kdtree_file
 !--------------------------------------------------------------------
 subroutine read_kdtree_file(dumpfile)
 
- use linklist, only: ncells
- use kdtree, only: node
+ use neighkdtree, only: ncells
+ use kdtree,      only: node
 
  implicit none
  character(len=*), intent(in):: dumpfile

--- a/src/utils/analysis_write_kdtree.F90
+++ b/src/utils/analysis_write_kdtree.F90
@@ -41,11 +41,11 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
 
 
  !****************************************
- ! 1. Build kdtree and linklist
+ ! 1. Build kdtree
  ! --> global (shared) neighbour lists for all particles in tree cell
  !****************************************
 
- print*, 'Building kdtree and linklist: '
+ print*, 'Building kdtree: '
 
  allocate(dumxyzh(4,npart))
  dumxyzh = xyzh

--- a/src/utils/einsteintk_wrapper.f90
+++ b/src/utils/einsteintk_wrapper.f90
@@ -15,7 +15,7 @@ module einsteintk_wrapper
 ! :Runtime parameters: None
 !
 ! :Dependencies: cons2prim, densityforce, deriv, einsteintk_utils, evwrite,
-!   extern_gr, fileutils, initial, io, linklist, metric, metric_tools,
+!   extern_gr, fileutils, initial, io, neighkdtree, metric, metric_tools,
 !   mpiutils, part, readwrite_dumps, timestep, tmunu2grid
 !
  implicit none
@@ -145,7 +145,7 @@ subroutine et2phantom_tmunu()
  use einsteintk_utils, only: get_phantom_dt,rhostargrid,tmunugrid
  use metric_tools, only:init_metric
  use densityforce, only:densityiterate
- use linklist,     only:set_linklist
+ use neighkdtree,  only:build_tree
 
  real :: stressmax
  real :: cfac
@@ -156,7 +156,7 @@ subroutine et2phantom_tmunu()
  call init_metric(npart,xyzh,metrics)
  ! Might be better to just do this in get derivs global with a number 2 call?
  ! Rebuild the tree
- call set_linklist(npart,npart,xyzh,vxyzu)
+ call build_tree(npart,npart,xyzh,vxyzu)
  ! Apparently init metric needs to be called again???
  !call init_metric(npart,xyzh,metrics)
  ! Calculate the cons density
@@ -182,14 +182,14 @@ subroutine et2phantom_tmunu()
 end subroutine et2phantom_tmunu
 
 subroutine phantom2et_consvar()
- use part,         only:npart,xyzh,vxyzu,fxyzu,fext,divcurlv,divcurlB,&
-                        Bevol,rad,radprop,metrics,igas,rhoh,alphaind,dvdx,&
-                        gradh,apr_level
- use densityforce, only:densityiterate
- use metric_tools, only:init_metric
- use linklist,     only:set_linklist
+ use part,             only:npart,xyzh,vxyzu,fxyzu,fext,divcurlv,divcurlB,&
+                            Bevol,rad,radprop,metrics,igas,rhoh,alphaind,dvdx,&
+                            gradh,apr_level
+ use densityforce,     only:densityiterate
+ use metric_tools,     only:init_metric
+ use neighkdtree,      only:build_tree
  use einsteintk_utils, only:rhostargrid,pxgrid,entropygrid
- use tmunu2grid, only:check_conserved_dens
+ use tmunu2grid,       only:check_conserved_dens
 
  real :: stressmax
  real :: cfac
@@ -199,7 +199,7 @@ subroutine phantom2et_consvar()
 
  ! Might be better to just do this in get derivs global with a number 2 call?
  ! Rebuild the tree
- call set_linklist(npart,npart,xyzh,vxyzu)
+ call build_tree(npart,npart,xyzh,vxyzu)
  ! Apparently init metric needs to be called again???
  call init_metric(npart,xyzh,metrics)
  ! Calculate the cons density

--- a/src/utils/einsteintk_wrapper.f90
+++ b/src/utils/einsteintk_wrapper.f90
@@ -243,7 +243,7 @@ subroutine phantom2et_rhostar()
 
 
  ! Get new cons density from new particle positions somehow (maybe)?
- ! Set linklist to update the tree for neighbour finding
+ ! Update the tree for neighbour finding
  ! Calculate the density for the new particle positions
  ! Call density iterate
 
@@ -284,7 +284,7 @@ subroutine phantom2et_entropy()
  integer :: i
 
  ! Get new cons density from new particle positions somehow (maybe)?
- ! Set linklist to update the tree for neighbour finding
+ ! Update the tree for neighbour finding
  ! Calculate the density for the new particle positions
  ! Call density iterate
 

--- a/src/utils/einsteintk_wrapper.f90
+++ b/src/utils/einsteintk_wrapper.f90
@@ -15,8 +15,8 @@ module einsteintk_wrapper
 ! :Runtime parameters: None
 !
 ! :Dependencies: cons2prim, densityforce, deriv, einsteintk_utils, evwrite,
-!   extern_gr, fileutils, initial, io, neighkdtree, metric, metric_tools,
-!   mpiutils, part, readwrite_dumps, timestep, tmunu2grid
+!   extern_gr, fileutils, initial, io, metric, metric_tools, mpiutils,
+!   neighkdtree, part, readwrite_dumps, timestep, tmunu2grid
 !
  implicit none
 contains

--- a/src/utils/utils_getneighbours.F90
+++ b/src/utils/utils_getneighbours.F90
@@ -66,11 +66,11 @@ subroutine generate_neighbour_lists(xyzh,vxyzu,npart,dumpfile,write_neighbour_li
  if (.not.allocated(xyzcache)) allocate(xyzcache(maxcellcache,4))
 
  !****************************************
- ! 1. Build kdtree and linklist
+ ! 1. Build kdtree
  ! --> global (shared) neighbour lists for all particles in tree cell
  !****************************************
 
- print*, 'Building kdtree and linklist: '
+ print*, 'Building kdtree : '
  allocate(dumxyzh(4,npart))
  dumxyzh = xyzh
  dummynpart = npart

--- a/src/utils/utils_getneighbours.F90
+++ b/src/utils/utils_getneighbours.F90
@@ -40,7 +40,7 @@ contains
 subroutine generate_neighbour_lists(xyzh,vxyzu,npart,dumpfile,write_neighbour_list)
  use dim,         only:maxp
  use kernel,      only:radkern2
- use neighkdtree, only:ncells, ifirstincell, build_tree, get_neighbour_list
+ use neighkdtree, only:ncells, itypecell, build_tree, get_neighbour_list
  use part,        only:get_partinfo, igas, maxphase, iphase, iamboundary, iamtype
  use kdtree,      only:inodeparts,inoderange
 #ifdef PERIODIC
@@ -92,7 +92,7 @@ subroutine generate_neighbour_lists(xyzh,vxyzu,npart,dumpfile,write_neighbour_li
  print*, 'Creating neighbour lists for particles'
 
  !$omp parallel default(none) &
- !$omp shared(ncells,ifirstincell,npart,maxphase,maxp,inodeparts,inoderange) &
+ !$omp shared(ncells,itypecell,npart,maxphase,maxp,inodeparts,inoderange) &
  !$omp shared(xyzh,vxyzu,iphase,neighcount,neighb) &
 #ifdef PERIODIC
  !$omp shared(dxbound,dybound,dzbound) &
@@ -104,7 +104,7 @@ subroutine generate_neighbour_lists(xyzh,vxyzu,npart,dumpfile,write_neighbour_li
  !$omp do schedule(runtime)
  over_cells: do icell=1,int(ncells)
 
-    k = ifirstincell(icell)
+    k = itypecell(icell)
 
     ! Skip empty/inactive cells
     if (k <= 0) cycle over_cells

--- a/src/utils/utils_getneighbours.F90
+++ b/src/utils/utils_getneighbours.F90
@@ -40,7 +40,7 @@ contains
 subroutine generate_neighbour_lists(xyzh,vxyzu,npart,dumpfile,write_neighbour_list)
  use dim,         only:maxp
  use kernel,      only:radkern2
- use neighkdtree, only:ncells, itypecell, build_tree, get_neighbour_list
+ use neighkdtree, only:ncells, leaf_is_active, build_tree, get_neighbour_list
  use part,        only:get_partinfo, igas, maxphase, iphase, iamboundary, iamtype
  use kdtree,      only:inodeparts,inoderange
 #ifdef PERIODIC
@@ -92,7 +92,7 @@ subroutine generate_neighbour_lists(xyzh,vxyzu,npart,dumpfile,write_neighbour_li
  print*, 'Creating neighbour lists for particles'
 
  !$omp parallel default(none) &
- !$omp shared(ncells,itypecell,npart,maxphase,maxp,inodeparts,inoderange) &
+ !$omp shared(ncells,leaf_is_active,npart,maxphase,maxp,inodeparts,inoderange) &
  !$omp shared(xyzh,vxyzu,iphase,neighcount,neighb) &
 #ifdef PERIODIC
  !$omp shared(dxbound,dybound,dzbound) &
@@ -104,10 +104,8 @@ subroutine generate_neighbour_lists(xyzh,vxyzu,npart,dumpfile,write_neighbour_li
  !$omp do schedule(runtime)
  over_cells: do icell=1,int(ncells)
 
-    k = itypecell(icell)
-
     ! Skip empty/inactive cells
-    if (k <= 0) cycle over_cells
+    if (leaf_is_active(icell) <= 0) cycle over_cells
 
     ! Get neighbour list for the cell
     call get_neighbour_list(icell,listneigh,nneigh,xyzh,xyzcache,maxcellcache,getj=.true.)

--- a/src/utils/utils_getneighbours.F90
+++ b/src/utils/utils_getneighbours.F90
@@ -15,7 +15,7 @@ module getneighbours
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: boundary, dim, kdtree, kernel, linklist, part
+! :Dependencies: boundary, dim, kdtree, kernel, neighkdtree, part
 !
  implicit none
 
@@ -38,13 +38,13 @@ contains
 !+
 !-----------------------------------------------------------------------
 subroutine generate_neighbour_lists(xyzh,vxyzu,npart,dumpfile,write_neighbour_list)
- use dim,      only:maxp
- use kernel,   only:radkern2
- use linklist, only:ncells, ifirstincell, set_linklist, get_neighbour_list
- use part,     only:get_partinfo, igas, maxphase, iphase, iamboundary, iamtype
- use kdtree,   only:inodeparts,inoderange
+ use dim,         only:maxp
+ use kernel,      only:radkern2
+ use neighkdtree, only:ncells, ifirstincell, build_tree, get_neighbour_list
+ use part,        only:get_partinfo, igas, maxphase, iphase, iamboundary, iamtype
+ use kdtree,      only:inodeparts,inoderange
 #ifdef PERIODIC
- use boundary, only:dxbound,dybound,dzbound
+ use boundary,    only:dxbound,dybound,dzbound
 #endif
  real,             intent(in)     :: xyzh(:,:),vxyzu(:,:)
  integer,          intent(in)     :: npart
@@ -74,7 +74,7 @@ subroutine generate_neighbour_lists(xyzh,vxyzu,npart,dumpfile,write_neighbour_li
  allocate(dumxyzh(4,npart))
  dumxyzh = xyzh
  dummynpart = npart
- call set_linklist(dummynpart,npart,dumxyzh,vxyzu(:,1:npart))
+ call build_tree(dummynpart,npart,dumxyzh,vxyzu(:,1:npart))
 
  print*, 'Allocating arrays for neighbour storage : '
  allocate(neighcount(npart))

--- a/src/utils/utils_raytracer_all.f90
+++ b/src/utils/utils_raytracer_all.f90
@@ -869,7 +869,7 @@ end subroutine get_tau_on_ray
  !+
  !--------------------------------------------------------------------------
 subroutine ray_tracer(primary, ray, xyzh, kappa, Rstar, tau_along_ray, dist_along_ray, len, maxDistance)
- use neighkdtree, only:getneigh_pos,itypecell,listneigh
+ use neighkdtree, only:getneigh_pos,leaf_is_active,listneigh
  use kernel,      only:radkern
  use units,       only:umass,udist
  real, intent(in)     :: primary(3), ray(3), Rstar, xyzh(:,:), kappa(:)
@@ -888,7 +888,7 @@ subroutine ray_tracer(primary, ray, xyzh, kappa, Rstar, tau_along_ray, dist_alon
  inext=0
  do while (inext==0)
     h = h*2.
-    call getneigh_pos(primary+Rstar*ray,0.,h,3,listneigh,nneigh,xyzcache,maxcache,itypecell)
+    call getneigh_pos(primary+Rstar*ray,0.,h,3,listneigh,nneigh,xyzcache,maxcache,leaf_is_active)
     call find_next(primary, ray, distance, xyzh, listneigh, inext, nneigh)
  enddo
  call calc_opacity(primary+Rstar*ray, xyzh, kappa, listneigh, nneigh, previousdtaudr)
@@ -900,7 +900,7 @@ subroutine ray_tracer(primary, ray, xyzh, kappa, Rstar, tau_along_ray, dist_alon
  do while (hasNext(inext,tau_along_ray(i),distance,maxDistance))
     i = i + 1
     call getneigh_pos(primary + distance*ray,0.,xyzh(4,inext)*radkern, &
-                              3,listneigh,nneigh,xyzcache,maxcache,itypecell)
+                              3,listneigh,nneigh,xyzcache,maxcache,leaf_is_active)
     call calc_opacity(primary + distance*ray, xyzh, kappa, listneigh, nneigh, nextdtaudr)
     dtaudr            = (nextdtaudr+previousdtaudr)/2
     previousdtaudr    = nextdtaudr
@@ -1057,7 +1057,7 @@ end subroutine get_all_tau_inwards_companion
  !+
  !--------------------------------------------------------------------------
 subroutine get_tau_inwards(point, primary, xyzh, neighbors, kappa, Rstar, tau)
- use neighkdtree, only:getneigh_pos,itypecell,listneigh
+ use neighkdtree, only:getneigh_pos,leaf_is_active,listneigh
  use kernel,      only:radkern
  use units,       only:umass,udist
  real, intent(in)    :: primary(3), xyzh(:,:), kappa(:), Rstar
@@ -1075,7 +1075,7 @@ subroutine get_tau_inwards(point, primary, xyzh, neighbors, kappa, Rstar, tau)
  maxDist=max(maxDist-Rstar,0.)
  next=point
  call getneigh_pos(xyzh(1:3,point),0.,xyzh(4,point)*radkern, &
-                           3,listneigh,nneigh,xyzcache,nmaxcache,itypecell)
+                           3,listneigh,nneigh,xyzcache,nmaxcache,leaf_is_active)
  call calc_opacity(xyzh(1:3,point), xyzh, kappa, listneigh, nneigh, nextdtaudr)
  nextDist=0.
 
@@ -1090,7 +1090,7 @@ subroutine get_tau_inwards(point, primary, xyzh, neighbors, kappa, Rstar, tau)
        nextDist = maxDist
     endif
     call getneigh_pos(xyzh(1:3,point) + nextDist*ray,0.,xyzh(4,previous)*radkern, &
-                              3,listneigh,nneigh,xyzcache,nmaxcache,itypecell)
+                              3,listneigh,nneigh,xyzcache,nmaxcache,leaf_is_active)
     previousdtaudr=nextdtaudr
     call calc_opacity(xyzh(1:3,point) + nextDist*ray, xyzh, kappa, listneigh, nneigh, nextdtaudr)
     dtaudr = (nextdtaudr+previousdtaudr)/2

--- a/src/utils/utils_raytracer_all.f90
+++ b/src/utils/utils_raytracer_all.f90
@@ -14,7 +14,7 @@ module raytracer_all
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: dim, healpix, kernel, linklist, part, units
+! :Dependencies: dim, healpix, kernel, neighkdtree, part, units
 !
  use healpix
  implicit none
@@ -869,9 +869,9 @@ end subroutine get_tau_on_ray
  !+
  !--------------------------------------------------------------------------
 subroutine ray_tracer(primary, ray, xyzh, kappa, Rstar, tau_along_ray, dist_along_ray, len, maxDistance)
- use linklist, only:getneigh_pos,ifirstincell,listneigh
- use kernel,   only:radkern
- use units, only:umass,udist
+ use neighkdtree, only:getneigh_pos,ifirstincell,listneigh
+ use kernel,      only:radkern
+ use units,       only:umass,udist
  real, intent(in)     :: primary(3), ray(3), Rstar, xyzh(:,:), kappa(:)
  real, optional       :: maxDistance
  real, intent(out)    :: dist_along_ray(:), tau_along_ray(:)
@@ -1057,9 +1057,9 @@ end subroutine get_all_tau_inwards_companion
  !+
  !--------------------------------------------------------------------------
 subroutine get_tau_inwards(point, primary, xyzh, neighbors, kappa, Rstar, tau)
- use linklist, only:getneigh_pos,ifirstincell,listneigh
- use kernel,   only:radkern
- use units, only:umass,udist
+ use neighkdtree, only:getneigh_pos,ifirstincell,listneigh
+ use kernel,      only:radkern
+ use units,       only:umass,udist
  real, intent(in)    :: primary(3), xyzh(:,:), kappa(:), Rstar
  integer, intent(in) :: point, neighbors(:,:)
  real, intent(out)   :: tau

--- a/src/utils/utils_raytracer_all.f90
+++ b/src/utils/utils_raytracer_all.f90
@@ -869,7 +869,7 @@ end subroutine get_tau_on_ray
  !+
  !--------------------------------------------------------------------------
 subroutine ray_tracer(primary, ray, xyzh, kappa, Rstar, tau_along_ray, dist_along_ray, len, maxDistance)
- use neighkdtree, only:getneigh_pos,ifirstincell,listneigh
+ use neighkdtree, only:getneigh_pos,itypecell,listneigh
  use kernel,      only:radkern
  use units,       only:umass,udist
  real, intent(in)     :: primary(3), ray(3), Rstar, xyzh(:,:), kappa(:)
@@ -888,7 +888,7 @@ subroutine ray_tracer(primary, ray, xyzh, kappa, Rstar, tau_along_ray, dist_alon
  inext=0
  do while (inext==0)
     h = h*2.
-    call getneigh_pos(primary+Rstar*ray,0.,h,3,listneigh,nneigh,xyzcache,maxcache,ifirstincell)
+    call getneigh_pos(primary+Rstar*ray,0.,h,3,listneigh,nneigh,xyzcache,maxcache,itypecell)
     call find_next(primary, ray, distance, xyzh, listneigh, inext, nneigh)
  enddo
  call calc_opacity(primary+Rstar*ray, xyzh, kappa, listneigh, nneigh, previousdtaudr)
@@ -900,7 +900,7 @@ subroutine ray_tracer(primary, ray, xyzh, kappa, Rstar, tau_along_ray, dist_alon
  do while (hasNext(inext,tau_along_ray(i),distance,maxDistance))
     i = i + 1
     call getneigh_pos(primary + distance*ray,0.,xyzh(4,inext)*radkern, &
-                              3,listneigh,nneigh,xyzcache,maxcache,ifirstincell)
+                              3,listneigh,nneigh,xyzcache,maxcache,itypecell)
     call calc_opacity(primary + distance*ray, xyzh, kappa, listneigh, nneigh, nextdtaudr)
     dtaudr            = (nextdtaudr+previousdtaudr)/2
     previousdtaudr    = nextdtaudr
@@ -1057,7 +1057,7 @@ end subroutine get_all_tau_inwards_companion
  !+
  !--------------------------------------------------------------------------
 subroutine get_tau_inwards(point, primary, xyzh, neighbors, kappa, Rstar, tau)
- use neighkdtree, only:getneigh_pos,ifirstincell,listneigh
+ use neighkdtree, only:getneigh_pos,itypecell,listneigh
  use kernel,      only:radkern
  use units,       only:umass,udist
  real, intent(in)    :: primary(3), xyzh(:,:), kappa(:), Rstar
@@ -1075,7 +1075,7 @@ subroutine get_tau_inwards(point, primary, xyzh, neighbors, kappa, Rstar, tau)
  maxDist=max(maxDist-Rstar,0.)
  next=point
  call getneigh_pos(xyzh(1:3,point),0.,xyzh(4,point)*radkern, &
-                           3,listneigh,nneigh,xyzcache,nmaxcache,ifirstincell)
+                           3,listneigh,nneigh,xyzcache,nmaxcache,itypecell)
  call calc_opacity(xyzh(1:3,point), xyzh, kappa, listneigh, nneigh, nextdtaudr)
  nextDist=0.
 
@@ -1090,7 +1090,7 @@ subroutine get_tau_inwards(point, primary, xyzh, neighbors, kappa, Rstar, tau)
        nextDist = maxDist
     endif
     call getneigh_pos(xyzh(1:3,point) + nextDist*ray,0.,xyzh(4,previous)*radkern, &
-                              3,listneigh,nneigh,xyzcache,nmaxcache,ifirstincell)
+                              3,listneigh,nneigh,xyzcache,nmaxcache,itypecell)
     previousdtaudr=nextdtaudr
     call calc_opacity(xyzh(1:3,point) + nextDist*ray, xyzh, kappa, listneigh, nneigh, nextdtaudr)
     dtaudr = (nextdtaudr+previousdtaudr)/2


### PR DESCRIPTION
Description:

This PR removes or renames every variable, comment, file name, module name, routine name or doc that references the deprecated linked list used to find neighbours. This linked list is not used anymore and has been replaced by the actual cached, tree-based neighbour finding. It will clarify the code reading in the future and avoid confusion for further development on the tree. 

I'm planning to add a secondary tree using only sink particles to optimise the accretion loop when the sink number starts to go higher than a thousand. It was then necessary to do this cleaning before doing any modifications to the tree routines.

The major changes:
- `linklist_kdtree.f90` -> `neigh_kdtree.f90` file name
- `linklist`                     -> `neighkdtree`         module name
- `set_linklist`              -> `build_tree`             routine name
- `ifirstincell`               -> `icell_is_active`                variable name
- `test_link.F90`          -> `test_neigh.f90`     file name
- `testlink`                   -> `testneigh`              module name
- `itimer_link`             -> `itimer_tree`            variable name

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [x] Setup (src/setup)
- [x] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [x] Analysis utilities (src/utils/analysis)
- [x] Documentation (docs/)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [x] Documentation update
- [x] Other : rm deprecated linkedlist refs

Testing:
It is just a big rename operation; nothing should be broken. Tests should all be green if I missed nothing.

Did you run the bots? yes

Did you update relevant documentation in the docs directory? yes

Did you add comments such that the purpose of the code is understandable? yes