### PR TITLE
SFMM algorithm with fixed stack size

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -40,6 +40,7 @@ jobs:
         curl -L -o binary.in "https://github.com/danieljprice/phantom/releases/download/v2025.0.0/binary.in"
         curl -L -o poly.setup "https://github.com/danieljprice/phantom/releases/download/v2025.0.0/poly.setup"
         curl -L -o poly.in "https://github.com/danieljprice/phantom/releases/download/v2025.0.0/poly.in"
+        curl -L -o sim.setup "https://github.com/danieljprice/phantom/releases/download/v2025.0.0/sim.setup"
         
         # Verify SHA256 hashes (Linux compatible)
         echo "95f9785284a5dc6e23d81991e12086218a4fa40e6449af43d205a8c613da2140  profile9donor.data" | sha256sum -c
@@ -48,6 +49,7 @@ jobs:
         echo "efea56e820e15fbcd4fa47bc62cd7d9b3eb64794906227ba4c2145c431272487  binary.in" | sha256sum -c
         echo "679ee7a3fd9af74063ebec4354c4c4235865aa26e8ee360d5711736839395459  poly.setup" | sha256sum -c
         echo "b7b7a780d22d3ffc1541576f93d18cac811212d03aa6e1992ef1105af80e342f  poly.in" | sha256sum -c
+        echo "f8b0bb9decb74b053b625d67c3df27c48d0f171b23d3e08848d4ef80e271b0dc  sim.setup" | sha256sum -c
 
         # run the test, run phantomsetup 3 times to ensure .setup file is rewritten if necessary
         ./phantomsetup binary.setup
@@ -64,3 +66,10 @@ jobs:
         ./phantomsetup poly.setup
         ./phantomsetup poly.setup
         ./phantom poly.in
+
+        # now also run a test with a polytrope + softened sink (https://github.com/danieljprice/phantom/issues/725)
+        rm relax*
+        ./phantomsetup sim.setup
+        if [ ! -f relax1_00005 ]; then echo "Missing relax1_00005 after phantomsetup"; ls -la; exit 1; fi
+        if [ ! -f sim_00000.tmp ]; then echo "Missing sim_00000.tmp after phantomsetup"; ls -la; exit 1; fi
+        if [ ! -f sim.in ]; then echo "Missing sim.in after phantomsetup"; ls -la; exit 1; fi

--- a/AUTHORS
+++ b/AUTHORS
@@ -78,7 +78,6 @@ Maxime Lombart <maxime.lombart@ens-lyon.fr>
 Orsola De Marco <orsola.demarco@mq.edu.au>
 Zachary Pellow <zpel1@student.monash.edu>
 Ali Pourmand <ali.pourmand@hdr.mq.edu.au>
-Antoine Alaguero <100609080+AlagueroA@users.noreply.github.com>
 Ariel Chitan <arielchitan@gmail.com>
 Cox, Samuel <sc676@leicester.ac.uk>
 David Bamba <dbambague@unal.edu.co>

--- a/scripts/writemake.sh
+++ b/scripts/writemake.sh
@@ -52,7 +52,7 @@ echo '	cd ${PHANTOMDIR}; make '$makeflags' setup; cd -; cp ${PHANTOMDIR}/bin/pha
 echo 'moddump:'
 echo '	cd ${PHANTOMDIR}; make '$makeflags' moddump; cd -; cp ${PHANTOMDIR}/bin/phantommoddump .'
 echo 'analysis:'
-echo '	cd ${PHANTOMDIR}; make '$makeflags$analysisflags' phantomanalysis; cd -; cp ${PHANTOMDIR}/bin/phantomanalysis .'
+echo '	cd ${PHANTOMDIR}; make '$makeflags$analysisflags' analysis; cd -; cp ${PHANTOMDIR}/bin/phantomanalysis .'
 echo 'phantomlib:'
 echo '	cd ${PHANTOMDIR}; make '$makeflags' libphantom; cd -; cp ${PHANTOMDIR}/bin/libphantom.so .'
 echo 'pyanalysis:'

--- a/src/main/extern_binary.f90
+++ b/src/main/extern_binary.f90
@@ -15,13 +15,14 @@ module extern_binary
 ! :Owner: Daniel Price
 !
 ! :Runtime parameters:
-!   - accradius1 : *accretion radius of primary*
-!   - accradius2 : *accretion radius of secondary (if iexternalforce=binary)*
-!   - eps_soft1  : *Plummer softening of primary*
-!   - eps_soft2  : *Plummer softening of secondary*
-!   - mass1      : *m1 of central binary system (if iexternalforce=binary)*
-!   - mass2      : *m2 of central binary system (if iexternalforce=binary)*
-!   - ramp       : *ramp up mass of secondary over first 5 orbits?*
+!   - accradius1   : *accretion radius of primary*
+!   - accradius2   : *accretion radius of secondary (if iexternalforce=binary)*
+!   - eps_soft1    : *Plummer softening of primary*
+!   - eps_soft2    : *Plummer softening of secondary*
+!   - mass1        : *m1 of central binary system (if iexternalforce=binary)*
+!   - mass2        : *m2 of central binary system (if iexternalforce=binary)*
+!   - ramp         : *ramp up mass of secondary over first N orbits?*
+!   - tramp_orbits : *how many orbits to ramp mass over*
 !
 ! :Dependencies: dump_utils, infile_utils, io, physcon
 !
@@ -38,6 +39,7 @@ module extern_binary
  real, public :: accretedmass2 = 0.
  real, public :: eps_soft1 = 0.0
  real, public :: eps_soft2 = 0.0
+ real, public :: tramp_orbits = 5.
  logical, public :: ramp = .false.
  logical, public :: surface_force = .false.
  real,    private :: mass2_temp
@@ -64,10 +66,11 @@ contains
 subroutine update_binary(ti)
  use physcon, only:pi
  real, intent(in) :: ti
- real :: omega,mtot,a,x,y
+ real :: omega,mtot,a,x,y,period
 
- if (ramp .and. ti < 10.*pi) then
-    mass2_temp = mass2*(sin(ti/20.)**2)
+ period = 2.*pi
+ if (ramp .and. ti < tramp_orbits*period) then
+    mass2_temp = mass2*(sin(0.5*pi*ti/(tramp_orbits*period))**2)
  else
     mass2_temp = mass2
  endif
@@ -241,7 +244,8 @@ subroutine write_options_externbinary(iunit)
  call write_inopt(accradius2,'accradius2','accretion radius of secondary (if iexternalforce=binary)',iunit)
  call write_inopt(eps_soft1,'eps_soft1','Plummer softening of primary',iunit)
  call write_inopt(eps_soft2,'eps_soft2','Plummer softening of secondary',iunit)
- call write_inopt(ramp,'ramp','ramp up mass of secondary over first 5 orbits?',iunit)
+ call write_inopt(ramp,'ramp','ramp up mass of secondary over first N orbits?',iunit)
+ if (ramp) call write_inopt(tramp_orbits,'tramp_orbits','how many orbits to ramp mass over',iunit)
 
 end subroutine write_options_externbinary
 
@@ -266,6 +270,7 @@ subroutine read_options_externbinary(db,nerr)
  call read_inopt(eps_soft1,'eps_soft1',db,errcount=nerr,min=0.,default=eps_soft1)
  call read_inopt(eps_soft2,'eps_soft2',db,errcount=nerr,min=0.,default=eps_soft2)
  call read_inopt(ramp,'ramp',db,errcount=nerr,default=ramp)
+ call read_inopt(tramp_orbits,'tramp_orbits',db,errcount=nerr,default=tramp_orbits)
 
 end subroutine read_options_externbinary
 

--- a/src/setup/set_orbit.f90
+++ b/src/setup/set_orbit.f90
@@ -222,7 +222,7 @@ subroutine set_orbit_elements(orbit,m1,m2,verbose)
     enddo
     d = in_code_units(orbit%flyby%d,ierr,unit_type='length')
     if (do_verbose) then
-       print "(/,a,/)", ' Flyby Reconstructor^TM Inputs:'
+       print "(/,a,/)", ' Orbit Reconstructor^TM Inputs:'
        print*,'          separation in code units = ',dx
        print*,' velocity difference in code units = ',dv
     endif
@@ -231,7 +231,7 @@ subroutine set_orbit_elements(orbit,m1,m2,verbose)
     call get_orbital_elements(mu,dx,dv,orbit%a,orbit%e,orbit%i,orbit%O,orbit%w,orbit%obs%f)
 
     if (do_verbose) then
-       print "(/,a,/)", ' Flyby Reconstructor^TM Recovered Orbital Parameters (at moment of observation):'
+       print "(/,a,/)", ' Orbit Reconstructor^TM Recovered Orbital Parameters (at moment of observation):'
        print "(a,1pg0.4)",'          rp in code units      = ',get_pericentre_distance(mu,dx,dv)
        print "(a,1pg0.4)",'          semi-major axis a     = ',orbit%a
        print "(a,1pg0.4)",'          projected separation  = ',sqrt(dot_product(dx(1:2),dx(1:2)))
@@ -368,7 +368,7 @@ logical function sep_in_range(orbit,sep,rp,ra)
  use orbits, only:orbit_is_parabolic
  type(orbit_t), intent(in) :: orbit
  real, intent(out) :: sep,rp,ra
- real :: a,e,d
+ real :: a,e
  integer :: ierr
 
  ! must have already called set_orbit_elements
@@ -389,9 +389,9 @@ logical function sep_in_range(orbit,sep,rp,ra)
  sep_in_range = .true.
  select case(orbit%input_type)
  case(1,2)
-    d = in_code_units(orbit%flyby%d,ierr)
-    if (e < 1. .and. d > ra) sep_in_range = .false.
-    if (d < rp) sep_in_range = .false.
+    sep = in_code_units(orbit%flyby%d,ierr)
+    if (e < 1. .and. sep > ra) sep_in_range = .false.
+    if (sep < rp) sep_in_range = .false.
  end select
 
 end function sep_in_range
@@ -420,7 +420,8 @@ subroutine write_options_orbit(orbit,iunit,label,prefix,comment_prefix,input_typ
  write(iunit,"(/,a)") '# orbit '//trim(c)
  if (.not.present(input_type)) then
     itype = orbit%input_type
-    call write_inopt(orbit%input_type,'itype'//trim(p)//trim(c),'type of orbital elements (0=aeiOwf,1=flyby,2=obs,3=posvel)',iunit)
+    call write_inopt(orbit%input_type,'itype'//trim(p)//trim(c),&
+         'orbital elements (0=aeiOwf,1=flyby,2=Orbit Reconstructor,3=posvel)',iunit)
  else
     itype = input_type
  endif
@@ -539,8 +540,13 @@ subroutine read_options_orbit(orbit,m1,m2,db,nerr,label,prefix,input_type)
  ! convert input parameters to standard orbital elements (a,e,i,O,w,f)
  call set_orbit_elements(orbit,m1,m2,verbose=.false.)
  if (.not.sep_in_range(orbit,sep,rp,ra)) then
-    nerr = nerr + 1
-    print "(4(a,1pg10.3))",' ERROR: initial distance ',sep,' out of range, need d >= ',rp,' and d <= ',ra,' for e=',orbit%e
+    if (orbit%input_type == 2) then
+       print "(/,4(a,1pg10.3))",' WARNING: initial distance ',sep,' out of range, need d >= ',rp,' and d <= ',ra,' for e=',orbit%e
+       print "(a,1pg10.3,a)",   '          => will start orbit at apocentre distance of ',ra,' instead'
+    else
+       print "(4(a,1pg10.3))",' ERROR: initial distance ',sep,' out of range, need d >= ',rp,' and d <= ',ra,' for e=',orbit%e
+       nerr = nerr + 1
+    endif
  endif
 
 end subroutine read_options_orbit

--- a/src/setup/set_star.f90
+++ b/src/setup/set_star.f90
@@ -85,8 +85,8 @@ subroutine set_defaults_star(star)
  type(star_t), intent(out) :: star
 
  star%iprofile    = 2
- star%r           = '1.0*rsun'
- star%m           = '1.0*msun'
+ star%r           = '1.0 rsun'
+ star%m           = '1.0 msun'
  star%ui_coef     = 0.05
  star%polyk       = 0.
  star%initialtemp = 1.0e7
@@ -96,7 +96,7 @@ subroutine set_defaults_star(star)
  star%hacc           = '1.0'
  star%rcore          = '0.0'
  star%mcore          = '0.0'
- star%lcore          = '0.*lsun'
+ star%lcore          = '0 lsun'
  star%isofteningopt  = 1 ! By default, specify rcore
  star%np             = 1000
  star%input_profile  = 'P12_Phantom_Profile.data'
@@ -326,7 +326,11 @@ subroutine set_star(id,master,star,xyzh,vxyzu,eos_vars,rad,&
     if (reduceall_mpi('+',npart)==npart) then
        polyk_eos = star%polyk
 
-       if (star%iprofile == imesa) then !If a MESA profile is used, the mtab array is used for the mass profile in relax_star.
+       if (star%iprofile == imesa .or. star%iprofile == ikepler) then
+          !
+          ! if a MESA profile is used, we supply the mtab array for the
+          ! mass profile in relax_star rather than integrating it manually
+          !
           call relax_star(npts,den,pres,r,npart,xyzh,use_var_comp,Xfrac,Yfrac,&
                           mu,iptmass_core,xyzmh_ptmass,ierr_relax,&
                           npin=npart_old,label=star%label,&
@@ -523,7 +527,7 @@ subroutine shift_star(npart,npartoftype,xyz,vxyz,x0,v0,itype,corotate)
     lhat   = L/sqrt(dot_product(L,L))
     rcyl   = x0 - dot_product(x0,lhat)*lhat
     omega  = L/dot_product(rcyl,rcyl)
-    print "(a,3(es10.3,','),a)",' Adding spin to star: omega = (',omega(1:3),')'
+    print "(a,2(es10.3,','),es10.3,a)",' Adding spin to star: omega = (',omega(1:3),')'
  endif
  if (present(itype)) print "(a,i0,2(a,2(es10.3,','),es10.3),a)",&
    ' MOVING STAR ',itype,' to x = (',x0(1:3),') and v = (',v0(1:3),')'
@@ -814,6 +818,8 @@ subroutine write_options_star(star,iunit,label)
  character(len=*), intent(in), optional :: label
  character(len=120) :: string
  character(len=10) :: c
+ real :: hacc,hsoft
+ integer :: ierr
 
  ! append optional label e.g. '1', '2'
  c = ''
@@ -829,7 +835,7 @@ subroutine write_options_star(star,iunit,label)
             'Path to input profile',iunit)
     else
        if (need_rstar(star%iprofile)) &
-          call write_inopt(star%r,'Rstar'//trim(c),'radius of body '//trim(c)//' (code units or e.g. 1*rsun)',iunit)
+          call write_inopt(star%r,'Rstar'//trim(c),'radius of body '//trim(c)//' (code units or e.g. 1 rsun)',iunit)
 
        ! add comment about being able to specify mean density instead of mass for uniform density sphere
        string = ' (code units or e.g. 1 msun'
@@ -882,7 +888,12 @@ subroutine write_options_star(star,iunit,label)
     call write_inopt(star%ui_coef,'ui_coef'//trim(c),&
          'specific internal energy (units of GM/R)',iunit)
  case(0)
-    call write_inopt(star%hacc,'hacc'//trim(c),'accretion radius for sink'//trim(c),iunit)
+    call write_inopt(star%hacc,'hacc'//trim(c),'accretion radius for sink (=0.0 for softened potential)',iunit)
+    call check_and_convert(star%hacc,'hacc','length',hacc,ierr)
+    call check_and_convert(star%hsoft,'hsoft','length',hsoft,ierr)
+    if (hacc < tiny(hacc) .or. hsoft > 0.) then
+       call write_inopt(star%hsoft,'hsoft'//trim(c),'softening radius for sink'//trim(c),iunit)
+    endif
  end select
 
  if (need_polyk(star%iprofile)) call write_inopt(star%polyk,'polyk'//trim(c),'polytropic constant (cs^2 if isothermal)',iunit)
@@ -964,6 +975,14 @@ subroutine read_options_star(star,db,nerr,label)
     call read_inopt(star%ui_coef,'ui_coef'//trim(c),db,errcount=nerr)
  case(:0)
     call read_inopt(star%hacc,'hacc'//trim(c),db,errcount=nerr)
+    call check_and_convert(star%hacc,'hacc','length',hacc,nerr)
+    if (hacc <= tiny(hacc)) then
+       ! if hacc is 0 then hsoft is compulsory
+       call read_inopt(star%hsoft,'hsoft'//trim(c),db,errcount=nerr)
+    else
+       ! otherwise hsoft is optional
+       call read_inopt(star%hsoft,'hsoft'//trim(c),db,err=ierr,default='0.0')
+    endif
  end select
 
  if (need_polyk(star%iprofile)) call read_inopt(star%polyk,'polyk'//trim(c),db,errcount=nerr)

--- a/src/setup/setup_disc.f90
+++ b/src/setup/setup_disc.f90
@@ -3321,8 +3321,8 @@ subroutine read_setupfile(filename,ierr)
        end select
        call read_inopt(pindex(i),'pindex'//trim(disclabel),db,errcount=nerr)
        if (lumdisc == 0) call read_inopt(qindex(i),'qindex'//trim(disclabel),db,errcount=nerr)
-       call read_inopt(posangl(i),'posangl'//trim(disclabel),db,min=0.,max=360.,errcount=nerr)
-       call read_inopt(incl(i),'incl'//trim(disclabel),db,min=0.,max=180.,errcount=nerr)
+       call read_inopt(posangl(i),'posangl'//trim(disclabel),db,min=-360.,max=360.,errcount=nerr)
+       call read_inopt(incl(i),'incl'//trim(disclabel),db,errcount=nerr)
        if (discstrat == 0 .and. lumdisc == 0) then
           call read_inopt(H_R(i),'H_R'//trim(disclabel),db,min=0.,errcount=nerr)
        endif

--- a/src/utils/moddump_addflyby.f90
+++ b/src/utils/moddump_addflyby.f90
@@ -25,11 +25,11 @@ contains
 subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  use part,              only:nptmass,xyzmh_ptmass,vxyz_ptmass!,igas,ihacc,ihsoft
  use prompting,         only:prompt
- use units,             only:umass,utime,udist,print_units
+ use units,             only:print_units
  use physcon,           only:au,solarm,pi,years
  use centreofmass,      only:reset_centreofmass,get_centreofmass
  use vectorutils,       only:rotatevec
- use setflyby,          only:get_T_flyby
+ use orbits,            only:get_T_flyby_par
  integer, intent(inout) :: npart
  integer, intent(inout) :: npartoftype(:)
  real,    intent(inout) :: massoftype(:)
@@ -97,7 +97,7 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  call rotatevec(vxyz_ptmass(1:3,nptmass), rot_axis,incl)
 
  call reset_centreofmass(npart,xyzh,vxyzu,nptmass,xyzmh_ptmass,vxyz_ptmass)
- period = get_T_flyby(star_m,mperturber,dma,n0) * dtmax ! computing time between dumps in code units
+ period = get_T_flyby_par(star_m+mperturber,dma,n0) * dtmax ! computing time between dumps in code units
 
  write(*,*) 'Time between dumps in code units to put in *.in file', period
 


### PR DESCRIPTION
Description:
This PR introduces a different dual tree walk to compute M2L interactions needed for the self-gravity. This new approach has the advantage to limit the memory footprint of the stack used to store pending interactions to test. Using the parallel select algorithm, the stack is now limited to the maxmimum depth of the tree which is 32 in Phantom. (previous size = ncellmax)
The new algorithm shows very limited penalties in perf. 
In addition some Flops optimisations has been done in `compute_M2L`. This routine represent half the cost of `get_neighdual`.
Overall there is no difference in perf with the previous implementation.

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Setup (src/setup)
- [x] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [ ] Test suite (src/tests)
- [ ] Documentation (docs/)
- [ ] Build/CI (build/ or github actions)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [x] Performance improvements
- [ ] Documentation update
- [ ] Better testing
- [x] Code cleanup / refactor
- [ ] Other (please describe)

Testing:
usual grav tests should pass with no issues.

Did you run the bots? yes

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? yes
