### PR TITLE
Revtree

### DIFF
--- a/src/main/kdtree.F90
+++ b/src/main/kdtree.F90
@@ -1833,6 +1833,7 @@ subroutine revtree(node, xyzh, leaf_is_active, ncells)
  ! find maximum index in inodeparts that we need to update in treecache
  nptot = 0
  do i=1,int(ncells)
+    if (i > 1 .and. node(i)%parent == 0) cycle
     if (inoderange(1,i) > 0 .and. inoderange(2,i) >= inoderange(1,i)) then
        nptot = max(nptot, inoderange(2,i))
     endif
@@ -1880,6 +1881,7 @@ subroutine revtree(node, xyzh, leaf_is_active, ncells)
 !$omp private(totmass)
 !$omp do schedule(guided)
  over_nodes: do inode=1,int(ncells)
+    if (inode > 1 .and. node(inode)%parent == 0) cycle
     ! initialize node properties
     node(inode)%xcen(:) = 0.
     node(inode)%size    = 0.

--- a/src/main/neigh_kdtree.f90
+++ b/src/main/neigh_kdtree.f90
@@ -160,7 +160,7 @@ end subroutine get_distance_from_centre_of_mass
 !-----------------------------------------------------------------------
 subroutine build_tree(npart,nactive,xyzh,vxyzu,for_apr)
  use io,           only:nprocs
- use kdtree,       only:maketree,maketreeglobal,revtree
+ use kdtree,       only:maketree,maketreeglobal!,revtree
  use dim,          only:mpi,use_sinktree
  use part,         only:nptmass,xyzmh_ptmass,maxp
  use allocutils,   only:allocate_array
@@ -197,11 +197,11 @@ subroutine build_tree(npart,nactive,xyzh,vxyzu,for_apr)
     else
        ! use revtree for small numbers of active particles to avoid tree rebuild overhead
        ! threshold: use revtree if < 0.1% of total particles
-       if (npart > 0 .and. nactive < 0.001*npart) then
-          call revtree(node,xyzh,leaf_is_active,ncells)
-       else
-          call maketree(node,xyzh,npart,leaf_is_active,ncells,apr_tree)
-       endif
+       !if (npart > 0 .and. nactive < 0.001*npart) then
+       !   call revtree(node,xyzh,leaf_is_active,ncells)
+       !else
+       call maketree(node,xyzh,npart,leaf_is_active,ncells,apr_tree)
+       !endif
     endif
  endif
 

--- a/src/tests/test_kdtree.F90
+++ b/src/tests/test_kdtree.F90
@@ -79,7 +79,7 @@ subroutine test_kdtree(ntests,npass)
     !
     ! now save the tree structure and leaf_is_active
     !
-    allocate(old_tree(ncells))
+    allocate(old_tree(int(ncells)))
     old_tree(1:ncells) = node(1:ncells)
     allocate(leaf_is_active_saved(int(ncells)))
     leaf_is_active_saved(1:int(ncells)) = leaf_is_active(1:int(ncells))
@@ -116,6 +116,7 @@ subroutine test_kdtree(ntests,npass)
     errmax(:)   = 0.
     tol = 2.e-11
     do i=1,int(ncells)
+       if (i > 1 .and. node(i)%parent == 0) cycle
        ! if (leaf_is_active(i) /= 0) then
        call checkvalbuf(node(i)%xcen(1),old_tree(i)%xcen(1),tol,'x0',nfailed(1),nchecked(1),errmax(1))
        call checkvalbuf(node(i)%xcen(2),old_tree(i)%xcen(2),tol,'y0',nfailed(2),nchecked(2),errmax(2))

--- a/src/tests/utils_testsuite.f90
+++ b/src/tests/utils_testsuite.f90
@@ -715,6 +715,7 @@ subroutine checkvalbuf_end_int(label,n,ndiff,ierrmax,itol,ntot)
  integer,          intent(in), optional :: ntot
 
  call print_testinfo(trim(label))
+
  if (present(ntot)) then
     call printresult(n,ndiff,ierrmax,itol,ntot)
  else
@@ -956,32 +957,23 @@ subroutine printresult_int(nchecki,ndiff,ierrmax,itol,ntot)
  ncheck  = reduce_mpi('+',nchecki)
  ndiff   = int(reduce_mpi('+',ndiff))
  ierrmax = int(reduce_mpi('max',ierrmax))
-
  if (id==master) then
     if (ndiff==0) then
        if (ierrmax > 0) then
-          write(*,"(a,i5,a,i2,a)") 'OK     [max err =',ierrmax,', tol =',itol,']'
+          write(*,"(a,i0,a,i0,a)") 'OK     [max err =',ierrmax,', tol =',itol,']'
        elseif (ncheck > 0) then
           if (present(ntot)) then
-             if (ntot < 1e6 .and. ncheck < 1e6) then
-                write(*,"(2(a,i5),a)")  'OK     [checked ',ncheck,' of ',ntot,' values]'
-             else
-                write(*,"(2(a,i10),a)") 'OK     [checked ',ncheck,' of ',ntot,' values]'
-             endif
+             write(*,"(2(a,i0),a)") 'OK     [checked ',ncheck,' of ',ntot,' values]'
           else
-             if (ncheck < 1e6) then
-                write(*,"(a,i5,a)") 'OK     [checked ',ncheck,' values]'
-             else
-                write(*,"(a,i10,a)") 'OK     [checked ',ncheck,' values]'
-             endif
+             write(*,"(a,i0,a)") 'OK     [checked ',ncheck,' values]'
           endif
        else
           write(*,"(a)") 'OK'
        endif
     elseif (ndiff > 0) then
-       write(*,"(2(a,i10),a,i10,a)") 'FAILED [on ',ndiff,' of ',ncheck,' values, max err =',ierrmax,']'
+       write(*,"(2(a,i0),a,i0,a)") 'FAILED [on ',ndiff,' of ',ncheck,' values, max err =',ierrmax,']'
     else ! this is used for single values
-       write(*,"(1x,a,i5,a,i2,a)") 'FAILED [max err =',ierrmax,', tol =',itol,']'
+       write(*,"(1x,a,i0,a,i0,a)") 'FAILED [max err =',ierrmax,', tol =',itol,']'
     endif
  endif
 
@@ -1005,17 +997,9 @@ subroutine printresult_logical(nchecki,ndiff,ntot)
     if (ndiff==0) then
        if (ncheck > 0) then
           if (present(ntot)) then
-             if (ntot < 1e6 .and. ncheck < 1e6) then
-                write(*,"(2(a,i5),a)")  'OK     [checked ',ncheck,' of ',ntot,' values]'
-             else
-                write(*,"(2(a,i10),a)") 'OK     [checked ',ncheck,' of ',ntot,' values]'
-             endif
+             write(*,"(2(a,i0),a)") 'OK     [checked ',ncheck,' of ',ntot,' values]'
           else
-             if (ncheck < 1e6) then
-                write(*,"(a,i5,a)") 'OK     [checked ',ncheck,' values]'
-             else
-                write(*,"(a,i10,a)") 'OK     [checked ',ncheck,' values]'
-             endif
+             write(*,"(a,i0,a)") 'OK     [checked ',ncheck,' values]'
           endif
        else
           write(*,"(a)") 'OK'


### PR DESCRIPTION
Description:
Implements #713 by at least fixing the revtree routine so that it actually works. This should replace the non-working rev tree routine currently sitting in master. However, performance tests currently show no speedup from utilising revtree since the factor of 2 faster tree build is offset by the larger tree nodes from not rebuilding the tree structure itself.

A unit test has been added for the rev tree routine to check that it works

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Setup (src/setup)
- [x] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [x] Test suite (src/tests)
- [ ] Documentation (docs/)
- [ ] Build/CI (build/ or github actions)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [x] Performance improvements
- [ ] Documentation update
- [ ] Better testing
- [ ] Code cleanup / refactor
- [ ] Other (please describe)

Testing:
make SETUP=testkd phantomtest && ./bin/phantomtest kdtree

Did you run the bots? no

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? yes

Is there a unit test that could be added for this feature/bug? yes

If so, please describe what a unit test might check:
implemented in test_kdtree.f90

<!-- If this PR is related to an issue, please link it here -->
Related issues: closes #713 
