### PR TITLE
Continue cleanups done in #711

### DIFF
--- a/src/main/H2regions.f90
+++ b/src/main/H2regions.f90
@@ -232,7 +232,7 @@ subroutine HII_feedback(nptmass,npart,xyzh,xyzmh_ptmass,vxyzu,isionised,dt)
           hcheck = Rmax
        endif
        do while(hcheck <= Rmax)
-          call getneigh_pos((/xi,yi,zi/),0.,hcheck,3,listneigh,nneigh,xyzcache,maxcache,leaf_is_active)
+          call getneigh_pos((/xi,yi,zi/),0.,hcheck,listneigh,nneigh,xyzcache,maxcache,leaf_is_active)
           call set_r2func_origin(xi,yi,zi)
           call Knnfunc(nneigh,r2func_origin,xyzh,listneigh) !! Here still serial version of the quicksort. Parallel version in prep..
           if (nneigh > 0) exit

--- a/src/main/dens.F90
+++ b/src/main/dens.F90
@@ -1692,7 +1692,7 @@ subroutine get_density_at_pos(x,rho,itype)
  real :: dx,dy,dz,hj1,rij2,q2j,qj,pmassj,wabi,grkerni
  logical :: same_type
 
- call getneigh_pos(x,0.,0.,3,listneigh,nneigh,xyzcache,maxcache,leaf_is_active,get_j=.true.)
+ call getneigh_pos(x,0.,0.,listneigh,nneigh,xyzcache,maxcache,leaf_is_active,get_j=.true.)
  same_type=.true.
  rho = 0.
  loop_over_neigh: do n=1,nneigh

--- a/src/main/dtype_kdtree.F90
+++ b/src/main/dtype_kdtree.F90
@@ -19,7 +19,7 @@ module dtypekdtree
  implicit none
 
  integer, parameter :: kdnode_bytes = &
-                      8*3 &  ! xcen(ndimtree)
+                      8*3 &  ! xcen(3)
                     + 8 &    ! size
                     + 8 &    ! hmax
                     + 8 &    ! mass

--- a/src/main/dtype_kdtree.F90
+++ b/src/main/dtype_kdtree.F90
@@ -17,29 +17,27 @@ module dtypekdtree
 ! :Dependencies: io, mpi, mpiutils
 !
  implicit none
- integer, parameter :: ndimtree = 3
 
  integer, parameter :: kdnode_bytes = &
-                      8*ndimtree &  ! xcen(ndimtree)
-                    + 8 &           ! size
-                    + 8 &           ! hmax
-                    + 4 &           ! leftchild
-                    + 4 &           ! rightchild
-                    + 4 &           ! parent
+                      8*3 &  ! xcen(ndimtree)
+                    + 8 &    ! size
+                    + 8 &    ! hmax
+                    + 8 &    ! mass
+                    + 4 &    ! leftchild
+                    + 4 &    ! rightchild
+                    + 4 &    ! parent
 #ifdef GRAVITY
-                    + 8 &           ! mass
-                    + 8*6 &         ! quads(6)
+                    + 8*6 &  ! quads(6)
 #endif
                     + 0
 
  private
- public :: ndimtree
  public :: kdnode
  public :: kdnode_bytes
  public :: get_mpitype_of_kdnode
  type kdnode
     sequence
-    real :: xcen(ndimtree)
+    real :: xcen(3)
     real :: size
     real :: hmax
     real :: mass   ! avoid ifort warning: align on 4-byte boundary

--- a/src/main/neigh_kdtree.f90
+++ b/src/main/neigh_kdtree.f90
@@ -41,7 +41,7 @@ module neighkdtree
  public :: allocate_neigh, deallocate_neigh
  public :: build_tree, get_neighbour_list, write_inopts_tree, read_inopts_tree
  public :: get_distance_from_centre_of_mass, getneigh_pos
- public :: set_hmaxcell,get_hmaxcell,update_hmax_remote
+ public :: set_hmaxcell,get_hmaxcell
  public :: get_cell_location
  public :: sync_hmax_mpi
 
@@ -108,30 +108,6 @@ subroutine set_hmaxcell(inode,hmaxcell)
  enddo
 
 end subroutine set_hmaxcell
-
-subroutine update_hmax_remote(ncells)
- use mpiutils, only:reduceall_mpi
- integer(kind=8), intent(in) :: ncells
- integer :: n,j
- real :: hmaxcell
-
- ! could do only active cells by checking leaf_is_active >= 0
- do n=1,int(ncells)
-    if (leaf_is_active(n) > 0) then
-       ! reduce on leaf nodes
-       node(n)%hmax = reduceall_mpi('max',node(n)%hmax)
-
-       ! propagate up local tree from active cells
-       hmaxcell = node(n)%hmax
-       j = n
-       do while (node(j)%parent  /=  0)
-          j = node(j)%parent
-          node(j)%hmax = max(node(j)%hmax, hmaxcell)
-       enddo
-    endif
- enddo
-
-end subroutine update_hmax_remote
 
 subroutine get_distance_from_centre_of_mass(inode,xi,yi,zi,dx,dy,dz,xcen)
  integer,   intent(in)           :: inode

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -1140,7 +1140,6 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,pxyzu,fxyzu,fext,divcurlv,pote
                          ispinx,ispiny,ispinz,eos_vars,igasP,igamma,ndptmass,apr_level,aprmassoftype,metrics_ptmass,&
                          isftype,inseed
  use dim,           only:maxp,maxvxyzu,maxptmass,ind_timesteps,use_apr,maxpsph,gr
- use kdtree,        only:getneigh
  use kernel,        only:kernel_softening,radkern
  use io,            only:id,iprint,fatal,iverbose,nprocs
 #ifdef PERIODIC
@@ -1304,7 +1303,7 @@ subroutine ptmass_create(nptmass,npart,itest,xyzh,pxyzu,fxyzu,fext,divcurlv,pote
 
  ! CHECK 3: all neighbours are all active ( & perform math for checks 4-6)
  ! find neighbours within the checking radius of hcheck
- call getneigh_pos((/xi,yi,zi/),0.,hcheck,3,listneigh,nneigh,xyzcache,maxcache,leaf_is_active)
+ call getneigh_pos((/xi,yi,zi/),0.,hcheck,listneigh,nneigh,xyzcache,maxcache,leaf_is_active)
  ! determine if we should approximate epot
  calc_exact_epot = .true.
  if ((nneigh_thresh > 0 .and. nneigh > nneigh_thresh) .or. (nprocs > 1)) calc_exact_epot = .false.

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -38,8 +38,8 @@ module ptmass
 !
 ! :Dependencies: HIIRegion, boundary, densityforce, dim, eos,
 !   eos_barotropic, eos_piecewise, extern_geopot, extern_gr,
-!   externalforces, infile_utils, io, io_summary, kdtree, kernel,
-!   metric_tools, mpidomain, mpiutils, neighkdtree, options, part, physcon,
+!   externalforces, infile_utils, io, io_summary, kernel, metric_tools,
+!   mpidomain, mpiutils, neighkdtree, options, part, physcon,
 !   ptmass_heating, random, subgroup, timestep, units, utils_kepler,
 !   vectorutils
 !

--- a/src/main/utils_raytracer.f90
+++ b/src/main/utils_raytracer.f90
@@ -494,7 +494,7 @@ subroutine find_next(inpoint, h, ray, xyzh, kappa, dtaudr, distance, inext)
  distance = 0.
 
  !for a given point (inpoint), returns the list of neighbouring particles (listneigh) within a radius h*radkern
- call getneigh_pos(inpoint,0.,h*radkern,3,listneigh,nneigh,xyzcache,nmaxcache,leaf_is_active)
+ call getneigh_pos(inpoint,0.,h*radkern,listneigh,nneigh,xyzcache,nmaxcache,leaf_is_active)
 
  dtaudr = 0.
  dmin = huge(0.)

--- a/src/tests/test_kdtree.F90
+++ b/src/tests/test_kdtree.F90
@@ -72,7 +72,7 @@ subroutine test_kdtree(ntests,npass)
     !
     call empty_tree(node)
     call cpu_time(t1)
-    call maketree(node,xyzh,npart,3,leaf_is_active,ncells,apr_tree=.false.)
+    call maketree(node,xyzh,npart,leaf_is_active,ncells,apr_tree=.false.)
     call cpu_time(t2)
     call print_time(t2-t1,'maketree completed in')
     !

--- a/src/utils/analysis_pairing.f90
+++ b/src/utils/analysis_pairing.f90
@@ -48,7 +48,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
  nneightot = 0
  do i=1,npart
     if (.not.isdead_or_accreted(xyzh(4,i))) then
-       call getneigh_pos(xyzh(1:3,i),0.,xyzh(4,i),3,listneigh,nneigh,xyzh,xyzcache,maxcache,leaf_is_active)
+       call getneigh_pos(xyzh(1:3,i),0.,xyzh(4,i),listneigh,nneigh,xyzh,xyzcache,maxcache,leaf_is_active)
        h2 = xyzh(4,i)**2
        ncheck = ncheck + 1
        do n = 1,nneigh

--- a/src/utils/utils_raytracer_all.f90
+++ b/src/utils/utils_raytracer_all.f90
@@ -888,7 +888,7 @@ subroutine ray_tracer(primary, ray, xyzh, kappa, Rstar, tau_along_ray, dist_alon
  inext=0
  do while (inext==0)
     h = h*2.
-    call getneigh_pos(primary+Rstar*ray,0.,h,3,listneigh,nneigh,xyzcache,maxcache,leaf_is_active)
+    call getneigh_pos(primary+Rstar*ray,0.,h,listneigh,nneigh,xyzcache,maxcache,leaf_is_active)
     call find_next(primary, ray, distance, xyzh, listneigh, inext, nneigh)
  enddo
  call calc_opacity(primary+Rstar*ray, xyzh, kappa, listneigh, nneigh, previousdtaudr)
@@ -900,7 +900,7 @@ subroutine ray_tracer(primary, ray, xyzh, kappa, Rstar, tau_along_ray, dist_alon
  do while (hasNext(inext,tau_along_ray(i),distance,maxDistance))
     i = i + 1
     call getneigh_pos(primary + distance*ray,0.,xyzh(4,inext)*radkern, &
-                              3,listneigh,nneigh,xyzcache,maxcache,leaf_is_active)
+                              listneigh,nneigh,xyzcache,maxcache,leaf_is_active)
     call calc_opacity(primary + distance*ray, xyzh, kappa, listneigh, nneigh, nextdtaudr)
     dtaudr            = (nextdtaudr+previousdtaudr)/2
     previousdtaudr    = nextdtaudr
@@ -1075,7 +1075,7 @@ subroutine get_tau_inwards(point, primary, xyzh, neighbors, kappa, Rstar, tau)
  maxDist=max(maxDist-Rstar,0.)
  next=point
  call getneigh_pos(xyzh(1:3,point),0.,xyzh(4,point)*radkern, &
-                           3,listneigh,nneigh,xyzcache,nmaxcache,leaf_is_active)
+                           listneigh,nneigh,xyzcache,nmaxcache,leaf_is_active)
  call calc_opacity(xyzh(1:3,point), xyzh, kappa, listneigh, nneigh, nextdtaudr)
  nextDist=0.
 
@@ -1090,7 +1090,7 @@ subroutine get_tau_inwards(point, primary, xyzh, neighbors, kappa, Rstar, tau)
        nextDist = maxDist
     endif
     call getneigh_pos(xyzh(1:3,point) + nextDist*ray,0.,xyzh(4,previous)*radkern, &
-                              3,listneigh,nneigh,xyzcache,nmaxcache,leaf_is_active)
+                              listneigh,nneigh,xyzcache,nmaxcache,leaf_is_active)
     previousdtaudr=nextdtaudr
     call calc_opacity(xyzh(1:3,point) + nextDist*ray, xyzh, kappa, listneigh, nneigh, nextdtaudr)
     dtaudr = (nextdtaudr+previousdtaudr)/2


### PR DESCRIPTION
Description:
Further cleanups in tree routines. Remove deprecated `ndim` and `ndimtree`. `irootnode` is now a parameter equal to 1. Remove unused `update_hmax_remote`

Components modified:
- [ ] Setup (src/setup)
- [X] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [ ] Documentation (docs/)

Type of change:
- [ ] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [x] Other (please describe)
- [x] cleanups  

Testing:
Should be the same in the tests...

Did you run the bots? yes

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? no

Is there a unit test that could be added for this feature/bug? no