### PR TITLE
Flyby reconstructor^TM

### DIFF
--- a/src/main/utils_orbits.f90
+++ b/src/main/utils_orbits.f90
@@ -844,7 +844,6 @@ subroutine convert_posvel_to_flyby(mu,dx,dv,rp,d,e,O,w,inc,initial_sep,time_to_o
 
  ! Calculate orbital elements from position and velocity
  call get_orbital_elements(mu,dx,dv,a,e,inc,O,w,f)
- print*,' binary is at true anomaly of f = ',f
 
  ! Calculate pericenter distance
  rp = get_pericentre_distance(mu,dx,dv)

--- a/src/setup/set_orbit.f90
+++ b/src/setup/set_orbit.f90
@@ -223,11 +223,10 @@ subroutine set_orbit_elements(orbit,m1,m2,verbose)
 
     ! convert observed separation and velocity to rp,d,e,O,w,i,f
     call get_orbital_elements(mu,dx,dv,orbit%a,orbit%e,orbit%i,orbit%O,orbit%w,orbit%obs%f)
-    rp = get_pericentre_distance(mu,dx,dv)
 
     if (do_verbose) then
        print "(/,a,/)", ' Flyby Reconstructor^TM Recovered Orbital Parameters (at moment of observation):'
-       print "(a,g0.4)",'          rp in code units      = ',rp
+       print "(a,g0.4)",'          rp in code units      = ',get_pericentre_distance(mu,dx,dv)
        print "(a,g0.4)",'          semi-major axis a     = ',orbit%a
        print "(a,g0.4)",'          projected separation  = ',sqrt(dot_product(dx(1:2),dx(1:2)))
        print "(a,g0.4)",'          true separation       = ',sqrt(dot_product(dx,dx))
@@ -250,7 +249,6 @@ subroutine set_orbit_elements(orbit,m1,m2,verbose)
     if (do_verbose) then
        print "(a,g0.4)",'  starting true anomaly f (true anomaly, deg) = ',orbit%f
        print "(a,g0.4)",'  time to observation = ',time_to_obs
-       read*
     endif
  case(1)
     ! flyby elements give pericentre distance and initial separation, convert to reals

--- a/src/setup/set_orbit.f90
+++ b/src/setup/set_orbit.f90
@@ -33,12 +33,7 @@ module setorbit
  integer, parameter :: len_str = 20
 
  type campbell_elems
-    character(len=len_str) :: semi_major_axis ! string because can specific units
-    real :: e   ! eccentricity
-    real :: i   ! inclination
-    real :: O   ! position angle of the ascending node
-    real :: w   ! argument of periapsis
-    real :: f   ! initial true anomaly
+    character(len=len_str) :: a ! semi-major axis as a string because can specify units
  end type campbell_elems
 
  type posvel_elems
@@ -49,31 +44,26 @@ module setorbit
  end type posvel_elems
 
  type flyby_elems
-    character(len=20) :: rp   ! pericentre distance in arbitrary units
-    character(len=20) :: d    ! initial separation in arbitrary units
-    real :: O                 ! position angle of the ascending node
-    real :: i                 ! inclination
-    real :: w                 ! argument of periapsis
-    real :: e                 ! eccentricity
-    real :: a
-    real :: f
+    character(len=len_str) :: rp   ! pericentre distance in arbitrary units
+    character(len=len_str) :: d    ! initial separation in arbitrary units
  end type flyby_elems
 
  type obs_elems
     character(len=len_str) :: dx(3)
     character(len=len_str) :: dv(3)
-    character(len=len_str) :: initial_sep
+    real :: f  ! true anomaly at moment of observation
  end type obs_elems
 
  !
  ! generic type handling all options
  !
  type orbit_t
-    integer :: itype
+    integer :: input_type
+    real :: a,e,i,O,w,f
     type(campbell_elems) :: elems
     type(flyby_elems)    :: flyby
-    type(posvel_elems)   :: posvel
     type(obs_elems)      :: obs
+    type(posvel_elems)   :: posvel
  end type orbit_t
 
  private
@@ -88,20 +78,25 @@ contains
 subroutine set_defaults_orbit(orbit)
  type(orbit_t), intent(out) :: orbit
 
- orbit%itype = 0
- orbit%elems%semi_major_axis = '10.'
- orbit%elems%e = 0.0
- orbit%elems%i = 0.0
- orbit%elems%O = 0.0
- orbit%elems%w = 270.  ! argument of periapsis
- orbit%elems%f = 180.  ! start orbit at apocentre
+ orbit%input_type = 0
+ orbit%elems%a = '10.'
+ orbit%a = 10.0
+ orbit%e = 0.0
+ orbit%i = 0.0
+ orbit%O = 0.0
+ orbit%w = 270.  ! argument of periapsis
+ orbit%f = 180.  ! start orbit at apocentre
 
  orbit%flyby%rp = '200.'
  orbit%flyby%d = '2000.0'
- orbit%flyby%O = 0.0
- orbit%flyby%i = 0.0
- orbit%flyby%w = 270.0
- orbit%flyby%e = 2.0
+
+ orbit%obs%dx(1) = '20.0'
+ orbit%obs%dx(2) = '0.0'
+ orbit%obs%dx(3) = '0.0'
+ orbit%obs%dv(1) = '0.0'
+ orbit%obs%dv(2) = '2.0'
+ orbit%obs%dv(3) = '0.0'
+ orbit%obs%f = 0.
 
  orbit%posvel%x1 = '0.0'
  orbit%posvel%v1 = '0.0'
@@ -112,14 +107,6 @@ subroutine set_defaults_orbit(orbit)
  orbit%posvel%v1(2) = '1.0'
  orbit%posvel%v2(2) = '-1.0'
 
- orbit%obs%dx(1) = '20.0'
- orbit%obs%dx(2) = '0.0'
- orbit%obs%dx(3) = '0.0'
- orbit%obs%dv(1) = '0.0'
- orbit%obs%dv(2) = '2.0'
- orbit%obs%dv(3) = '0.0'
- orbit%obs%initial_sep = '200.0'
-
 end subroutine set_defaults_orbit
 
 !----------------------------------------------------------------
@@ -128,41 +115,26 @@ end subroutine set_defaults_orbit
 !+
 !----------------------------------------------------------------
 subroutine set_orbit(orbit,m1,m2,hacc1,hacc2,xyzmh_ptmass,vxyz_ptmass,nptmass,verbose,ierr,omega_corotate)
- use physcon,   only:days
- use units,     only:in_code_units,is_time_unit,utime
+ use units,     only:in_code_units
  use setbinary, only:set_binary
- use orbits,    only:get_semimajor_axis,convert_flyby_to_elements,convert_posvel_to_flyby
- type(orbit_t), intent(in)    :: orbit
+ use orbits,    only:convert_flyby_to_elements,convert_posvel_to_flyby,get_orbital_elements
+ type(orbit_t), intent(inout) :: orbit
  real,          intent(in)    :: m1,m2,hacc1,hacc2
  real,          intent(inout) :: xyzmh_ptmass(:,:),vxyz_ptmass(:,:)
  integer,       intent(inout) :: nptmass
  logical,       intent(in)    :: verbose
  integer,       intent(out)   :: ierr
  real,          intent(out), optional :: omega_corotate
- real :: x1(3),x2(3),v1(3),v2(3),dx(3),dv(3)
- real :: rp,a,e,d,O,w,inc,time_to_obs,mu,sep
- real :: f_tmp
+ real :: x1(3),x2(3),v1(3),v2(3)
  integer :: i
 
  ierr = 0
- select case(orbit%itype)
+ select case(orbit%input_type)
  case(3)
-    do i=1,3
-       dx(i) = in_code_units(orbit%obs%dx(i),ierr,unit_type='length')
-       dv(i) = in_code_units(orbit%obs%dv(i),ierr,unit_type='velocity')
-    enddo
-    sep = in_code_units(orbit%obs%initial_sep,ierr,unit_type='length')
-    ! convert observed separation and velocity to rp,e,d,O,w,i,f
-    mu = m1+m2
-    call convert_posvel_to_flyby(mu,dx,dv,rp,e,d,O,w,inc,sep,time_to_obs)
-    ! convert rp,e,d to semi-major axis and initial true anomaly
-    call convert_flyby_to_elements(rp,e,d,a,f_tmp)
-    ! set up binary with flyby elements
-    call set_binary(m1,m2,a,e,hacc1,hacc2,&
-                    xyzmh_ptmass,vxyz_ptmass,nptmass,ierr,omega_corotate,&
-                    posang_ascnode=O,arg_peri=w,&
-                    incl=inc,f=f_tmp,verbose=verbose)
- case(2)
+    !
+    ! for posvel input we do not call set_binary at all, just set x and v for both bodies.
+    ! However, the result should be the same, just without the centre of mass being at zero
+    !
     do i=1,3
        x1(i) = in_code_units(orbit%posvel%x1(i),ierr,unit_type='length')
        x2(i) = in_code_units(orbit%posvel%x2(i),ierr,unit_type='length')
@@ -179,100 +151,235 @@ subroutine set_orbit(orbit,m1,m2,hacc1,hacc2,xyzmh_ptmass,vxyz_ptmass,nptmass,ve
     xyzmh_ptmass(4,nptmass+2)   = m2
     xyzmh_ptmass(5,nptmass+2)   = hacc2
     vxyz_ptmass(1:3,nptmass+2)  = v2
- case(1)
-    rp = in_code_units(orbit%flyby%rp,ierr)
-    d = in_code_units(orbit%flyby%d,ierr)
-
-    call convert_flyby_to_elements(rp, orbit%flyby%e, d, a, f_tmp)
-
-    call set_binary(m1,m2,a,orbit%flyby%e,hacc1,hacc2,&
-                    xyzmh_ptmass,vxyz_ptmass,nptmass,ierr,omega_corotate,&
-                    posang_ascnode=orbit%flyby%O,arg_peri=orbit%flyby%w,&
-                    incl=orbit%flyby%i,f=f_tmp,verbose=verbose)
  case default
-    !
-    !--if a is negative or is given time units, interpret this as a period
-    !
-    a = in_code_units(orbit%elems%semi_major_axis,ierr)
-    if (is_time_unit(orbit%elems%semi_major_axis) .and. ierr == 0) then
-       a = -abs(a)
-       print "(a,g0,a,g0,a)",' Using PERIOD = ',abs(a),' = ',abs(a)*utime/days,' days'
-    endif
-    mu = m1+m2
-    if (a < 0.) a = get_semimajor_axis(mu,abs(a)) ! convert period to semi-major axis
+    call set_orbit_elements(orbit,m1,m2,verbose=verbose)
     !
     !--now setup orbit using sink particles
     !
     if (present(omega_corotate)) then
-       call set_binary(m1,m2,a,orbit%elems%e,hacc1,hacc2,&
+       call set_binary(m1,m2,orbit%a,orbit%e,hacc1,hacc2,&
                        xyzmh_ptmass,vxyz_ptmass,nptmass,ierr,omega_corotate,&
-                       posang_ascnode=orbit%elems%O,arg_peri=orbit%elems%w,&
-                       incl=orbit%elems%i,f=orbit%elems%f,verbose=verbose)
+                       posang_ascnode=orbit%O,arg_peri=orbit%w,&
+                       incl=orbit%i,f=orbit%f,verbose=verbose)
     else
-       call set_binary(m1,m2,a,orbit%elems%e,hacc1,hacc2,&
+       call set_binary(m1,m2,orbit%a,orbit%e,hacc1,hacc2,&
                        xyzmh_ptmass,vxyz_ptmass,nptmass,ierr,&
-                       posang_ascnode=orbit%elems%O,arg_peri=orbit%elems%w,&
-                       incl=orbit%elems%i,f=orbit%elems%f,verbose=verbose)
+                       posang_ascnode=orbit%O,arg_peri=orbit%w,&
+                       incl=orbit%i,f=orbit%f,verbose=verbose)
     endif
  end select
 
 end subroutine set_orbit
+
+!----------------------------------------------------------------------
+!+
+!  convert input parameters to standard orbital elements (a,e,i,O,w,f)
+!+
+!----------------------------------------------------------------------
+subroutine set_orbit_elements(orbit,m1,m2,verbose)
+ use physcon, only:days
+ use units,   only:in_code_units,is_time_unit,utime
+ use orbits,  only:get_semimajor_axis,convert_flyby_to_elements,get_orbital_elements,&
+                   get_pericentre_distance,get_true_anomaly_from_separation,rad_to_deg,&
+                   get_time_to_separation,get_time_between_true_anomalies
+ type(orbit_t), intent(inout) :: orbit
+ real,          intent(in)    :: m1,m2
+ logical,       intent(in), optional :: verbose
+ integer :: ierr,i
+ logical :: do_verbose
+ real :: dx(3),dv(3),mu,rp,d,time_to_obs
+ real :: x1(3),x2(3),v1(3),v2(3)
+
+ ierr = 0
+ do_verbose = .true.
+ if (present(verbose)) do_verbose = verbose
+
+ mu = m1+m2
+ select case(orbit%input_type)
+ case(3)
+    ! convert input strings to code units
+    do i=1,3
+       x1(i) = in_code_units(orbit%posvel%x1(i),ierr,unit_type='length')
+       x2(i) = in_code_units(orbit%posvel%x2(i),ierr,unit_type='length')
+       v1(i) = in_code_units(orbit%posvel%v1(i),ierr,unit_type='velocity')
+       v2(i) = in_code_units(orbit%posvel%v2(i),ierr,unit_type='velocity')
+    enddo
+    ! for posvel input, compute orbital elements from relative position and velocity
+    dx = x2 - x1
+    dv = v2 - v1
+    call get_orbital_elements(mu,dx,dv,orbit%a,orbit%e,orbit%i,orbit%O,orbit%w,orbit%f)
+ case(2)
+    ! convert input strings to code units
+    do i=1,3
+       dx(i) = in_code_units(orbit%obs%dx(i),ierr,unit_type='length')
+       dv(i) = in_code_units(orbit%obs%dv(i),ierr,unit_type='velocity')
+    enddo
+    d = in_code_units(orbit%flyby%d,ierr,unit_type='length')
+    if (do_verbose) then
+       print "(/,a,/)", ' Flyby Reconstructor^TM Inputs:'
+       print*,'          separation in code units = ',dx
+       print*,' velocity difference in code units = ',dv
+    endif
+
+    ! convert observed separation and velocity to rp,d,e,O,w,i,f
+    call get_orbital_elements(mu,dx,dv,orbit%a,orbit%e,orbit%i,orbit%O,orbit%w,orbit%obs%f)
+    rp = get_pericentre_distance(mu,dx,dv)
+
+    if (do_verbose) then
+       print "(/,a,/)", ' Flyby Reconstructor^TM Recovered Orbital Parameters (at moment of observation):'
+       print "(a,g0.4)",'          rp in code units      = ',rp
+       print "(a,g0.4)",'          semi-major axis a     = ',orbit%a
+       print "(a,g0.4)",'          projected separation  = ',sqrt(dot_product(dx(1:2),dx(1:2)))
+       print "(a,g0.4)",'          true separation       = ',sqrt(dot_product(dx,dx))
+       print "(a,g0.4)",'          eccentricity          = ',orbit%e
+       print "(a,g0.4)",'          O (pos. angle, deg)   = ',orbit%O
+       print "(a,g0.4)",'          w (arg. peri, deg)    = ',orbit%w
+       print "(a,g0.4)",'          i (inclination, deg)  = ',orbit%i
+       print "(a,g0.4)",'          f (true anomaly, deg) = ',orbit%obs%f
+    endif
+
+    ! convert desired initial separation to initial true anomaly
+    orbit%f = get_true_anomaly_from_separation(orbit%a,orbit%e,d)
+
+    ! compute time from initial true anomaly to true anomaly at moment of observation
+    time_to_obs = get_time_between_true_anomalies(mu,orbit%a,orbit%e,orbit%f,orbit%obs%f)
+    if (time_to_obs < 0.0) then
+       orbit%f = -orbit%f
+       time_to_obs = get_time_between_true_anomalies(mu,orbit%a,orbit%e,orbit%f,orbit%obs%f)
+    endif
+    if (do_verbose) then
+       print "(a,g0.4)",'  starting true anomaly f (true anomaly, deg) = ',orbit%f
+       print "(a,g0.4)",'  time to observation = ',time_to_obs
+       read*
+    endif
+ case(1)
+    ! flyby elements give pericentre distance and initial separation, convert to reals
+    rp = in_code_units(orbit%flyby%rp,ierr)
+    d = in_code_units(orbit%flyby%d,ierr)
+
+    ! convert rp,e,d to semi-major axis and initial true anomaly
+    call convert_flyby_to_elements(rp,d,orbit%e,orbit%a,orbit%f)
+ case default
+    ! convert input string for semi-major axis to code units
+    orbit%a = in_code_units(orbit%elems%a,ierr)
+
+    ! can also specify period in time units, convert to semi-major axis
+    if (is_time_unit(orbit%elems%a) .and. ierr == 0) then
+       orbit%a = -abs(orbit%a)
+       if (do_verbose) then
+          print "(a,g0,a,g0,a)",' Using PERIOD = ',abs(orbit%a),' = ',abs(orbit%a)*utime/days,' days'
+       endif
+    endif
+    if (orbit%a < 0.) orbit%a = get_semimajor_axis(mu,abs(orbit%a)) ! convert period to semi-major axis
+ end select
+ 
+end subroutine set_orbit_elements
+
+!----------------------------------------------------------------
+!+
+!  check if separation exceeds apocentre for flyby elements
+!+
+!----------------------------------------------------------------
+logical function sep_in_range(orbit,sep,rp,ra)
+ use units,  only:in_code_units
+ use orbits, only:orbit_is_parabolic
+ type(orbit_t), intent(in) :: orbit
+ real, intent(out) :: sep,rp,ra
+ real :: a,e,d
+ integer :: ierr
+
+ ! must have already called set_orbit_elements
+ a = orbit%a
+ e = orbit%e
+ sep = 0.
+ if (orbit_is_parabolic(e)) then
+    rp = a
+    ra = huge(ra)
+ elseif (e > 1.) then
+    rp = a*(1. - e)
+    ra = huge(ra)
+ else
+    rp = a*(1. - e)
+    ra = a*(1. + e)
+ endif
+
+ sep_in_range = .true.
+ select case(orbit%input_type)
+ case(1,2)
+    d = in_code_units(orbit%flyby%d,ierr)
+    if (e < 1. .and. d > ra) sep_in_range = .false.
+    if (d < rp) sep_in_range = .false.
+ end select
+
+end function sep_in_range
 
 !----------------------------------------------------------------
 !+
 !  write options to .setup file
 !+
 !----------------------------------------------------------------
-subroutine write_options_orbit(orbit,iunit,label)
+subroutine write_options_orbit(orbit,iunit,label,prefix,comment_prefix,input_type)
  use infile_utils, only:write_inopt
- type(orbit_t), intent(in) :: orbit
- integer,       intent(in) :: iunit
- character(len=*), intent(in), optional :: label
- character(len=10) :: c
+ type(orbit_t),    intent(in) :: orbit
+ integer,          intent(in) :: iunit
+ character(len=*), intent(in), optional :: label,prefix,comment_prefix
+ integer,          intent(in), optional :: input_type
+ character(len=10) :: c,p
+ character(len=20) :: cp
+ integer :: itype
 
- ! append optional label e.g. '1', '2'
- c = ''
+ ! append optional label e.g. '1', '2' or prefix e.g. 'binary' and comment prefix e.g. 'outer binary:'
+ c = ''; p = ''; cp = ''
  if (present(label)) c = trim(adjustl(label))
+ if (present(prefix)) p = '_'//trim(adjustl(prefix))
+ if (present(comment_prefix)) cp = trim(adjustl(comment_prefix))//':'
 
  write(iunit,"(/,a)") '# orbit '//trim(c)
- call write_inopt(orbit%itype,'itype'//trim(c),'type of orbital elements (0=aeiOwf,1=flyby,2=posvel)',iunit)
- select case(orbit%itype)
+ if (.not.present(input_type)) then
+    itype = orbit%input_type
+    call write_inopt(orbit%input_type,'itype'//trim(p)//trim(c),'type of orbital elements (0=aeiOwf,1=flyby,2=obs,3=posvel)',iunit)
+ else
+    itype = input_type
+ endif
+ if (present(prefix)) p = trim(adjustl(prefix))//'_'
+
+ select case(itype)
  case(3)
-    call write_inopt(orbit%obs%dx(1),'dx'//trim(c),'observed x separation at t=tmax (code units or e.g. 1*au)',iunit)
-    call write_inopt(orbit%obs%dx(2),'dy'//trim(c),'observed y separation at t=tmax (code units or e.g. 1*au)',iunit)
-    call write_inopt(orbit%obs%dx(3),'dz'//trim(c),'[guessed] z separation at t=tmax (code units or e.g. 1*au)',iunit)
-    call write_inopt(orbit%obs%dv(1),'dvx'//trim(c),'[guessed] x velocity difference at t=tmax (code units or e.g. 1*km/s)',iunit)
-    call write_inopt(orbit%obs%dv(2),'dvy'//trim(c),'[guessed] y velocity difference at t=tmax (code units or e.g. 1*km/s)',iunit)
-    call write_inopt(orbit%obs%dv(3),'dvz'//trim(c),'observed z velocity difference at t=tmax (code units or e.g. 1*km/s)',iunit)
-    call write_inopt(orbit%obs%initial_sep,'sep'//trim(c),'separation at t=0 if unbound flyby (code units or e.g. 1*au)',iunit)
+    call write_inopt(orbit%posvel%x1(1),trim(p)//'x1'//trim(c),trim(cp)//'x position body 1 (code units or e.g. 1*au)',iunit)
+    call write_inopt(orbit%posvel%x1(2),trim(p)//'y1'//trim(c),trim(cp)//'y position body 1 (code units or e.g. 1*au)',iunit)
+    call write_inopt(orbit%posvel%x1(3),trim(p)//'z1'//trim(c),trim(cp)//'z position body 1 (code units or e.g. 1*au)',iunit)
+    call write_inopt(orbit%posvel%v1(1),trim(p)//'vx1'//trim(c),trim(cp)//'x velocity body 1 (code units or e.g. 1*km/s)',iunit)
+    call write_inopt(orbit%posvel%v1(2),trim(p)//'vy1'//trim(c),trim(cp)//'y velocity body 1 (code units or e.g. 1*km/s)',iunit)
+    call write_inopt(orbit%posvel%v1(3),trim(p)//'vz1'//trim(c),trim(cp)//'z velocity body 1 (code units or e.g. 1*km/s)',iunit)
+    call write_inopt(orbit%posvel%x2(1),trim(p)//'x2'//trim(c),trim(cp)//'x position body 2 (code units or e.g. 1*au)',iunit)
+    call write_inopt(orbit%posvel%x2(2),trim(p)//'y2'//trim(c),trim(cp)//'y position body 2 (code units or e.g. 1*au)',iunit)
+    call write_inopt(orbit%posvel%x2(3),trim(p)//'z2'//trim(c),trim(cp)//'z position body 2 (code units or e.g. 1*au)',iunit)
+    call write_inopt(orbit%posvel%v2(1),trim(p)//'vx2'//trim(c),trim(cp)//'x velocity body 2 (code units or e.g. 1*km/s)',iunit)
+    call write_inopt(orbit%posvel%v2(2),trim(p)//'vy2'//trim(c),trim(cp)//'y velocity body 2 (code units or e.g. 1*km/s)',iunit)
+    call write_inopt(orbit%posvel%v2(3),trim(p)//'vz2'//trim(c),trim(cp)//'z velocity body 2 (code units or e.g. 1*km/s)',iunit)
  case(2)
-    call write_inopt(orbit%posvel%x1(1),'x1'//trim(c),'x position body 1 (code units or e.g. 1*au)',iunit)
-    call write_inopt(orbit%posvel%x1(2),'y1'//trim(c),'y position body 1 (code units or e.g. 1*au)',iunit)
-    call write_inopt(orbit%posvel%x1(3),'z1'//trim(c),'z position body 1 (code units or e.g. 1*au)',iunit)
-    call write_inopt(orbit%posvel%v1(1),'vx1'//trim(c),'x velocity body 1 (code units or e.g. 1*km/s)',iunit)
-    call write_inopt(orbit%posvel%v1(2),'vy1'//trim(c),'y velocity body 1 (code units or e.g. 1*km/s)',iunit)
-    call write_inopt(orbit%posvel%v1(3),'vz1'//trim(c),'z velocity body 1 (code units or e.g. 1*km/s)',iunit)
-    call write_inopt(orbit%posvel%x2(1),'x2'//trim(c),'x position body 2 (code units or e.g. 1*au)',iunit)
-    call write_inopt(orbit%posvel%x2(2),'y2'//trim(c),'y position body 2 (code units or e.g. 1*au)',iunit)
-    call write_inopt(orbit%posvel%x2(3),'z2'//trim(c),'z position body 2 (code units or e.g. 1*au)',iunit)
-    call write_inopt(orbit%posvel%v2(1),'vx2'//trim(c),'x velocity body 2 (code units or e.g. 1*km/s)',iunit)
-    call write_inopt(orbit%posvel%v2(2),'vy2'//trim(c),'y velocity body 2 (code units or e.g. 1*km/s)',iunit)
-    call write_inopt(orbit%posvel%v2(3),'vz2'//trim(c),'z velocity body 2 (code units or e.g. 1*km/s)',iunit)
+    call write_inopt(orbit%obs%dx(1),trim(p)//'dx'//trim(c),trim(cp)//'observed dx at t=tmax (code units or e.g. 1*au)',iunit)
+    call write_inopt(orbit%obs%dx(2),trim(p)//'dy'//trim(c),trim(cp)//'observed dy at t=tmax (code units or e.g. 1*au)',iunit)
+    call write_inopt(orbit%obs%dx(3),trim(p)//'dz'//trim(c),trim(cp)//'[guessed] dz at t=tmax (code units or e.g. 1*au)',iunit)
+    call write_inopt(orbit%obs%dv(1),trim(p)//'dvx'//trim(c),trim(cp)//'[guessed] dvx at t=tmax (code units or e.g. 1*km/s)',iunit)
+    call write_inopt(orbit%obs%dv(2),trim(p)//'dvy'//trim(c),trim(cp)//'[guessed] dvy at t=tmax (code units or e.g. 1*km/s)',iunit)
+    call write_inopt(orbit%obs%dv(3),trim(p)//'dvz'//trim(c),trim(cp)//'observed dvz at t=tmax (code units or e.g. 1*km/s)',iunit)
+    call write_inopt(orbit%flyby%d,trim(p)//'d'//trim(c),trim(cp)//'separation at t=0 if unbound',iunit)
  case(1)
-    call write_inopt(orbit%flyby%rp,'rp'//trim(c),'pericentre distance (code units or e.g. 1*au)',iunit)
-    call write_inopt(orbit%flyby%d,'d'//trim(c),'initial separation (code units or e.g. 1*au)',iunit)
-    call write_inopt(orbit%flyby%O,'O'//trim(c),'position angle of the ascending node (deg)',iunit)
-    call write_inopt(orbit%flyby%i,'i'//trim(c),'inclination (deg)',iunit)
-    call write_inopt(orbit%flyby%w,'w'//trim(c),'argument of periapsis (deg)',iunit)
-    call write_inopt(orbit%flyby%e,'e'//trim(c),'eccentricity',iunit)
+    call write_inopt(orbit%flyby%rp,trim(p)//'rp'//trim(c),trim(cp)//'pericentre distance (code units or e.g. 1*au)',iunit)
+    call write_inopt(orbit%flyby%d,trim(p)//'d'//trim(c),trim(cp)//'initial separation (code units or e.g. 1*au)',iunit)
+    call write_inopt(orbit%O,trim(p)//'O'//trim(c),trim(cp)//'position angle of the ascending node (deg)',iunit)
+    call write_inopt(orbit%i,trim(p)//'i'//trim(c),trim(cp)//'inclination (deg)',iunit)
+    call write_inopt(orbit%w,trim(p)//'w'//trim(c),trim(cp)//'argument of periapsis (deg)',iunit)
+    call write_inopt(orbit%e,trim(p)//'e'//trim(c),trim(cp)//'eccentricity',iunit)
  case default
-    call write_inopt(orbit%elems%semi_major_axis,'a'//trim(c),&
-                     'semi-major axis (e.g. 1 au), period (e.g. 10*days) or rp if e>=1',iunit)
-    call write_inopt(orbit%elems%e,'ecc'//trim(c),'eccentricity',iunit)
-    call write_inopt(orbit%elems%i,'inc'//trim(c),'inclination (deg)',iunit)
-    call write_inopt(orbit%elems%O,'O'//trim(c),'position angle of ascending node (deg)',iunit)
-    call write_inopt(orbit%elems%w,'w'//trim(c),'argument of periapsis (deg)',iunit)
-    call write_inopt(orbit%elems%f,'f'//trim(c),'initial true anomaly (180=apoastron)',iunit)
+    call write_inopt(orbit%elems%a,trim(p)//'a'//trim(c),&
+                     trim(cp)//'semi-major axis (e.g. 1 au), period (e.g. 10*days) or rp if e>=1',iunit)
+    call write_inopt(orbit%e,trim(p)//'e'//trim(c),trim(cp)//'eccentricity',iunit)
+    call write_inopt(orbit%i,trim(p)//'i'//trim(c),trim(cp)//'inclination (deg)',iunit)
+    call write_inopt(orbit%O,trim(p)//'O'//trim(c),trim(cp)//'position angle of ascending node (deg)',iunit)
+    call write_inopt(orbit%w,trim(p)//'w'//trim(c),trim(cp)//'argument of periapsis (deg)',iunit)
+    call write_inopt(orbit%f,trim(p)//'f'//trim(c),trim(cp)//'initial true anomaly (180=apoastron)',iunit)
  end select
 
 end subroutine write_options_orbit
@@ -282,57 +389,76 @@ end subroutine write_options_orbit
 !  read options from .setup file
 !+
 !----------------------------------------------------------------
-subroutine read_options_orbit(orbit,db,nerr,label)
+subroutine read_options_orbit(orbit,m1,m2,db,nerr,label,prefix,input_type)
  use infile_utils, only:inopts,read_inopt
  type(orbit_t),             intent(out)   :: orbit
+ real,                      intent(in)    :: m1,m2
  type(inopts), allocatable, intent(inout) :: db(:)
  integer,                   intent(inout) :: nerr
- character(len=*),          intent(in), optional :: label
- character(len=10) :: c
+ character(len=*),          intent(in), optional :: label,prefix
+ integer,                   intent(in), optional :: input_type
+ character(len=10) :: c,p
+ real :: sep,rp,ra
 
- ! append optional label e.g. '1', '2'
- c = ''
+ ! append optional label e.g. '1', '2' or prefix e.g. 'binary' and comment prefix e.g. 'outer binary:'
+ c = ''; p = ''
  if (present(label)) c = trim(adjustl(label))
+ if (present(prefix)) p = '_'//trim(adjustl(prefix))
 
  call set_defaults_orbit(orbit)
- call read_inopt(orbit%itype,'itype'//trim(c),db,errcount=nerr,min=0,max=3)
- select case(orbit%itype)
+
+ ! can force read of a particular input type, if provided as argument
+ if (present(input_type)) then
+    orbit%input_type = input_type
+ else
+    call read_inopt(orbit%input_type,'itype'//trim(p)//trim(c),db,errcount=nerr,min=0,max=3)
+ endif
+ if (present(prefix)) p = trim(adjustl(prefix))//'_'
+
+ select case(orbit%input_type)
  case(3)
-    call read_inopt(orbit%obs%dx(1),'dx'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%obs%dx(2),'dy'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%obs%dx(3),'dz'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%obs%dv(1),'dvx'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%obs%dv(2),'dvy'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%obs%dv(3),'dvz'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%obs%initial_sep,'sep'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%posvel%x1(1),trim(p)//'x1'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%posvel%x1(2),trim(p)//'y1'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%posvel%x1(3),trim(p)//'z1'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%posvel%v1(1),trim(p)//'vx1'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%posvel%v1(2),trim(p)//'vy1'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%posvel%v1(3),trim(p)//'vz1'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%posvel%x2(1),trim(p)//'x2'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%posvel%x2(2),trim(p)//'y2'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%posvel%x2(3),trim(p)//'z2'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%posvel%v2(1),trim(p)//'vx2'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%posvel%v2(2),trim(p)//'vy2'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%posvel%v2(3),trim(p)//'vz2'//trim(c),db,errcount=nerr)
  case(2)
-    call read_inopt(orbit%posvel%x1(1),'x1'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%posvel%x1(2),'y1'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%posvel%x1(3),'z1'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%posvel%v1(1),'vx1'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%posvel%v1(2),'vy1'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%posvel%v1(3),'vz1'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%posvel%x2(1),'x2'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%posvel%x2(2),'y2'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%posvel%x2(3),'z2'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%posvel%v2(1),'vx2'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%posvel%v2(2),'vy2'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%posvel%v2(3),'vz2'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%obs%dx(1),trim(p)//'dx'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%obs%dx(2),trim(p)//'dy'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%obs%dx(3),trim(p)//'dz'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%obs%dv(1),trim(p)//'dvx'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%obs%dv(2),trim(p)//'dvy'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%obs%dv(3),trim(p)//'dvz'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%flyby%d,trim(p)//'d'//trim(c),db,errcount=nerr)
  case(1)
-    call read_inopt(orbit%flyby%rp,'rp'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%flyby%d,'d'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%flyby%O,'O'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%flyby%i,'i'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%flyby%w,'w'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%flyby%e,'e'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%flyby%rp,trim(p)//'rp'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%flyby%d,trim(p)//'d'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%e,trim(p)//'e'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%i,trim(p)//'i'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%O,trim(p)//'O'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%w,trim(p)//'w'//trim(c),db,errcount=nerr)
  case default
-    call read_inopt(orbit%elems%semi_major_axis,'a'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%elems%e,'ecc'//trim(c),db,min=0.,errcount=nerr)
-    call read_inopt(orbit%elems%i,'inc'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%elems%O,'O'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%elems%w,'w'//trim(c),db,errcount=nerr)
-    call read_inopt(orbit%elems%f,'f'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%elems%a,trim(p)//'a'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%e,trim(p)//'e'//trim(c),db,min=0.,errcount=nerr)
+    call read_inopt(orbit%i,trim(p)//'i'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%O,trim(p)//'O'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%w,trim(p)//'w'//trim(c),db,errcount=nerr)
+    call read_inopt(orbit%f,trim(p)//'f'//trim(c),db,errcount=nerr)
  end select
+
+ ! convert input parameters to standard orbital elements (a,e,i,O,w,f)
+ call set_orbit_elements(orbit,m1,m2,verbose=.false.)
+ if (.not.sep_in_range(orbit,sep,rp,ra)) then
+    nerr = nerr + 1
+    print "(4(a,1pg10.3))",' ERROR: initial distance ',sep,' out of range, need d >= ',rp,' and d <= ',ra,' for e=',orbit%e
+ endif
 
 end subroutine read_options_orbit
 

--- a/src/setup/setup_binary.f90
+++ b/src/setup/setup_binary.f90
@@ -202,11 +202,13 @@ subroutine read_setupfile(filename,ierr)
  use setstar,      only:read_options_stars
  use setorbit,     only:read_options_orbit
  use setunits,     only:read_options_and_set_units
+ use units,        only:in_code_units
  character(len=*), intent(in)  :: filename
  integer,          intent(out) :: ierr
  integer, parameter :: iunit = 21
  integer :: nerr
  type(inopts), allocatable :: db(:)
+ real :: m1,m2
 
  nerr = 0
  ierr = 0
@@ -214,7 +216,9 @@ subroutine read_setupfile(filename,ierr)
  call read_options_and_set_units(db,nerr,gr)
  call read_options_stars(star,ieos,relax,write_rho_to_file,db,nerr)
  call read_inopt(corotate,'corotate',db,errcount=nerr)
- call read_options_orbit(orbit,db,nerr)
+ m1 = in_code_units(star(1)%m,ierr,unit_type='mass')
+ m2 = in_code_units(star(2)%m,ierr,unit_type='mass')
+ call read_options_orbit(orbit,m1,m2,db,nerr)
  call close_db(db)
 
  if (nerr > 0) then

--- a/src/setup/setup_grdisc.f90
+++ b/src/setup/setup_grdisc.f90
@@ -282,11 +282,14 @@ subroutine read_setupfile(filename,ierr)
  use setstar,      only:read_options_stars
  use setorbit,     only:read_options_orbit
  use setunits,     only:read_options_and_set_units
+ use units,        only:in_code_units,umass
+ use physcon,      only:solarm
  character(len=*), intent(in)    :: filename
  integer,          intent(out)   :: ierr
  integer, parameter :: iunit = 21
  integer :: nerr,i
  type(inopts), allocatable :: db(:)
+ real :: mstar
 
  print "(a)",'reading setup options from '//trim(filename)
  nerr = 0
@@ -310,7 +313,8 @@ subroutine read_setupfile(filename,ierr)
  call read_inopt(np     ,'np   '  ,db,min=0 ,errcount=nerr)
  call read_options_stars(star,ieos,relax,write_rho_to_file,db,nerr,nstars)
  do i=1,nstars
-    call read_options_orbit(orbit(i),db,nerr,label=achar(i+48))
+    mstar = in_code_units(star(i)%m,ierr,unit_type='mass')
+    call read_options_orbit(orbit(i),mhole*solarm/umass,mstar,db,nerr,label=achar(i+48))
  enddo
  call close_db(db)
  if (nerr > 0) then

--- a/src/setup/setup_grtde.f90
+++ b/src/setup/setup_grtde.f90
@@ -109,7 +109,6 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  real    :: vxyzstar(3),xyzstar(3),vec(3)
  real    :: r0,vel,lorentz
  real    :: vhat(3),x0,y0
- real    :: semi_maj_val
  real    :: mstars(max_stars),rstars(max_stars),haccs(max_stars)
  real    :: xyzmh_ptmass_in(nsinkproperties,2),vxyz_ptmass_in(3,2),angle
  real    :: alpha,delta_v,epsilon_target,tol
@@ -209,10 +208,9 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
     rtidal          = rstars(1) * (mass1/mstars(1))**(1./3.)
     rp              = rtidal/beta
  else
-    semi_maj_val = in_code_units(orbit%elems%semi_major_axis,ierr,unit_type='length')
     ! for a binary, tidal radius is given by
     ! orbit.an * (MM / mm)**(1/3) where mm is mass of binary and orbit.an is semi-major axis of binary
-    rtidal          = semi_maj_val * (mass1 / (mstars(1) + mstars(2)))**(1./3.)
+    rtidal          = orbit%a * (mass1 / (mstars(1) + mstars(2)))**(1./3.)
     rp              = rtidal/beta
  endif
 
@@ -372,7 +370,6 @@ subroutine write_setupfile(filename)
  use setorbit,     only:write_options_orbit
  use eos,          only:ieos
  use setunits,     only:write_options_units
-
  character(len=*), intent(in) :: filename
  integer :: iunit
 
@@ -424,7 +421,7 @@ subroutine read_setupfile(filename,ierr)
  use setstar,      only:read_options_star,read_options_stars
  use relaxstar,    only:read_options_relax
  use physcon,      only:solarm,solarr
- use units,        only:set_units,umass
+ use units,        only:set_units,umass,in_code_units
  use setorbit,     only:read_options_orbit
  use eos,          only:ieos
  use setunits,     only:read_options_and_set_units
@@ -433,6 +430,7 @@ subroutine read_setupfile(filename,ierr)
  integer, parameter :: iunit = 21
  integer :: nerr
  type(inopts), allocatable :: db(:)
+ real :: m1,m2
 
  print "(a)",'reading setup options from '//trim(filename)
  nerr = 0
@@ -466,7 +464,9 @@ subroutine read_setupfile(filename,ierr)
     call read_inopt(norbits,        'norbits',        db,min=0.,errcount=nerr)
     call read_inopt(dumpsperorbit,  'dumpsperorbit',  db,min=0 ,errcount=nerr)
     if (nstar > 1) then
-       call read_options_orbit(orbit,db,nerr)
+       m1 = in_code_units(star(1)%m,ierr,unit_type='mass')
+       m2 = in_code_units(star(2)%m,ierr,unit_type='mass')
+       call read_options_orbit(orbit,m1,m2,db,nerr)
     endif
  else
     call read_params(db,nerr,nstar)

--- a/src/tests/test_orbits.f90
+++ b/src/tests/test_orbits.f90
@@ -100,15 +100,15 @@ subroutine test_true_anomaly_from_separation(ntests,npass)
 
  f0 = get_true_anomaly_from_separation(a,e,a)  ! r=a occurs at f = acos((a(1-e^2)/a -1)/e)
  fp = get_true_anomaly_from_separation(a,e,rp) ! pericentre -> f=0
- fa = get_true_anomaly_from_separation(a,e,ra) ! apocentre -> f=pi
+ fa = get_true_anomaly_from_separation(a,e,ra) ! apocentre -> f=180.0
  fp1 = get_true_anomaly_from_separation(a,1.0,a) ! pericentre of parabolic orbit, f=0
- fp2 = get_true_anomaly_from_separation(a,0.0,a) ! pericentre of circular orbit, f=0
+ fp2 = get_true_anomaly_from_separation(a,0.0,a) ! circular orbit, ambiguous but should return f=180.
 
  call checkval(fp,0.0,tol,nfailed(1),'true anomaly at pericentre')
- call checkval(fa,pi,tol,nfailed(2),'true anomaly at apocentre')
- call checkval(f0,acos((a*(1.-e**2)/a - 1.)/e),tol,nfailed(3),'true anomaly at r=a')
+ call checkval(fa,180.0,tol,nfailed(2),'true anomaly at apocentre')
+ call checkval(f0,acos((a*(1.-e**2)/a - 1.)/e)*rad_to_deg,tol,nfailed(3),'true anomaly at r=a')
  call checkval(fp1,0.0,tol,nfailed(4),'true anomaly at rp (e=1)')
- call checkval(fp2,0.0,tol,nfailed(5),'true anomaly at rp (e=0)')
+ call checkval(fp2,180.0,tol,nfailed(5),'true anomaly at rp (e=0)')
  call update_test_scores(ntests,nfailed,npass)
 
 end subroutine test_true_anomaly_from_separation
@@ -153,7 +153,7 @@ subroutine test_convert_flyby(ntests,npass)
  rp = 2.0; e = 0.6; d = 10.0
  call convert_flyby_to_elements(rp,d,e,a,f)
  call checkval(a,rp/(1.-e),tol,nfailed(1),'a from flyby (e<1)')
- call checkval(f,180.0,tol,nfailed(2),'f from flyby (e<1)')
+ call checkval(f,-180.0,tol,nfailed(2),'f from flyby (e<1)')
 
  ! parabolic case
  e = 1.0


### PR DESCRIPTION
This p-r implements functionality to be able to specify the observed separation and velocity of two stars in a flyby encounter, and run the orbit so that the stars finish at exactly that separation and velocity difference

Description:
- implemented new option in set_orbits
- reworked setup_disc to use set_orbits instead of directly calling set_binary
- fix issues in some of the orbits helper routines for getting true anomaly from separation

Components modified:
- [x] Setup (src/setup)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Bug fix
- [ ] Physics improvements
- [x] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [ ] Better testing
- [x] Code cleanup / refactor
- [ ] Other (please describe)

Testing:
running SETUP=disc for a flyby

Did you run the bots? no

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? yes

Is there a unit test that could be added for this feature/bug? yes

If so, please describe what a unit test might check:
mostly already done in the test_orbits module

<!-- If this PR is related to an issue, please link it here -->
Related issues: #
