### PR TITLE
Apr file tracking and code update

### DIFF
--- a/src/main/apr.f90
+++ b/src/main/apr.f90
@@ -33,7 +33,6 @@ module apr
  logical :: apr_verbose = .false.
  logical :: do_relax = .false.
  logical :: adjusted_split = .true.
- logical :: directional = .true.
 
 contains
 
@@ -48,6 +47,7 @@ subroutine init_apr(apr_level,ierr)
  use utils_apr,     only:ntrack_max
  use get_apr_level, only:set_get_apr
  use io_summary,    only:print_apr,iosum_apr
+ use io,            only:warning
  integer,         intent(inout) :: ierr
  integer(kind=1), intent(inout) :: apr_level(:)
  logical :: previously_set
@@ -100,7 +100,10 @@ subroutine init_apr(apr_level,ierr)
     ntrack_max = 1
  endif
 
- if (ntrack_max > 1) directional = .false. ! no directional splitting for creating/multiple regions
+ if ((ntrack_max > 1) .and. (split_dir /= 3)) then
+   split_dir = 3 ! no directional splitting for creating/multiple regions
+   call warning('init_apr','resetting split_dir=3 because using multiple regions')
+ endif
 
  allocate(apr_centre(3,ntrack_max),track_part(ntrack_max))
  apr_centre(:,:) = 0.
@@ -427,7 +430,7 @@ subroutine splitpart(i,npartnew)
        if (.not.apr_region_is_circle) then
           dz = xyzh(3,i) - apr_centre(3,icentre)       ! for now, let's split about the CoM
 
-          if (directional) then
+          if (split_dir == 1) then
              ! Calculate a vector, v, that lies on the plane
              u = (/1.0,0.5,1.0/)
              w = (/dx,dy,dz/)

--- a/src/main/apr.f90
+++ b/src/main/apr.f90
@@ -92,7 +92,7 @@ subroutine init_apr(apr_level,ierr)
 
  ! how many regions do we need
  if (apr_type == 3) then
-    ntrack_max = 1000
+    ntrack_max = 999
     ntrack = 0 ! to start with
  elseif (apr_type == -1) then
     ntrack_max = 2

--- a/src/main/apr.f90
+++ b/src/main/apr.f90
@@ -342,8 +342,18 @@ subroutine splitpart(i,npartnew)
  integer :: j,npartold,next_door
  real :: theta,dx,dy,dz,x_add,y_add,z_add,sep,rneigh
  real :: v(3),u(3),w(3),a,b,c,mag_v,uold,hnew,pmass
- integer, save :: iseed = 4
+ real :: angle1, angle2, angle3
+ integer, save :: nangle = 1
  integer(kind=1) :: aprnew
+
+ ! set the "random" angles using some irrational numbers
+ ! this just increments a different irrational number for each
+ ! angle and calculates the remainder(angle,2*pi) so they always
+ ! sit between 0->2*pi
+ angle1 = nangle*(1./sqrt(2.)) - 2*pi*nint(nangle*(1./sqrt(2.))/(2.*pi)) + pi
+ angle2 = nangle*(sqrt(2.) - 1.) - 2*pi*nint(nangle*(sqrt(2.) - 1.)/(2.*pi)) + pi
+ angle3 = nangle*(pi - 3.) - 2*pi*nint(nangle*(pi - 3.)/(2.*pi)) + pi
+ nangle = nangle + 1 ! for next round
 
  if (adjusted_split) then
     call closest_neigh(i,next_door,rneigh)
@@ -437,13 +447,13 @@ subroutine splitpart(i,npartnew)
              call cross_product3D(u,w,v)
 
              ! rotate it around the normal to the plane by a random amount
-             theta = ran2(iseed)*2.*pi
+             theta = angle1
              call rotatevec(v,w,theta)
           else
              ! No directional splitting, so just create a unit vector in a random direction
-             a = ran2(iseed) - 0.5
-             b = ran2(iseed) - 0.5
-             c = ran2(iseed) - 0.5
+             a = angle1
+             b = angle2
+             c = angle3
              v = (/a, b, c/)
           endif
 

--- a/src/main/evolve_utils.F90
+++ b/src/main/evolve_utils.F90
@@ -263,10 +263,11 @@ end subroutine write_ev_files
 subroutine check_and_write_dump(time,tstart,tcpustart,rhomaxold,rhomaxnow,nsteps,&
                                 nout,noutput,noutput_dtmax,ncount_fulldumps,&
                                 dumpfile,infile,evfile,logfile,abortrun)
- use dim,              only:ind_timesteps,inject_parts,driving,idumpfile
+ use dim,              only:ind_timesteps,inject_parts,driving,idumpfile,use_apr
  use io,               only:iprint,iwritein,id,master,flush_warnings
  use fileutils,        only:getnextfilename
  use forcing,          only:write_forcingdump
+ use utils_apr,        only:write_aprtrack
  use options,          only:nfulldump,twallmax,write_files,rkill
  use part,             only:ideadhead,shuffle_part,npart,nptmass,xyzmh_ptmass,accrete_particles_outside_sphere
  use ptmass,           only:calculate_mdot
@@ -380,6 +381,7 @@ subroutine check_and_write_dump(time,tstart,tcpustart,rhomaxold,rhomaxnow,nsteps
     else
        call write_smalldump(time,dumpfile)
     endif
+    if (use_apr) call write_aprtrack(time,dumpfile)
  endif
  call get_timings(t2,tcpu2)
  call increment_timer(itimer_io,t2-t1,tcpu2-tcpu1)

--- a/src/main/io.F90
+++ b/src/main/io.F90
@@ -28,6 +28,7 @@ module io
  integer, public :: iprint, ievfile, idump, ireadin, iwritein, idisk1
  integer, public :: imflow, ivmflow, ibinpos, igpos
  integer, public :: ifile,ifdump,ifdumpread,ireadgrid,ireaddrv,ianalysis
+ integer, public :: iaprdump,iaprdumpread
  integer, public :: iscfile,iskfile,igit,iuniteos
 
  !--verboseness level is set to zero by default
@@ -109,6 +110,8 @@ subroutine set_io_unit_numbers
  igit       = 29 ! for reading phantom_version
  iscfile    = 32 ! for writing details of sink creation
  iskfile    =407 ! for writing details of the sink particles; opens files iskfile to iskfile+nptmass
+ iaprdump   = 52 ! for writing APR tracking information
+ iaprdumpread = 54 ! for reading APR tracking information
  iverbose   = 0
  fileprefix = '' ! blank by default, set to name of .in file
 

--- a/src/main/utils_apr.f90
+++ b/src/main/utils_apr.f90
@@ -292,4 +292,85 @@ subroutine write_options_apr(iunit)
 
 end subroutine write_options_apr
 
+!-----------------------------------------------------------------------
+!+
+!  Writes tracking file for APR regions
+!+
+!-----------------------------------------------------------------------
+
+subroutine write_aprtrack(tdump,dumpfile)
+ use io, only:iaprdump,error
+ real,             intent(in) :: tdump
+ character(len=*), intent(in) :: dumpfile
+ integer :: ierr, i, j
+ character(len=10) :: filename
+ character(len=3)  :: padded_ntrack
+ character(len=11) :: label
+ character(len=100) :: fmt
+ integer :: dumpfile_int, dump_length, start_pos
+ logical :: iexist
+
+
+ if (ntrack == 0) return ! nothing to do here
+
+ ! clever formatting
+ dump_length = len_trim(dumpfile)
+ start_pos = dump_length - 5 + 1
+ read(dumpfile(start_pos:dump_length), *) dumpfile_int
+ ! dynamically make the formatting string to accomodate the right number of regions
+ fmt = '(ES18.10,2X,I16.5,2X,3(ES18.10,1X)'
+ do j = 1,apr_max_in - 1
+   fmt = trim(fmt) // ',ES18.10,1X'
+ enddo
+ fmt = trim(fmt) // ',ES18.10)'
+
+
+ do i = 1,ntrack
+    filename = trim(dumpfile)//'.ev'
+    write(padded_ntrack, '(I3.3)') i
+    filename = 'apr_' // padded_ntrack // '.ev'
+
+    ! check if the file exists or not
+    inquire(file=filename,exist=iexist)
+    if (.not.iexist .or. (tdump < tiny(tdump))) then
+      ! create a new file
+      open(unit=iaprdump,file=filename,status='replace',form='formatted',iostat=ierr)
+      write(iaprdump, '("# APR info for region ",i3)') i
+      write(iaprdump, '("# ref_dir: ",i2)') ref_dir
+      write(iaprdump, '("# apr_type: ",i1)') apr_type
+      write(iaprdump, '("# split_dir: ",i1)') split_dir
+      write(iaprdump,"('#',5(1x,'[',i2.2,1x,a11,']',2x))",advance="no") &
+          1,'time', &
+          2,'dump', &
+          3,'x centre', &
+          4,'y centre', &
+          5,'z centre'
+          do j = 1,apr_max-1
+            write(label, '(A7,I0)') 'radius_', j  ! the different radii
+            label = adjustl(label)  ! remove leading spaces
+            label = label // repeat(' ', 11 - len_trim(label))  ! pad to 11 chars
+
+            write(iaprdump, "(1x,'[',i2.2,1x,a11,']',2x)", advance="no") 5 + j, label
+          enddo
+          write(iaprdump,*)
+    else
+     ! append the existing file
+     open(unit=iaprdump,file=filename,status='old',form='formatted',position='append',iostat=ierr)
+    endif
+
+    if (ierr /= 0) then
+       call error('write_aprtrack','could not open APR tracking file for writing')
+    else
+       if (ref_dir == 1) then
+          write(iaprdump,fmt) tdump,dumpfile_int,apr_centre(1:3,i),apr_regions(2:apr_max)
+       else
+          write(iaprdump,fmt) tdump,dumpfile_int,apr_centre(1:3,i),apr_regions(1:apr_max-1)
+       endif 
+
+    endif
+    close(unit=iaprdump)
+ enddo
+
+end subroutine write_aprtrack
+
 end module utils_apr

--- a/src/main/utils_apr.f90
+++ b/src/main/utils_apr.f90
@@ -19,7 +19,7 @@ module utils_apr
 !   - apr_type     : *1: static, 2: sink, 3: clumps, 4: sequential sinks, 5: com, 6: vertical*
 !   - ref_dir      : *increase (1) or decrease (-1) resolution*
 !   - rho_crit_cgs : *density above which apr zones are created (g/cm^3)*
-!   - split_dir    : *split particle (1) tangential to split boundary, (2) along trajectory*
+!   - split_dir    : *split particle (1) tangential to split boundary, (2) along trajectory, (3) purely randomly*
 !   - track_part   : *number of sink to track*
 !
 ! :Dependencies: infile_utils, io, part, ptmass
@@ -271,7 +271,7 @@ subroutine write_options_apr(iunit)
  write(iunit,"(/,a)") '# options for adaptive particle refinement'
  call write_inopt(apr_max_in,'apr_max','number of additional refinement levels (3 -> 2x resolution)',iunit)
  call write_inopt(ref_dir,'ref_dir','increase (1) or decrease (-1) resolution',iunit)
- call write_inopt(split_dir,'split_dir','split particle (1) tangential to split boundary, (2) along trajectory',iunit)
+ call write_inopt(split_dir,'split_dir','1: tangent to boundary, 2: along trajectory, 3: purely randomly',iunit)
  call write_inopt(apr_type,'apr_type','1: static, 2: sink, 3: clumps, 4: sequential sinks, 5: com, 6: vertical',iunit)
 
  select case (apr_type)


### PR DESCRIPTION
Description:
Added APR region tracking files. File prints the APR region location in x, y, z as well as the radii of the different refinement levels. File also includes the time stamp and the dumpfile number that it corresponds to.
Also tidied up some of the new options and removed the ran2 in the particle splitting code.

Components modified:
- [x] Main code (src/main)

Type of change:
- [x] Performance improvements
- [x] Code cleanup / refactor
- [x] New feature

Testing:
make DEBUG=yes

Did you run the bots? no

Did you update relevant documentation in the docs directory? N/A

Did you add comments such that the purpose of the code is understandable? yes

Is there a unit test that could be added for this feature/bug? N/A
