### PR TITLE
[CI] split ci by events and add concurrency on PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,16 +1,7 @@
 name: build
 
 on:
-  push:
-    branches: [ master ]
-    paths-ignore:
-      - 'docs/**'
-      - 'README.md'
-  pull_request:
-    branches: [ master ]
-    paths-ignore:
-      - 'docs/**'
-      - 'README.md'
+  workflow_call:
 
 env:
   OMP_STACKSIZE: 512M

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,35 +124,13 @@ jobs:
         RETURN_ERR: yes
 
     - name: Summary of build failures with SYSTEM=${{ matrix.system }}
-      if: always()
+      if: success() || failure()
       run: cat logs/build-failures-${{ matrix.system }}.txt || true
 
     - name: Summary of setup failures with SYSTEM=${{ matrix.system }}
-      if: always()
+      if: success() || failure()
       run: cat logs/setup-failures-${{ matrix.system }}.txt || true
 
     - name: Summary of analysis failures with SYSTEM=${{ matrix.system }}
-      if: always()
+      if: success() || failure()
       run: cat logs/analysis-failures-${{ matrix.system }}.txt || true
-
-  # Gather results into a dummy job that will fail if the previous job fails
-  gather_results:
-    if: ${{ always() && github.event_name != 'schedule' }}
-    needs:
-    - build
-
-    # This name matches the branch protection requirement
-    name: build
-
-    # Always run on github runner; no need to use custom runner for the check
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Check all builds succeeded
-      run: |
-        if [[ "${{ needs.build.result }}" == "success" ]]; then
-          echo "All build succeeded"
-        else
-          echo "At least one build failed"
-          exit 1
-        fi

--- a/.github/workflows/growth.yml
+++ b/.github/workflows/growth.yml
@@ -1,12 +1,7 @@
 name: growth
 
-# Trigger on pull request, but only for the master branch
 on:
-  pull_request:
-    branches: [ master ]
-    paths-ignore:
-      - 'docs/**'
-      - 'README.md'
+  workflow_call:
 
 env:
   SYSTEM: gfortran

--- a/.github/workflows/krome.yml
+++ b/.github/workflows/krome.yml
@@ -1,12 +1,7 @@
 name: krome
 
-# Trigger on pull request, but only for the master branch
 on:
-  pull_request:
-    branches: [ master ]
-    paths-ignore:
-      - 'docs/**'
-      - 'README.md'
+  workflow_call:
 
 env:
   PREFIX: /usr/local/

--- a/.github/workflows/mcfost.yml
+++ b/.github/workflows/mcfost.yml
@@ -1,12 +1,7 @@
 name: mcfost
 
-# Trigger on pull request, but only for the master branch
 on:
-  pull_request:
-    branches: [ master ]
-    paths-ignore:
-      - 'docs/**'
-      - 'README.md'
+  workflow_call:
 
 env:
   PREFIX: /opt/homebrew

--- a/.github/workflows/mpi.yml
+++ b/.github/workflows/mpi.yml
@@ -60,24 +60,3 @@ jobs:
 
     - name: Test with MPI
       run: mpirun --allow-run-as-root -np ${{ matrix.ntasks }} --oversubscribe ./bin/phantomtest ${{ matrix.input[1] }}
-
-  # Gather results into a dummy job that will fail if the previous job fails
-  gather_results:
-    if: always()
-    needs:
-    - test
-
-    # This name matches the branch protection requirement
-    name: mpi
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Check all tests
-      run: |
-        if [[ "${{ needs.test.result }}" == "success" ]]; then
-          echo "All tests succeeded"
-        else
-          echo "At least one test failed"
-          exit 1
-        fi

--- a/.github/workflows/mpi.yml
+++ b/.github/workflows/mpi.yml
@@ -1,10 +1,7 @@
 name: mpi
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -12,7 +12,7 @@ concurrency:
     cancel-in-progress: true
     
 jobs:
-
+ 
     build:
         name: Build
         uses: ./.github/workflows/build.yml

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -1,3 +1,5 @@
+name: pr
+
 on:
     pull_request:
       branches: [ master ]

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -1,5 +1,3 @@
-name: "On PR"
-
 on:
     pull_request:
       branches: [ master ]
@@ -14,25 +12,19 @@ concurrency:
 jobs:
 
     build:
-        name: Build
         uses: ./.github/workflows/build.yml
 
     test:
-        name: Tests
         uses: ./.github/workflows/test.yml
 
     mpi:
-        name: MPI
         uses: ./.github/workflows/mpi.yml
 
     mcfost:
-        name: McFost
         uses: ./.github/workflows/mcfost.yml
         
     growth:
-        name: Growth
         uses: ./.github/workflows/growth.yml
 
     krome:
-        name: Krome
         uses: ./.github/workflows/krome.yml

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -32,9 +32,12 @@ jobs:
         uses: ./.github/workflows/krome.yml
 
     summary:
+
+        # This name matches the branch protection requirement
         name: summary
+        
         needs: [build, test, mpi, mcfost, growth, krome]
-        if: always() && github.event_name == 'pull_request'
+        if: success() || failure() && github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         steps:
         - name: Check all jobs succeeded

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -1,0 +1,38 @@
+name: "On PR"
+
+on:
+    pull_request:
+      branches: [ master ]
+      paths-ignore:
+        - 'docs/**'
+        - 'README.md'
+
+concurrency:
+    group: ci-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
+    cancel-in-progress: true
+    
+jobs:
+
+    build:
+        name: Build
+        uses: ./.github/workflows/build.yml
+
+    test:
+        name: Tests
+        uses: ./.github/workflows/test.yml
+
+    mpi:
+        name: MPI
+        uses: ./.github/workflows/mpi.yml
+
+    mcfost:
+        name: McFost
+        uses: ./.github/workflows/mcfost.yml
+        
+    growth:
+        name: Growth
+        uses: ./.github/workflows/growth.yml
+
+    krome:
+        name: Krome
+        uses: ./.github/workflows/krome.yml

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -12,7 +12,7 @@ concurrency:
     cancel-in-progress: true
     
 jobs:
- 
+
     build:
         name: Build
         uses: ./.github/workflows/build.yml

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -28,3 +28,55 @@ jobs:
 
     krome:
         uses: ./.github/workflows/krome.yml
+
+    summary:
+        name: summary
+        needs: [build, test, mpi, mcfost, growth, krome]
+        if: always() && github.event_name == 'pull_request'
+        runs-on: ubuntu-latest
+        steps:
+        - name: Check all jobs succeeded
+          run: |
+            if [[ "${{ needs.build.result }}" == "success" ]]; then
+              echo "All build jobs succeeded"
+            else
+              echo "At least one job failed"
+              exit 1
+            fi
+
+            if [[ "${{ needs.test.result }}" == "success" ]]; then
+              echo "All test jobs succeeded"
+            else
+              echo "At least one test failed"
+              exit 1
+            fi
+            
+            if [[ "${{ needs.mpi.result }}" == "success" ]]; then
+              echo "All MPI jobs succeeded"
+            else
+              echo "At least one MPI test failed"
+              exit 1
+            fi
+            
+            if [[ "${{ needs.mcfost.result }}" == "success" ]]; then
+              echo "All McFost jobs succeeded"
+            else
+              echo "At least one McFost test failed"
+              exit 1
+            fi
+            
+            if [[ "${{ needs.growth.result }}" == "success" ]]; then
+              echo "All growth jobs succeeded"
+            else
+              echo "At least one growth test failed"
+              exit 1
+            fi
+            
+            if [[ "${{ needs.krome.result }}" == "success" ]]; then
+              echo "All Krome jobs succeeded"
+            else
+              echo "At least one Krome test failed"
+              exit 1
+            fi
+
+            echo "All tests succeeded"

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -1,5 +1,3 @@
-name: On Push
-
 on:
     push:
       branches: [ master ]
@@ -10,31 +8,19 @@ on:
 jobs:
 
     build:
-        name: Build
         uses: ./.github/workflows/build.yml
 
     test:
-        name: Tests
         uses: ./.github/workflows/test.yml
 
     mpi:
-        name: MPI
         uses: ./.github/workflows/mpi.yml
 
-    # Trigger only on pull request, change the if you want it to run also on push
     mcfost:
-        if: false
-        name: McFost
         uses: ./.github/workflows/mcfost.yml
 
-    # Trigger only on pull request, change the if you want it to run also on push
     growth:
-        if: false
-        name: Growth
         uses: ./.github/workflows/growth.yml
 
-    # Trigger only on pull request, change the if you want it to run also on push
     krome:
-        if: false
-        name: Krome
         uses: ./.github/workflows/krome.yml

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -1,0 +1,40 @@
+name: On Push
+
+on:
+    push:
+      branches: [ master ]
+      paths-ignore:
+        - 'docs/**'
+        - 'README.md'
+
+jobs:
+
+    build:
+        name: Build
+        uses: ./.github/workflows/build.yml
+
+    test:
+        name: Tests
+        uses: ./.github/workflows/test.yml
+
+    mpi:
+        name: MPI
+        uses: ./.github/workflows/mpi.yml
+
+    # Trigger only on pull request, change the if you want it to run also on push
+    mcfost:
+        if: false
+        name: McFost
+        uses: ./.github/workflows/mcfost.yml
+
+    # Trigger only on pull request, change the if you want it to run also on push
+    growth:
+        if: false
+        name: Growth
+        uses: ./.github/workflows/growth.yml
+
+    # Trigger only on pull request, change the if you want it to run also on push
+    krome:
+        if: false
+        name: Krome
+        uses: ./.github/workflows/krome.yml

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -1,3 +1,5 @@
+name: push 
+
 on:
     push:
       branches: [ master ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,7 @@
 name: test
 
 on:
-  push:
-    branches: [ master ]
-    paths-ignore:
-      - 'docs/**'
-      - 'README.md'
-  pull_request:
-    branches: [ master ]
-    paths-ignore:
-      - 'docs/**'
-      - 'README.md'
+  workflow_call:
 
 env:
   OMP_STACKSIZE: 512M

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,24 +61,3 @@ jobs:
 
     - name: "Run phantom tests"
       run: ./bin/phantomtest ${{ matrix.input[1] }}
-
-  # Gather results into a dummy job that will fail if the previous job fails
-  gather_results:
-    if: always()
-    needs:
-    - test
-
-    # This name matches the branch protection requirement
-    name: test
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Check all tests
-      run: |
-        if [[ "${{ needs.test.result }}" == "success" ]]; then
-          echo "All tests succeeded"
-        else
-          echo "At least one test failed"
-          exit 1
-        fi

--- a/src/main/mpi_derivs.F90
+++ b/src/main/mpi_derivs.F90
@@ -355,7 +355,7 @@ subroutine recv_while_wait_force(stack,xrecvbuf,irequestrecv,irequestsend,thread
  !$omp master
  do newproc=0,nprocs-1
     if (newproc /= id) then
-       call MPI_ISEND(counters(newproc+1,isent),1,MPI_INTEGER4,newproc,0,comm_cellcount,irequestsend(newproc+1),mpierr)
+       call MPI_ISEND(counters(newproc+1,isent)-100000,1,MPI_INTEGER4,newproc,0,comm_cellcount,irequestsend(newproc+1),mpierr)
     endif
  enddo
  !$omp end master

--- a/src/main/mpi_derivs.F90
+++ b/src/main/mpi_derivs.F90
@@ -355,7 +355,7 @@ subroutine recv_while_wait_force(stack,xrecvbuf,irequestrecv,irequestsend,thread
  !$omp master
  do newproc=0,nprocs-1
     if (newproc /= id) then
-       call MPI_ISEND(counters(newproc+1,isent)-100000,1,MPI_INTEGER4,newproc,0,comm_cellcount,irequestsend(newproc+1),mpierr)
+       call MPI_ISEND(counters(newproc+1,isent),1,MPI_INTEGER4,newproc,0,comm_cellcount,irequestsend(newproc+1),mpierr)
     endif
  enddo
  !$omp end master


### PR DESCRIPTION
Description:

This PR split the ci workflow into 1 file = 1 event and call the subsequent jobs using workflow calls to avoid duplication.
This allows the usage of GitHub job concurrency on PR to auto cancel old jobs if a new commit is pushed to the PR in the meantime

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Setup (src/setup)
- [ ] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [ ] Documentation (docs/)
- [x] CI

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [x] Other (please describe -> CI)

Testing:

Did you run the bots? no

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? no

Is there a unit test that could be added for this feature/bug? no