### PR TITLE
Add test for star setup with radiation

### DIFF
--- a/scripts/testbot.sh
+++ b/scripts/testbot.sh
@@ -66,7 +66,7 @@ echo "Test suite checked: "`date` >> $htmlfile;
 echo "<table>" >> $htmlfile;
 ncheck=0;
 nfail=0;
-listofsetups="test testkd test2 testcyl testgrav testgr testdust testnimhd testgrowth";
+listofsetups="test testkd test2 testcyl testgrav radstar testgr testdust testnimhd testgrowth";
 for setup in $listofsetups; do
     cd $phantomdir;
     errorlog="./logs/test-results-$setup-$SYSTEM$tag.txt";
@@ -94,6 +94,8 @@ for setup in $listofsetups; do
        arg="dustgrowth";
     elif [ $setup == "testgr" ]; then
        arg="gr"
+    elif [ $setup == "radstar" ]; then
+       arg="star"
     else
        arg="";
     fi

--- a/src/main/eos.f90
+++ b/src/main/eos.f90
@@ -72,8 +72,8 @@ module eos
  public  :: init_eos,finish_eos
  public  :: write_options_eos,read_options_eos,set_defaults_eos
  public  :: write_headeropts_eos,read_headeropts_eos
- public  :: eos_requires_isothermal,eos_requires_polyk,eos_allows_shock_and_work
- public  :: eos_is_not_implemented,eos_has_pressure_without_u
+ public  :: eos_requires_isothermal,eos_works_with_radiation,eos_requires_polyk
+ public  :: eos_allows_shock_and_work,eos_is_not_implemented,eos_has_pressure_without_u
 
  public :: irecomb  ! propagated from eos_gasradrec
 
@@ -590,10 +590,7 @@ subroutine init_eos(eos_type,ierr)
     !
     write(*,'(1x,a,f7.5,a,f7.5)') 'Initialising MESA EoS with X = ',X_in,', Z = ',Z_in
     call init_eos_mesa(X_in,Z_in,ierr)
-    if (do_radiation .and. ierr==0) then
-       call error('eos','ieos=10, cannot use eos with radiation, will double count radiation pressure')
-       ierr=ierr_option_conflict !return error if using radiation and mesa EOS, shouldn't use mesa eos, as it will double count rad pres
-    elseif (use_var_comp) then
+    if (use_var_comp) then
        call error('eos','ieos=10, variable composition not supported from MESA EoS')
        ierr=ierr_option_conflict ! can only read EoS table for fixed composition at the moment
     endif
@@ -603,10 +600,6 @@ subroutine init_eos(eos_type,ierr)
     ! ideal plus radiation
     !
     write(*,'(1x,a,f7.5)') 'Using ideal plus radiation EoS with mu = ',gmw
-    if (do_radiation) then
-       call error('eos','ieos=12, cannot use eos with radiation, will double count radiation pressure')
-       ierr = ierr_option_conflict
-    endif
 
  case(15)
 
@@ -637,10 +630,18 @@ subroutine init_eos(eos_type,ierr)
  end select
  done_init_eos = .true.
 
- if (do_radiation .and. iopacity_type==1) then
-    write(*,'(1x,a,f7.5,a,f7.5)') 'Using radiation with MESA opacities. Initialising MESA EoS with X = ',X_in,', Z = ',Z_in
-    call init_eos_mesa(X_in,Z_in,ierr_mesakapp)
-    ierr = max(ierr,ierr_mesakapp)
+ if (do_radiation) then
+    if (.not. eos_works_with_radiation(eos_type)) then
+       call error('eos','eos is incompatible with radiation')
+       ierr = ierr_option_conflict
+       return
+    endif
+    
+    if (iopacity_type==1) then
+       write(*,'(1x,a,f7.5,a,f7.5)') 'Using radiation with MESA opacities. Initialising MESA EoS with X = ',X_in,', Z = ',Z_in
+       call init_eos_mesa(X_in,Z_in,ierr_mesakapp)
+       ierr = max(ierr,ierr_mesakapp)
+    endif
  endif
 
 end subroutine init_eos
@@ -1442,6 +1443,24 @@ logical function eos_outputs_temp(ieos)
  end select
 
 end function eos_outputs_temp
+
+!-----------------------------------------------------------------------
+!+
+!  Query function for whether the equation of state is compatible
+!  with radiation transport
+!+
+!-----------------------------------------------------------------------
+logical function eos_works_with_radiation(ieos)
+ integer, intent(in) :: ieos
+
+ select case(ieos)
+ case(2,20)
+    eos_works_with_radiation = .true.
+ case default
+    eos_works_with_radiation = .false.
+ end select
+
+end function eos_works_with_radiation
 
 !-----------------------------------------------------------------------
 !+

--- a/src/setup/set_star.f90
+++ b/src/setup/set_star.f90
@@ -69,10 +69,10 @@ module setstar
  integer, parameter :: istar_offset = 3 ! offset for particle type to distinguish particles
  ! placed in stars from other particles in the simulation
 
- integer, public :: ierr_sink_profile = 1, &
-                    ierr_part = 2, &
-                    ierr_unbound = 3, &
-                    ierr_radiation_conflict = 4
+ integer, parameter, public :: ierr_sink_profile = 1, &
+                               ierr_part = 2, &
+                               ierr_unbound = 3, &
+                               ierr_radiation_conflict = 4
 
  integer, private :: EOSopt = 1
 

--- a/src/setup/set_star.f90
+++ b/src/setup/set_star.f90
@@ -69,6 +69,11 @@ module setstar
  integer, parameter :: istar_offset = 3 ! offset for particle type to distinguish particles
  ! placed in stars from other particles in the simulation
 
+ integer, public :: ierr_sink_profile = 1, &
+                    ierr_part = 2, &
+                    ierr_unbound = 3, &
+                    ierr_radiation_conflict = 4
+
  integer, private :: EOSopt = 1
 
  private
@@ -190,9 +195,9 @@ subroutine set_star(id,master,star,xyzh,vxyzu,eos_vars,rad,&
                     rhozero,npart_total,mask,ierr,x0,v0,itype,&
                     write_files,density_error,energy_error)
  use centreofmass,       only:reset_centreofmass
- use dim,                only:gr,gravity,maxvxyzu
+ use dim,                only:gr,gravity,maxvxyzu,do_radiation
  use io,                 only:fatal,error,warning
- use eos,                only:eos_outputs_mu,polyk_eos=>polyk
+ use eos,                only:eos_works_with_radiation,eos_outputs_mu,polyk_eos=>polyk
  use setstar_utils,      only:set_stellar_core,read_star_profile,set_star_density, &
                               set_star_composition,set_star_thermalenergy,&
                               write_kepler_comp
@@ -248,7 +253,7 @@ subroutine set_star(id,master,star,xyzh,vxyzu,eos_vars,rad,&
  call get_star_properties_in_code_units(star,star%r_code,mstar,star%rcore_code,star%mcore_code,&
                                         star%hsoft_code,star%lcore_code,star%hacc_code,nerr)
  if (nerr /= 0) then
-    ierr = 2
+    ierr = ierr_part
     return
  endif
 
@@ -258,7 +263,15 @@ subroutine set_star(id,master,star,xyzh,vxyzu,eos_vars,rad,&
  if (star%iprofile <= 0) then
     star%m_code = mstar
     call write_mass('Sink particle with mass = ',star%m_code,umass)
-    ierr = 1
+    ierr = ierr_sink_profile
+    return
+ endif
+ !
+ ! throw error if equation of state is incompatible with radiation
+ !
+ if (do_radiation .and. (.not. eos_works_with_radiation(ieos))) then
+    call error('set_star','radiation is not supported with the chosen equation of state')
+    ierr = ierr_radiation_conflict
     return
  endif
  !
@@ -280,12 +293,12 @@ subroutine set_star(id,master,star,xyzh,vxyzu,eos_vars,rad,&
  if (relax) lattice='random'
  if (star%np < 1 .and. npart_old==0) then
     call fatal('set_star','cannot set up a star with zero particles')
-    ierr = 2
+    ierr = ierr_part
     return
  endif
  if (mstar < 0.) then
     call fatal('set_star','cannot set up a star with negative mass!')
-    ierr = 2
+    ierr = ierr_part
     return
  endif
  call set_star_density(lattice,id,master,rmin,star%r_code,mstar,hfact,&

--- a/src/tests/test_eos.f90
+++ b/src/tests/test_eos.f90
@@ -75,7 +75,7 @@ end subroutine test_eos
 subroutine test_all(ntests, npass)
  use eos,       only:maxeos,init_eos,isink,polyk,polyk2,qfacdisc,&
                      ierr_file_not_found,ierr_option_conflict,&
-                     eos_is_not_implemented
+                     eos_is_not_implemented,eos_works_with_radiation
  use io,        only:id,master
  use testutils, only:checkval,update_test_scores
  use dim,       only:do_radiation
@@ -116,7 +116,7 @@ subroutine test_all(ntests, npass)
     if (ieos==15 .and. ierr /= 0 .and. .not. got_phantom_dir) cycle ! skip helmholtz
     if (ieos==16 .and. ierr /= 0 .and. .not. got_phantom_dir) cycle ! skip Shen
 
-    if (do_radiation .and. (ieos==10 .or. ieos==12)) correct_answer = ierr_option_conflict
+    if (do_radiation .and. (.not. eos_works_with_radiation(ieos))) correct_answer = ierr_option_conflict
     call checkval(ierr,correct_answer,0,nfailed(1),'eos initialisation')
     call update_test_scores(ntests,nfailed,npass)
     !

--- a/src/tests/test_setstar.f90
+++ b/src/tests/test_setstar.f90
@@ -211,7 +211,7 @@ subroutine test_redsupergiant(ntests,npass)
  use dim,       only:do_radiation
  use datafiles, only:find_phantom_datafile
  use part,      only:init_part,npart,npartoftype,xyzh,vxyzu,eos_vars,rad,massoftype,hfact,&
-                     xyzmh_ptmass,vxyz_ptmass,nptmass,rhoh,igas,igasP,imu,iX,iZ,radprop,iradxi,&
+                     xyzmh_ptmass,vxyz_ptmass,nptmass,rhoh,igas,igasP,imu,iX,iZ,iradxi,&
                      eos_vars,itemp
  use mpidomain, only:i_belong
  use options,   only:ieos

--- a/src/tests/test_setstar.f90
+++ b/src/tests/test_setstar.f90
@@ -33,7 +33,7 @@ contains
 subroutine test_setstar(ntests,npass)
  use checksetup, only:check_setup
  use io,         only:id,master
- use dim,        only:gravity
+ use dim,        only:gravity,do_radiation
  integer, intent(inout) :: ntests,npass
 
  if (.not.gravity) then
@@ -47,7 +47,7 @@ subroutine test_setstar(ntests,npass)
  call test_get_mass_coord(ntests,npass)
 
  ! test polytrope
- call test_polytrope(ntests,npass)
+ if (.not. do_radiation) call test_polytrope(ntests,npass)
 
  ! test red supergiant
  call test_redsupergiant(ntests,npass)
@@ -208,26 +208,30 @@ end subroutine test_polytrope
 !-----------------------------------------------------------------------
 subroutine test_redsupergiant(ntests,npass)
  use io,        only:id,master,iverbose,warning
+ use dim,       only:do_radiation
  use datafiles, only:find_phantom_datafile
- use part,      only:npart,npartoftype,xyzh,vxyzu,eos_vars,rad,massoftype,hfact,&
-                     xyzmh_ptmass,vxyz_ptmass,nptmass,rhoh,igas,igasP,imu,iX,iZ
+ use part,      only:init_part,npart,npartoftype,xyzh,vxyzu,eos_vars,rad,massoftype,hfact,&
+                     xyzmh_ptmass,vxyz_ptmass,nptmass,rhoh,igas,igasP,imu,iX,iZ,radprop,iradxi,&
+                     eos_vars,itemp
  use mpidomain, only:i_belong
  use options,   only:ieos
  use physcon,   only:solarr,solarm
- use eos,       only:init_eos,gamma,gmw,X_in,Z_in,irecomb
- use setstar,   only:star_t,set_star,set_defaults_star,imesa
+ use eos,       only:init_eos,gamma,gmw,X_in,Z_in,irecomb,eos_works_with_radiation
+ use setstar,   only:star_t,set_star,set_defaults_star,imesa,ierr_radiation_conflict
  use units,     only:set_units
  use relaxstar, only:maxits
  use checksetup,  only:check_setup
  use testutils,   only:checkvalbuf,checkvalbuf_end
  use table_utils, only:yinterp
- use readwrite_mesa, only:read_mesa
+ use readwrite_mesa,  only:read_mesa
+ use radiation_utils, only:Trad_from_radxi
  integer, intent(inout) :: ntests,npass
  type(star_t) :: star
  character(len=500) :: filepath
- real :: rhozero,rmserr,rmserr_mu,rmserr_X,rmserr_Z,ekin,x0(3),errmax(2),Mstar,tolprof,tolcomposition,rhoj,rhoj_mesa,rj
+ real :: rhozero,rmserr,rmserr_mu,rmserr_X,rmserr_Z,ekin,x0(3),errmax(2)
+ real :: Mstar,tolprof,tolcomposition,rhoj,rhoj_mesa,rj,Tgas,Trad
  integer(kind=8) :: ntot
- integer :: ierr,nfail(1),i,j,nerror,nwarn,iunit
+ integer :: ierr,nfail(2),ncheck(2),i,j,nerror,nwarn,iunit,expected_error
  logical :: relax_star,var_comp
  real, allocatable :: r(:),den(:),pres(:),temp(:),en(:),mtab(:),Xfrac(:),Yfrac(:),Zfrac(:),mu(:)
 
@@ -260,7 +264,7 @@ subroutine test_redsupergiant(ntests,npass)
  star%iprofile = imesa
  x0 = 0.
 
- nfail = 0; errmax = 0.
+ nfail = 0; ncheck = 0; errmax = 0.
  tolprof = 0.08
  tolcomposition = 0.08
 
@@ -268,13 +272,7 @@ subroutine test_redsupergiant(ntests,npass)
  Zfrac = 1.-Xfrac-Yfrac
 
  do i=1,4
-    npart = 0
-    npartoftype = 0
-    massoftype = 0.
-    nptmass = 0
-    xyzmh_ptmass = 0.
-    vxyz_ptmass = 0.
-
+    call init_part()
     if (i==1) then  ! ideal gas EoS
        ieos = 2
     elseif (i==2) then  ! ideal gas + radiation EoS
@@ -299,8 +297,14 @@ subroutine test_redsupergiant(ntests,npass)
                rhozero=rhozero,npart_total=ntot,mask=i_belong,ierr=ierr,&
                write_files=.false.,density_error=rmserr,energy_error=ekin)
 
-    call checkval(ierr,0,0,nfail(1),'set_star runs with ierr = 0')
+    if (do_radiation .and. (.not. eos_works_with_radiation(ieos))) then
+       expected_error = ierr_radiation_conflict
+    else
+       expected_error = 0
+    endif
+    call checkval(ierr,expected_error,0,nfail(1),'set_star runs with expected ierr')
     call update_test_scores(ntests,nfail,npass)
+    if (ierr == ierr_radiation_conflict) cycle  ! skip the rest of the checks if we get a radiation conflict error
 
     call check_setup(nerror,nwarn,restart=.false.)
     call checkval(nerror+nwarn,0,0,nfail(1),'no errors or warnings')
@@ -322,6 +326,12 @@ subroutine test_redsupergiant(ntests,npass)
        rhoj_mesa = yinterp(den,r,rj)
        rmserr = rmserr + (1-rhoj/rhoj_mesa)**2
 
+       if (do_radiation) then
+          Trad = Trad_from_radxi(rhoj, rad(iradxi,j))
+          Tgas = eos_vars(itemp,j)
+          call checkvalbuf(Trad/Tgas,1.,1e-15,'Trad/Tgas = 1 for radiative star',nfail(2),ncheck(2),errmax(2),use_rel_tol=.true.)
+       endif
+
        if (i==5) then  ! calculate rms error in mu, X, Z, not implemented yet
           rmserr_mu = rmserr_mu + (1-abs(eos_vars(imu,j)/yinterp(mu,r,rj)))**2
           rmserr_X = rmserr_X + (1-abs(eos_vars(iX,j)/yinterp(Xfrac,r,rj)))**2
@@ -330,6 +340,9 @@ subroutine test_redsupergiant(ntests,npass)
     enddo
     rmserr = sqrt(rmserr/npart)  ! root mean square relative error
     call checkval(rmserr,0.,tolprof,nfail(1),'density matches MESA profile')
+    call update_test_scores(ntests,nfail,npass)
+
+    call checkvalbuf_end('Trad/Tgas ~ 1 for radiative star',ncheck(2),nfail(2),errmax(2),1.e-15)
     call update_test_scores(ntests,nfail,npass)
 
     if (i==5) then  ! not implemented yet


### PR DESCRIPTION
Checks star can be set up with radiation and that Tgas = Trad initially. Skips EoSs that are incompatible with radiation.