### PR TITLE
fix aocc build failure #689

### DIFF
--- a/src/setup/stretchmap.f90
+++ b/src/setup/stretchmap.f90
@@ -170,7 +170,7 @@ subroutine set_density_profile(np,xyzh,min,max,rhofunc,massfunc,rhotab,xtab,star
           endif
           xtable(1:nt) = xtab(1:nt)
        else
-          call linspace(xtable(1:nt),xmin,xmax)
+          call linspace(xtable,xmin,xmax)
        endif
        if (is_r) then
           call get_mass_tab_r(masstab,rhotab,xtable)
@@ -179,8 +179,8 @@ subroutine set_density_profile(np,xyzh,min,max,rhofunc,massfunc,rhotab,xtab,star
        else
           call get_mass_tab(masstab,rhotab,xtable)
        endif
-       totmass    = yinterp(masstab,xtable(1:nt),xmax)
-       rho_at_min = yinterp(rhotab,xtable(1:nt),xmin)
+       totmass    = yinterp(masstab,xtable,xmax)
+       rho_at_min = yinterp(rhotab,xtable,xmin)
     else
        if (isverbose) write(*,*) 'stretching to match density profile in '&
                        //trim(labelcoord(icoord,igeom))//' direction'
@@ -247,7 +247,7 @@ subroutine set_density_profile(np,xyzh,min,max,rhofunc,massfunc,rhotab,xtab,star
           xi    = xold   ! starting guess
           ! calc func to determine if tol is met
           if (use_rhotab) then
-             func  = yinterp(masstab,xtable(1:nt),xi)
+             func  = yinterp(masstab,xtable,xi)
           else
              if (is_r) then
                 func  = get_mass_r(rhofunc,xi,xmin)
@@ -267,13 +267,13 @@ subroutine set_density_profile(np,xyzh,min,max,rhofunc,massfunc,rhotab,xtab,star
              xprev = xi
              its   = its + 1
              if (use_rhotab) then
-                func  = yinterp(masstab,xtable(1:nt),xi) - fracmassold
+                func  = yinterp(masstab,xtable,xi) - fracmassold
                 if (is_r) then
-                   dfunc = 4.*pi*xi**2*yinterp(rhotab,xtable(1:nt),xi)
+                   dfunc = 4.*pi*xi**2*yinterp(rhotab,xtable,xi)
                 elseif (is_rcyl) then
-                   dfunc = 2.*pi*xi*yinterp(rhotab,xtable(1:nt),xi)
+                   dfunc = 2.*pi*xi*yinterp(rhotab,xtable,xi)
                 else
-                   dfunc = yinterp(rhotab,xtable(1:nt),xi)
+                   dfunc = yinterp(rhotab,xtable,xi)
                 endif
              else
                 if (is_r) then
@@ -318,7 +318,7 @@ subroutine set_density_profile(np,xyzh,min,max,rhofunc,massfunc,rhotab,xtab,star
              endif
           enddo
           if (use_rhotab) then
-             rhoi = yinterp(rhotab,xtable(1:nt),xi)
+             rhoi = yinterp(rhotab,xtable,xi)
           else
              rhoi = rhofunc(xi)
           endif


### PR DESCRIPTION
Description:
This PR fixes the sporadic failure in the test suite identified in #689. The code crashed due to a density set to `0.`  in `yinterp`, which was used in a division later in `strechmap.f90`. Sporadically, the `xtable` array had random values inside `yinterp`.   `xtable` was passed to `yinterp`  as `xtable(1:nt)`. I have read online that passing the array as a slice could result in a copy instead of passing a pointer when using no optimisation. `-O0` aocc compilation option is not fully tested yet and could hide a bug while doing this copy... This issue disappears with any other optimisation option, which suggests that it may be a compiler bug. I have tried to reproduce the issue in a simple snippet with no results... Passing `xtable` without the slice (not necessary in this part of the code) solved the issue.

Components modified:
- [X] Main code (src/main)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [x] Bug fix

Testing:
aocc build 19/32 should always pass now

Did you run the bots? no

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? no

Is there a unit test that could be added for this feature/bug? no

<!-- If this PR is related to an issue, please link it here -->
Related issues: #689 
