### PR TITLE
Bug fix in polytrope setup for n=1

### DIFF
--- a/src/setup/density_profiles.f90
+++ b/src/setup/density_profiles.f90
@@ -77,7 +77,7 @@ subroutine rho_polytrope(gamma,polyk,Mstar,rtab,rhotab,npts,rhocentre,set_polyk,
  integer                          :: i,j
  real                             :: r(size(rtab)),v(size(rtab)),den(size(rtab))
  real                             :: dr,an,rhs,Mstar_f,rhocentre0
- real                             :: fac,rfac
+ real                             :: fac,rfac,rfac_target
 
  dr   = 0.001
  an   = 1./(gamma-1.)
@@ -119,9 +119,10 @@ subroutine rho_polytrope(gamma,polyk,Mstar,rtab,rhotab,npts,rhocentre,set_polyk,
 
  if (present(set_polyk) .and. present(Rstar) ) then
     if ( set_polyk ) then
-       !--Rescale radius to get polyk
-       rfac      = Rstar/(r(npts)*rfac)
-       polyk     = polyk*rfac
+       !--Rescale K so radius matches target Rstar.
+       !  With fixed mass, radius scales as R ~ K^(1/(3*gamma-4)).
+       rfac_target = Rstar/(r(npts)*rfac)
+       polyk       = polyk*rfac_target**(3.*gamma - 4.)
        !
        !--Re-rescale central density to give desired mass (using the correct polyk)
        fac        = (gamma*polyk)/(fourpi*(gamma - 1.))


### PR DESCRIPTION
Description:
Bug fix in polytrope setup for n=1

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [x] Setup (src/setup)
- [ ] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [ ] Test suite (src/tests)
- [ ] Documentation (docs/)
- [ ] Build/CI (build/ or github actions)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [x] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [ ] Better testing
- [ ] Code cleanup / refactor
- [ ] Other (please describe)

Testing:

sets up planet with correct radius for n=1 polytrope

Did you run the bots? no

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? no

Is there a unit test that could be added for this feature/bug? yes

If so, please describe what a unit test might check:
 
should check that polytrope is set correctly with desired radius

<!-- If this PR is related to an issue, please link it here -->
Related issues: #
