### PR TITLE
Added element input to eos helmholtz with default being C/O 50,50. 

### DIFF
--- a/src/main/eos.f90
+++ b/src/main/eos.f90
@@ -1724,7 +1724,7 @@ end subroutine read_headeropts_eos
 subroutine write_options_eos(iunit)
  use dim,            only:use_krome,isothermal,mhd
  use infile_utils,   only:write_inopt
- use eos_helmholtz,  only:eos_helmholtz_write_inopt
+ use eos_helmholtz,  only:write_options_eos_helmholtz
  use eos_barotropic, only:write_options_eos_barotropic
  use eos_piecewise,  only:write_options_eos_piecewise
  use eos_gasradrec,  only:write_options_eos_gasradrec
@@ -1747,7 +1747,7 @@ subroutine write_options_eos(iunit)
     call write_inopt(X_in,'X','hydrogen mass fraction',iunit)
     call write_inopt(Z_in,'Z','metallicity',iunit)
  case(15) ! helmholtz eos
-    call eos_helmholtz_write_inopt(iunit)
+    call write_options_eos_helmholtz(iunit)
  case(20)
     call write_options_eos_gasradrec(iunit)
     if (.not. use_var_comp) then
@@ -1782,6 +1782,7 @@ subroutine read_options_eos(db,nerr)
  use eos_barotropic, only:read_options_eos_barotropic
  use eos_piecewise,  only:read_options_eos_piecewise
  use eos_gasradrec,  only:read_options_eos_gasradrec
+ use eos_helmholtz,  only:read_options_eos_helmholtz
  use eos_tillotson,  only:read_options_eos_tillotson
  type(inopts), intent(inout) :: db(:)
  integer,      intent(inout) :: nerr
@@ -1810,6 +1811,7 @@ subroutine read_options_eos(db,nerr)
 
  if (ieos== 8) call read_options_eos_barotropic(db,nerr)
  if (ieos== 9) call read_options_eos_piecewise(db,nerr)
+ if (ieos==15) call read_options_eos_helmholtz(db,nerr)
  if (ieos==20) call read_options_eos_gasradrec(db,nerr)
  if (ieos==23) call read_options_eos_tillotson(db,nerr)
 

--- a/src/main/eos_helmholtz.f90
+++ b/src/main/eos_helmholtz.f90
@@ -178,7 +178,7 @@ subroutine eos_helmholtz_init(ierr)
  xmass(4) = xo
  xmass(5) = xne
  xmass(6) = xmg
- if (sum(xmass(:)) > 1.0+tiny(xmass) .or. sum(xmass(:)) < 1.0-tiny(xmass)) then
+ if (sum(xmass(:)) > 1.0+1e-6 .or. sum(xmass(:)) < 1.0-1e-6) then
     call warning('eos_helmholtz', 'mass fractions total != 1')
     ierr = 1
     return
@@ -374,12 +374,12 @@ subroutine read_options_eos_helmholtz(db,nerr)
  type(inopts), intent(inout) :: db(:)
  integer, intent(inout) :: nerr
 
- call read_inopt(xh ,'xh' ,db,errcount=nerr,min=0.,max=1.)
- call read_inopt(xhe,'xhe',db,errcount=nerr,min=0.,max=1.)
- call read_inopt(xc ,'xc' ,db,errcount=nerr,min=0.,max=1.)
- call read_inopt(xo ,'xo' ,db,errcount=nerr,min=0.,max=1.)
- call read_inopt(xne,'xne',db,errcount=nerr,min=0.,max=1.)
- call read_inopt(xmg,'xmg',db,errcount=nerr,min=0.,max=1.)
+ call read_inopt(xh ,'xh' ,db,errcount=nerr,min=0.,max=1.,default=xh)
+ call read_inopt(xhe,'xhe',db,errcount=nerr,min=0.,max=1.,default=xhe)
+ call read_inopt(xc ,'xc' ,db,errcount=nerr,min=0.,max=1.,default=xc)
+ call read_inopt(xo ,'xo' ,db,errcount=nerr,min=0.,max=1.,default=xo)
+ call read_inopt(xne,'xne',db,errcount=nerr,min=0.,max=1.,default=xne)
+ call read_inopt(xmg,'xmg',db,errcount=nerr,min=0.,max=1.,default=xmg)
 
 end subroutine read_options_eos_helmholtz
 

--- a/src/main/eos_helmholtz.f90
+++ b/src/main/eos_helmholtz.f90
@@ -23,7 +23,6 @@ module eos_helmholtz
 
 ! subroutines to read/initialise tables, and get pressure/sound speed
  public :: eos_helmholtz_init
-!  public :: eos_helmholtz_write_inopt
  public :: read_options_eos_helmholtz
  public :: write_options_eos_helmholtz
  public :: eos_helmholtz_pres_sound          ! performs iterations, called by eos.F90
@@ -364,11 +363,6 @@ subroutine write_options_eos_helmholtz(iunit)
  call write_inopt(xmg,'xmg','Magnesium mass fraction',iunit)
 
 end subroutine write_options_eos_helmholtz
-
-! subroutine eos_helmholtz_write_inopt(iunit)
-!  integer, intent(in) :: iunit
-
-! end subroutine eos_helmholtz_write_inopt
 
 !----------------------------------------------------------------
 !+ 

--- a/src/main/eos_helmholtz.f90
+++ b/src/main/eos_helmholtz.f90
@@ -23,7 +23,9 @@ module eos_helmholtz
 
 ! subroutines to read/initialise tables, and get pressure/sound speed
  public :: eos_helmholtz_init
- public :: eos_helmholtz_write_inopt
+!  public :: eos_helmholtz_write_inopt
+ public :: read_options_eos_helmholtz
+ public :: write_options_eos_helmholtz
  public :: eos_helmholtz_pres_sound          ! performs iterations, called by eos.F90
  public :: eos_helmholtz_compute_pres_sound  ! the actual eos calculation
  public :: eos_helmholtz_energy_from_rhoT  ! invert EOS: get energy from rho, pressure, T
@@ -38,8 +40,14 @@ module eos_helmholtz
  private
 
  ! these set the mixture of species
- ! currently hard-coded to 50/50 carbon-oxygen
-
+ ! following elements can be set by user at runtime
+ real :: xh  = 0.0
+ real :: xhe = 0.0
+ real :: xc  = 0.5
+ real :: xo  = 0.5
+ real :: xne = 0.0
+ real :: xmg = 0.0 
+ 
  integer, parameter :: speciesmax = 15
  character(len=10) :: speciesname(speciesmax)
  real :: xmass(speciesmax) ! mass fraction of species
@@ -163,13 +171,14 @@ subroutine eos_helmholtz_init(ierr)
  Aion(14) = 56.0  ;  Zion(14) = 28.0  ! nickel
  Aion(15) = 60.0  ;  Zion(15) = 30.0  ! zinc
 
- ! set the mass weightings of each species
- ! currently hard-coded to 50/50 carbon-oxygen
- ! TODO: update this be set by user at runtime
+ ! set the mass weightings of each species, user sets the mass fractions of each species, and we check that they sum to 1
  xmass(:) = 0.0
- xmass(3) = 0.5
- xmass(4) = 0.5
-
+ xmass(1) = xh
+ xmass(2) = xhe
+ xmass(3) = xc
+ xmass(4) = xo
+ xmass(5) = xne
+ xmass(6) = xmg
  if (sum(xmass(:)) > 1.0+tiny(xmass) .or. sum(xmass(:)) < 1.0-tiny(xmass)) then
     call warning('eos_helmholtz', 'mass fractions total != 1')
     ierr = 1
@@ -339,13 +348,47 @@ end subroutine eos_helmholtz_calc_AbarZbar
 
 !----------------------------------------------------------------
 !+
-!  write options to the input file (currently nothing)
+!  write options to the input file (abundances of each species)
 !+
 !----------------------------------------------------------------
-subroutine eos_helmholtz_write_inopt(iunit)
+
+subroutine write_options_eos_helmholtz(iunit)
+ use infile_utils, only: write_inopt
  integer, intent(in) :: iunit
 
-end subroutine eos_helmholtz_write_inopt
+ call write_inopt(xh ,'xh' ,'Hydrogen mass fraction',iunit)
+ call write_inopt(xhe,'xhe','Helium mass fraction',iunit)
+ call write_inopt(xc ,'xc' ,'Carbon mass fraction',iunit)
+ call write_inopt(xo ,'xo' ,'Oxygen mass fraction',iunit)
+ call write_inopt(xne,'xne','Neon mass fraction',iunit)
+ call write_inopt(xmg,'xmg','Magnesium mass fraction',iunit)
+
+end subroutine write_options_eos_helmholtz
+
+! subroutine eos_helmholtz_write_inopt(iunit)
+!  integer, intent(in) :: iunit
+
+! end subroutine eos_helmholtz_write_inopt
+
+!----------------------------------------------------------------
+!+ 
+!  read options from the input file (abundances of each species)
+!+
+!----------------------------------------------------------------
+subroutine read_options_eos_helmholtz(db,nerr)
+ use infile_utils, only: inopts, read_inopt
+ type(inopts), intent(inout) :: db(:)
+ integer, intent(inout) :: nerr
+
+ call read_inopt(xh ,'xh' ,db,errcount=nerr,min=0.,max=1.)
+ call read_inopt(xhe,'xhe',db,errcount=nerr,min=0.,max=1.)
+ call read_inopt(xc ,'xc' ,db,errcount=nerr,min=0.,max=1.)
+ call read_inopt(xo ,'xo' ,db,errcount=nerr,min=0.,max=1.)
+ call read_inopt(xne,'xne',db,errcount=nerr,min=0.,max=1.)
+ call read_inopt(xmg,'xmg',db,errcount=nerr,min=0.,max=1.)
+
+end subroutine read_options_eos_helmholtz
+
 
 ! return min density from table limits in code units
 real function eos_helmholtz_get_minrho()

--- a/src/setup/set_star_utils.f90
+++ b/src/setup/set_star_utils.f90
@@ -102,7 +102,7 @@ subroutine read_star_profile(iprofile,ieos,input_profile,gamma,polyk,ui_coef,&
  !
  calc_polyk = .true.
  allocate(r(ng_max),den(ng_max),pres(ng_max),temp(ng_max),en(ng_max),mtab(ng_max))
-
+ temp = 0.  ! Initialize temperature array for non-file-based profiles
  print "(/,a,/)",' Using '//trim(profile_opt(iprofile))
  select case(iprofile)
  case(ipoly)


### PR DESCRIPTION


Description:
The element abundance in EOS helmholtz was hardcoded before; now elements H,He,C,O,Ne,Mg can be added as a runtime parameter in .in files when eos is helmholtz

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Setup (src/setup)
- [ x] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [ ] Test suite (src/tests)
- [ ] Documentation (docs/)
- [ ] Build/CI (build/ or github actions)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [x ] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [ ] Better testing
- [x ] Code cleanup / refactor
- [ ] Other (please describe)

Testing:
 setting the total elements to more than 1 and seeing if it gives errors

Did you run the bots? no

Did you add comments such that the purpose of the code is understandable? yes/
