### PR TITLE
beta cooling uses actual mass of sink particle or central potential

### DIFF
--- a/src/main/cooling_gammie.f90
+++ b/src/main/cooling_gammie.f90
@@ -29,19 +29,22 @@ contains
 !+
 !-----------------------------------------------------------------------
 subroutine cooling_Gammie_explicit(xi,yi,zi,ui,dudti)
- use part, only:xyzmh_ptmass, nptmass
+ use part,           only:xyzmh_ptmass, nptmass
+ use externalforces, only:mass1
  real, intent(in)    :: ui,xi,yi,zi
  real, intent(inout) :: dudti
 
- real :: omegai,r2,tcool1
+ real :: omegai,r2,tcool1,m1
 
  if (nptmass > 0) then
-    r2     = (xi-xyzmh_ptmass(1,1))**2 + (yi-xyzmh_ptmass(2,1))**2 + (zi-xyzmh_ptmass(3,1))**2
+    r2 = (xi-xyzmh_ptmass(1,1))**2 + (yi-xyzmh_ptmass(2,1))**2 + (zi-xyzmh_ptmass(3,1))**2
+    m1 = xyzmh_ptmass(4,1)
  else
-    r2     = xi*xi + yi*yi + zi*zi
+    r2 = xi*xi + yi*yi + zi*zi
+    m1 = mass1
  endif
 
- Omegai = r2**(-0.75)
+ Omegai = sqrt(m1)*r2**(-0.75)
  tcool1 = Omegai/beta_cool
  dudti  = dudti - ui*tcool1
 


### PR DESCRIPTION
Description:
fixes #550

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Setup (src/setup)
- [x] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [ ] Test suite (src/tests)
- [ ] Documentation (docs/)
- [ ] Build/CI (build/ or github actions)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [x] Bug fix
- [x] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [ ] Better testing
- [ ] Code cleanup / refactor
- [ ] Other (please describe)

Testing:
code compiles

Did you run the bots? no

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? yes

Is there a unit test that could be added for this feature/bug? unsure

<!-- If this PR is related to an issue, please link it here -->
Related issues: closes #550
