### PR TITLE
Fixed relax_star not calculating the mass profile correctly when relaxing a MESA profile.

### DIFF
--- a/src/setup/relax_star.f90
+++ b/src/setup/relax_star.f90
@@ -56,7 +56,7 @@ contains
 !+
 !----------------------------------------------------------------
 subroutine relax_star(nt,rho,pr,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,&
-                      iptmass_core,xyzmh_ptmass,ierr,npin,label,write_dumps,density_error,energy_error)
+                      iptmass_core,xyzmh_ptmass,ierr,npin,label,write_dumps,density_error,energy_error,mtab)
  use table_utils,     only:yinterp
  use deriv,           only:get_derivs_global
  use dim,             only:maxp,maxvxyzu,gr,gravity,use_apr
@@ -87,6 +87,7 @@ subroutine relax_star(nt,rho,pr,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,&
  character(len=*), intent(in), optional :: label
  logical, intent(in),  optional :: write_dumps
  real,    intent(out), optional :: density_error,energy_error
+ real,    intent(in),  optional :: mtab(nt)
  integer :: nits,nerr,nwarn,iunit,i1
  real    :: t,dt,dtmax,rmserr,rstar,mstar,tdyn,x0(3),mtot
  real    :: entrop(nt),utherm(nt),mr(nt),rmax,dtext,dtnew
@@ -114,7 +115,15 @@ subroutine relax_star(nt,rho,pr,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,mu,&
  x0 = 0.
  if (gr) x0 = [1000.,0.,0.]   ! for GR need to shift star away from origin to avoid singularities
  rstar = maxval(r)
- mr = get_mr(rho,r)
+
+ !The mass profile is constructed from the density profile unless mtab is present.
+ !If mtab is present, it is used as the mass profile.
+ if (present(mtab)) then
+   mr=mtab
+ else
+   mr = get_mr(rho,r)
+ endif
+
  mstar = mr(nt)   ! mstar is the mass of the star excluding the core
  mtot = mstar
  if (iptmass_core > 0) mtot = mtot + xyzmh_ptmass(4,iptmass_core) ! mtot is the total mass of the star

--- a/src/setup/set_star.f90
+++ b/src/setup/set_star.f90
@@ -325,10 +325,19 @@ subroutine set_star(id,master,star,xyzh,vxyzu,eos_vars,rad,&
  if (relax) then
     if (reduceall_mpi('+',npart)==npart) then
        polyk_eos = star%polyk
-       call relax_star(npts,den,pres,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,&
-                       mu,iptmass_core,xyzmh_ptmass,ierr_relax,&
-                       npin=npart_old,label=star%label,&
-                       write_dumps=write_dumps,density_error=rmserr,energy_error=en_err)
+
+       if (star%iprofile == imesa) then !If a MESA profile is used, the mtab array is used for the mass profile in relax_star.
+          call relax_star(npts,den,pres,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,&
+                          mu,iptmass_core,xyzmh_ptmass,ierr_relax,&
+                          npin=npart_old,label=star%label,&
+                          write_dumps=write_dumps,density_error=rmserr,energy_error=en_err,mtab=mtab)
+       else
+          call relax_star(npts,den,pres,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,&
+                          mu,iptmass_core,xyzmh_ptmass,ierr_relax,&
+                          npin=npart_old,label=star%label,&
+                          write_dumps=write_dumps,density_error=rmserr,energy_error=en_err)
+       endif
+
        if (present(density_error)) density_error = rmserr
        if (present(energy_error)) energy_error = en_err
     else


### PR DESCRIPTION
Description:
In "relax_star", the mass profile is calculated using the "get_mr" function, which assumes that the first entry in the resulting "mr" array is zero. This is not necessarily the case for a MESA profile's mass profile, and as other quantities are calculated using the mass coordinates, it results in various quantities being calculated incorrectly as the calculated mass profile is different compared to the original MESA one. For planets that I created in MESA, this could result in up to 3% of the planet's total mass not being accounted for by the "get_mr" function. This problem seemed to result in the internal energy being set incorrectly for some of the planets during relaxation, which further seemed to cause some of the resulting models to become unbound and be unable to be relaxed. The change that I have made is that if a MESA profile is being relaxed, the mass profile from the MESA profile is used directly.

Components modified:
- [ ] Setup (src/setup)

Type of change:
- [ ] Bug fix


Testing:
I created a planet profile with MESA that would previously fail to relax due to "relax_star" causing it to become unbound, by making this change it now is capable of being relaxed.

Did you run the bots? yes

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? yes

Is there a unit test that could be added for this feature/bug? yes

If so, please describe what a unit test might check:
I can provide an example of a planet MESA profile that failed to relax previously due to "relax_star" causing it to be unbound, but with my new changes is now bound. The test would be to see if the planet can be successfully relaxed.

