### PR TITLE
APR in MCFOST

### DIFF
--- a/src/utils/analysis_mcfost.f90
+++ b/src/utils/analysis_mcfost.f90
@@ -69,6 +69,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
  logical, parameter :: write_T_files = .false. ! ask mcfost to write fits files with temperature structure
  character(len=len(dumpfile) + 20) :: mcfost_para_filename
  real :: a_code,rhoi,pmassi,Tmin,Tmax,default_kappa,kappa_diffusion
+ integer(kind=1), dimension(npart) :: new_level
 
  if (.not. use_mcfost) return
 
@@ -122,11 +123,17 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
  endif
  factor = 1.0/(temperature_coef*gmw*(gamma-1))
 
+ if (use_apr) then
+     new_level = apr_level(1:npart)
+ else
+   new_level = 1
+ endif
+
  !-- calling mcfost to get Tdust
  call run_mcfost_phantom(npart,nptmass,ntypes,ndusttypes,dustfluidtype,&
          npartoftype,xyzh,vxyzu,itype,grainsize,graindens,dustfrac,massoftype,&
          xyzmh_ptmass,vxyz_ptmass,hfact,umass,utime,udist,nlum,dudt,compute_Frad,SPH_limits,Tdust,&
-         n_packets,mu_gas,ierr,write_T_files,ISM,eos_vars(itemp,:), apr_level, use_apr)
+         n_packets,mu_gas,ierr,write_T_files,ISM,eos_vars(itemp,:), new_level, use_apr)
 
  Tmin = minval(Tdust, mask=(Tdust > 1.))
  Tmax = maxval(Tdust)


### PR DESCRIPTION
Description:
Pass `apr_level` as an optional argument to `run_mcfost_phantom`.
~Requires https://github.com/cpinte/mcfost/pull/148~
Requires https://github.com/cpinte/mcfost/pull/151

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Setup (src/setup)
- [ ] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [x] Analysis utilities (src/utils/analysis)
- [ ] Test suite (src/tests)
- [ ] Documentation (docs/)
- [ ] Build/CI (build/ or github actions)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Bug fix
- [x] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [ ] Better testing
- [ ] Code cleanup / refactor
- [x] Other (please describe)

Testing:
<!-- Describe how you have tested the change -->
> Ran test Phantom simulations with MCFOST=yes APR=yes.
> Temperature profile matches the control even inside the APR regions.

Did you run the bots? yes

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? no

Is there a unit test that could be added for this feature/bug? no

If so, please describe what a unit test might check:
<!--e.g.: a test should check that running phantomsetup on SETUP=disc with ieos=2 successfully creates a dump-->
<!--obviously it is desirable to actually add the test, but at least describing it helps to inform future development-->

<!-- If this PR is related to an issue, please link it here -->

~There are still bugs to be fixed, per example, Phantom freezes after deleting dump_00000.tmp~
