### PR TITLE
bug fix of Racc in grdisc setup

### DIFF
--- a/src/setup/setup_grdisc.f90
+++ b/src/setup/setup_grdisc.f90
@@ -179,6 +179,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
        ! place stars in orbit
        call set_orbit(orbit(i),mhole/umass,star(i)%m_code,r_in,star(i)%hacc_code, &
                      xyzmh_ptmass_in,vxyz_ptmass_in,nptmass_in,(id==master),ierr)
+       if (ierr /= 0) stop 'error setting up orbit'
 
        ! shift the star to the position of the second body
        if (star(i)%iprofile > 0) then

--- a/src/setup/setup_grdisc.f90
+++ b/src/setup/setup_grdisc.f90
@@ -62,7 +62,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  use externalforces, only:accradius1,accradius1_hard
  use options,        only:iexternalforce,alphau
  use eos,            only:ipdv_heating,ishock_heating
- use units,          only:set_units,umass,in_code_units
+ use units,          only:set_units,umass
  use physcon,        only:solarm,pi
  use externalforces, only:iext_einsteinprec,a
  use prompting,      only:prompt
@@ -89,7 +89,7 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
  integer :: ierr,nptmass_in,i
  integer(kind=8) :: npart_total
  logical :: write_profile
- real    :: cs2,mstar,rstar
+ real    :: cs2
  real :: xyzmh_ptmass_in(nsinkproperties,2),vxyz_ptmass_in(3,2)
 
  time            = 0.
@@ -176,10 +176,8 @@ subroutine setpart(id,npart,npartoftype,xyzh,massoftype,vxyzu,polyk,gamma,hfact,
                   rhozero,npart_total,i_belong,ierr)
     do i=1,nstars
        nptmass_in = 0
-       ! convert stellar mass and radius to code units
-       mstar = in_code_units(star(i)%m,ierr)
-       rstar = in_code_units(star(i)%r,ierr)
-       call set_orbit(orbit(i),mhole/umass,mstar,r_in,rstar, &
+       ! place stars in orbit
+       call set_orbit(orbit(i),mhole/umass,star(i)%m_code,r_in,star(i)%hacc_code, &
                      xyzmh_ptmass_in,vxyz_ptmass_in,nptmass_in,(id==master),ierr)
 
        ! shift the star to the position of the second body


### PR DESCRIPTION
Description:
Fixed bug in grdisc setup wrt racc of secondary sink

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [x] Setup (src/setup)
- [ ] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [ ] Test suite (src/tests)
- [ ] Documentation (docs/)
- [ ] Build/CI (build/ or github actions)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [x] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [ ] Better testing
- [ ] Code cleanup / refactor
- [ ] Other (please describe)

Testing:
<!-- Describe how you have tested the change -->

Did you run the bots? no

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? yes

Is there a unit test that could be added for this feature/bug? yes
grdisc setup should work with the following config: 
```
# how many bodies
              nstars =           1    ! number of bodies to add (0-10)

# options for body 1
           iprofile1 =           0    ! 0=Sink,1=Unif,2=Poly,3=Dens,4=KEPL,5=MESA,6=Piec
              Mstar1 =    1.0E+08 msun    ! mass of body 1 (code units or e.g. 1 msun)
               hacc1 =         1.0    ! accretion radius for sink (=0.0 for softened potential)
              hsoft1 =         1.0    ! softening radius for sink1
```

<!-- If this PR is related to an issue, please link it here -->
Related issues: Fixes #830 
