### PR TITLE
Zero Temperature eos

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -492,7 +492,7 @@ SRCMESA= eos_mesa_microphysics.f90 eos_mesa.f90
 
 SRCEOS = eos_tillotson.f90 eos_barotropic.f90 eos_stratified.f90 eos_piecewise.f90 ${SRCMESA} \
          eos_shen.f90 eos_helmholtz.f90 eos_idealplusrad.f90 \
-         ionization.f90 eos_gasradrec.f90 eos_HIIR.f90 eos_stamatellos.f90 eos.f90
+         ionization.f90 eos_gasradrec.f90 eos_HIIR.f90 eos_stamatellos.f90 eos_zerotemp.f90 eos.f90
 
 SRCRW_DUMPS= readwrite_dumps_common.f90 readwrite_dumps.f90
 

--- a/src/main/datafiles.f90
+++ b/src/main/datafiles.f90
@@ -79,6 +79,8 @@ function map_dir_to_web(search_dir) result(url)
     url = 'https://zenodo.org/records/18615172/files/'
  case('data/eos/lombardi')
     url = 'https://zenodo.org/records/13842491/files/'
+ case('data/star_data_files/pourmandwd.data')
+    url = 'https://zenodo.org/records/20738843/files/'
  case default
     url = 'https://users.monash.edu.au/~dprice/'//trim(search_dir)
  end select

--- a/src/main/datafiles.f90
+++ b/src/main/datafiles.f90
@@ -79,7 +79,7 @@ function map_dir_to_web(search_dir) result(url)
     url = 'https://zenodo.org/records/18615172/files/'
  case('data/eos/lombardi')
     url = 'https://zenodo.org/records/13842491/files/'
- case('data/star_data_files/pourmandwd.data')
+ case('data/star_data_files')
     url = 'https://zenodo.org/records/20738843/files/'
  case default
     url = 'https://users.monash.edu.au/~dprice/'//trim(search_dir)

--- a/src/main/eos.f90
+++ b/src/main/eos.f90
@@ -1595,6 +1595,7 @@ subroutine eosinfo(eos_type,iprint)
  use eos_gasradrec,  only:eos_info_gasradrec
  use eos_stamatellos,only:eos_file
  use eos_tillotson,  only:eos_info_tillotson
+ use eos_zerotemp,   only:eos_zerotemp_eosinfo
  integer, intent(in) :: eos_type,iprint
 
  if (id/=master) return
@@ -1760,7 +1761,7 @@ subroutine write_options_eos(iunit)
  use eos_piecewise,  only:write_options_eos_piecewise
  use eos_gasradrec,  only:write_options_eos_gasradrec
  use eos_tillotson,  only:write_options_eos_tillotson
- use eos_zerotemp,   only:write_eos_zerotemp_options
+ use eos_zerotemp,   only:write_options_eos_zerotemp
  integer, intent(in) :: iunit
 
  write(iunit,"(/,a)") '# options controlling equation of state'
@@ -1789,7 +1790,7 @@ subroutine write_options_eos(iunit)
  case(23)
     call write_options_eos_tillotson(iunit)
  case(25)
-   call write_eos_zerotemp_options(iunit)
+   call write_options_eos_zerotemp(iunit)
  end select
 
  if (.not.isothermal .and. eos_allows_shock_and_work(ieos)) then
@@ -1818,7 +1819,7 @@ subroutine read_options_eos(db,nerr)
  use eos_gasradrec,  only:read_options_eos_gasradrec
  use eos_helmholtz,  only:read_options_eos_helmholtz
  use eos_tillotson,  only:read_options_eos_tillotson
- use eos_zerotemp,   only:eos_zerotemp_read_options
+ use eos_zerotemp,   only:read_options_eos_zerotemp
  type(inopts), intent(inout) :: db(:)
  integer,      intent(inout) :: nerr
  character(len=*), parameter  :: label = 'read_infile'

--- a/src/main/eos.f90
+++ b/src/main/eos.f90
@@ -567,6 +567,7 @@ subroutine init_eos(eos_type,ierr)
  use eos_HIIR,       only:init_eos_HIIR
  use dim,            only:maxvxyzu,do_radiation
  use eos_tillotson,  only:init_eos_tillotson
+ use eos_zerotemp,   only:eos_zerotemp_init
  integer, intent(in)  :: eos_type
  integer, intent(out) :: ierr
  integer              :: ierr_mesakapp,ierr_ra
@@ -651,7 +652,7 @@ subroutine init_eos(eos_type,ierr)
     !
     ! zero temperature
     !
-    write(*,*) 'Using zero temperature EoS (assuming mu_electron=2) '
+    call eos_zerotemp_init(ierr)
 
  end select
  done_init_eos = .true.
@@ -1647,7 +1648,7 @@ subroutine eosinfo(eos_type,iprint)
  case(24)
     write(iprint,"(/,a,a)") 'Using tabulated Eos from file:', eos_file, 'and calculated gamma.'
  case(25)
-    write(*,'(1x,a,i1,a)') 'Using zero temperature EoS, assuming mu_electron=2'
+    call eos_zerotemp_eosinfo(iprint)
 
  end select
  write(iprint,*)
@@ -1759,6 +1760,7 @@ subroutine write_options_eos(iunit)
  use eos_piecewise,  only:write_options_eos_piecewise
  use eos_gasradrec,  only:write_options_eos_gasradrec
  use eos_tillotson,  only:write_options_eos_tillotson
+ use eos_zerotemp,   only:write_eos_zerotemp_options
  integer, intent(in) :: iunit
 
  write(iunit,"(/,a)") '# options controlling equation of state'
@@ -1786,6 +1788,8 @@ subroutine write_options_eos(iunit)
     endif
  case(23)
     call write_options_eos_tillotson(iunit)
+ case(25)
+   call write_eos_zerotemp_options(iunit)
  end select
 
  if (.not.isothermal .and. eos_allows_shock_and_work(ieos)) then
@@ -1814,6 +1818,7 @@ subroutine read_options_eos(db,nerr)
  use eos_gasradrec,  only:read_options_eos_gasradrec
  use eos_helmholtz,  only:read_options_eos_helmholtz
  use eos_tillotson,  only:read_options_eos_tillotson
+ use eos_zerotemp,   only:eos_zerotemp_read_options
  type(inopts), intent(inout) :: db(:)
  integer,      intent(inout) :: nerr
  character(len=*), parameter  :: label = 'read_infile'
@@ -1844,6 +1849,7 @@ subroutine read_options_eos(db,nerr)
  if (ieos==15) call read_options_eos_helmholtz(db,nerr)
  if (ieos==20) call read_options_eos_gasradrec(db,nerr)
  if (ieos==23) call read_options_eos_tillotson(db,nerr)
+ if (ieos==25) call read_options_eos_zerotemp(db,nerr)
 
 end subroutine read_options_eos
 

--- a/src/main/eos.f90
+++ b/src/main/eos.f90
@@ -529,7 +529,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,tempi,eni,gam
     ponrhoi = presi/rhoi
     gammai = 1.d0 + presi/(eni*rhoi)
     spsoundi = sqrt(gammai*ponrhoi)
-   case (25) ! zero temperature EOS (under construction)
+   case (25) ! zero temperature EOS 
     cgsrhoi = rhoi * unit_density
 
     call get_zerotemp_pressure(cgsrhoi,cgspresi)
@@ -538,10 +538,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,tempi,eni,gam
     presi = cgspresi/unit_pressure
     ponrhoi = presi/rhoi
     spsoundi = cgsspsoundi / unit_velocity
-
-   !  tempi    =  0  !we don't need a temperature
-
-
+    tempi = 0. 
  case default
     spsoundi = 0. ! avoids compiler warnings
     ponrhoi  = 0.
@@ -652,7 +649,7 @@ subroutine init_eos(eos_type,ierr)
 
  case(25)
     !
-    ! zero temperature (do we need this?)
+    ! zero temperature
     !
     write(*,*) 'Using zero temperature EoS (assuming mu_electron=2) '
 
@@ -951,6 +948,7 @@ subroutine calc_temp_and_ene(eos_type,rho,pres,ene,temp,ierr,guesseint,mu_local,
  use eos_gasradrec,    only:calc_uT_from_rhoP_gasradrec
  use eos_stamatellos,  only:getintenerg_opdep
  use eos_helmholtz,   only:eos_helmholtz_energy_from_rhoT
+ use eos_zerotemp,    only:get_zerotemp_u
  integer, intent(in)              :: eos_type
  real,    intent(in)              :: rho,pres
  real,    intent(inout)           :: ene,temp
@@ -990,7 +988,7 @@ subroutine calc_temp_and_ene(eos_type,rho,pres,ene,temp,ierr,guesseint,mu_local,
  case(24) ! Stamatellos
     temp = pres /(rho * Rg) * mu
     call getintenerg_opdep(temp, rho, ene)
- case(25) ! zero temp eos (Ali: should I add this here? not sure...)
+ case(25) ! zero temp eos 
     call get_zerotemp_u(rho,ene)
     temp = 0
  case default
@@ -1035,7 +1033,8 @@ subroutine calc_rho_from_PT(eos_type,pres,temp,rho,ierr,mu_local,X_local,Z_local
     rho = pres / (temp * Rg) * mu
  case(12) ! Ideal gas + radiation
     call get_idealplusrad_rhofrompresT(pres,temp,mu,rho)
- case(25) ! zero temperature eos (not sure if this should be here since it doesn't take in temperature)
+ case(25) ! zero temperature eos 
+    call get_zerotemp_rhofrompres(pres,rho,ierr)
  case default
     ierr = 1
  end select
@@ -1404,7 +1403,7 @@ logical function eos_is_non_ideal(ieos)
  integer, intent(in) :: ieos
 
  select case(ieos)
- case(10,12,15,20)
+ case(10,12,15,20,25)
     eos_is_non_ideal = .true.
  case default
     eos_is_non_ideal = .false.
@@ -1527,7 +1526,7 @@ logical function eos_allows_shock_and_work(ieos)
  integer, intent(in) :: ieos
 
  select case(ieos)
- case(2,5,10,12,15,16,21,22,24,25) !does eos zero temp allow for it?
+ case(2,5,10,12,15,16,21,22,24,25) 
     eos_allows_shock_and_work = .true.
  case default
     eos_allows_shock_and_work = .false.
@@ -1554,11 +1553,12 @@ end function eos_requires_polyk
 !  a non-zero pressure even if no thermal energy is set
 !+
 !-----------------------------------------------------------------------
-logical function eos_has_pressure_without_u(ieos) !! not sure if zero temp needs this ali
+logical function eos_has_pressure_without_u(ieos) 
  integer, intent(in) :: ieos
 
  eos_has_pressure_without_u = eos_requires_isothermal(ieos) .or. &
-                              ieos==9 .or. ieos==16 .or. ieos == 23
+                              ieos==9 .or. ieos==16 .or. &
+                              ieos == 23 .or. ieos == 25
 
 end function eos_has_pressure_without_u
 

--- a/src/main/eos.f90
+++ b/src/main/eos.f90
@@ -28,6 +28,7 @@ module eos
 !    20 = Ideal gas + radiation + various forms of recombination energy from HORMONE (Hirai et al., 2020)
 !    23 = Hypervelocity Impact of solids-fluids from Tillotson EOS (Tillotson 1962 - implemented by Brundage A. 2013
 !    24 = read tabulated eos (for use with icooling == 9)
+!    25 = zero temperature eos (simplified eos for white dwarfs, Helmholtz is the better choice)
 !
 ! :References:
 !    Lodato & Pringle (2007)
@@ -56,7 +57,7 @@ module eos
  use dim,           only:gr,do_radiation
  use eos_gasradrec, only:irecomb
  implicit none
- integer, parameter, public :: maxeos = 24
+ integer, parameter, public :: maxeos = 25
  real,               public :: polyk, polyk2, gamma
  real,               public :: qfacdisc = 0.75, qfacdisc2 = 0.75
  real,               public :: cs_min = 0.0
@@ -145,6 +146,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,tempi,eni,gam
  use eos_tillotson,    only:equationofstate_tillotson
  use eos_stamatellos
  use eos_HIIR,         only:get_eos_HIIR_iso,get_eos_HIIR_adiab
+ use eos_zerotemp,     only:get_zerotemp_pressure,get_zerotemp_spsoundi
  integer, intent(in)    :: eos_type
  real,    intent(in)    :: rhoi,xi,yi,zi
  real,    intent(out)   :: ponrhoi,spsoundi
@@ -527,6 +529,18 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,tempi,eni,gam
     ponrhoi = presi/rhoi
     gammai = 1.d0 + presi/(eni*rhoi)
     spsoundi = sqrt(gammai*ponrhoi)
+   case (25) ! zero temperature EOS (under construction)
+    cgsrhoi = rhoi * unit_density
+
+    call get_zerotemp_pressure(cgsrhoi,cgspresi)
+    call get_zerotemp_spsoundi(cgsrhoi,cgsspsoundi)
+
+    presi = cgspresi/unit_pressure
+    ponrhoi = presi/rhoi
+    spsoundi = cgsspsoundi / unit_velocity
+
+   !  tempi    =  0  !we don't need a temperature
+
 
  case default
     spsoundi = 0. ! avoids compiler warnings
@@ -634,6 +648,14 @@ subroutine init_eos(eos_type,ierr)
     call read_optab(eos_file,ierr_ra)
     if (ierr_ra > 0) call warning('init_eos','Failed to read EOS file')
     call init_coolra
+
+
+ case(25)
+    !
+    ! zero temperature (do we need this?)
+    !
+    write(*,*) 'Using zero temperature EoS (assuming mu_electron=2) '
+
  end select
  done_init_eos = .true.
 
@@ -968,6 +990,9 @@ subroutine calc_temp_and_ene(eos_type,rho,pres,ene,temp,ierr,guesseint,mu_local,
  case(24) ! Stamatellos
     temp = pres /(rho * Rg) * mu
     call getintenerg_opdep(temp, rho, ene)
+ case(25) ! zero temp eos (Ali: should I add this here? not sure...)
+    call get_zerotemp_u(rho,ene)
+    temp = 0
  case default
     ierr = 1
  end select
@@ -1010,6 +1035,7 @@ subroutine calc_rho_from_PT(eos_type,pres,temp,rho,ierr,mu_local,X_local,Z_local
     rho = pres / (temp * Rg) * mu
  case(12) ! Ideal gas + radiation
     call get_idealplusrad_rhofrompresT(pres,temp,mu,rho)
+ case(25) ! zero temperature eos (not sure if this should be here since it doesn't take in temperature)
  case default
     ierr = 1
  end select
@@ -1485,7 +1511,7 @@ logical function eos_requires_isothermal(ieos)
  case(1,3,6,7,8,13,14,21)
     eos_requires_isothermal = .true.
  case default
-    !case(2,5,4,10,11,12,15,16,20,22,23,24,9)
+    !case(2,5,4,10,11,12,15,16,20,22,23,24,25,9)
     eos_requires_isothermal = .false.
  end select
 
@@ -1501,7 +1527,7 @@ logical function eos_allows_shock_and_work(ieos)
  integer, intent(in) :: ieos
 
  select case(ieos)
- case(2,5,10,12,15,16,21,22,24)
+ case(2,5,10,12,15,16,21,22,24,25) !does eos zero temp allow for it?
     eos_allows_shock_and_work = .true.
  case default
     eos_allows_shock_and_work = .false.
@@ -1528,7 +1554,7 @@ end function eos_requires_polyk
 !  a non-zero pressure even if no thermal energy is set
 !+
 !-----------------------------------------------------------------------
-logical function eos_has_pressure_without_u(ieos)
+logical function eos_has_pressure_without_u(ieos) !! not sure if zero temp needs this ali
  integer, intent(in) :: ieos
 
  eos_has_pressure_without_u = eos_requires_isothermal(ieos) .or. &
@@ -1619,6 +1645,9 @@ subroutine eosinfo(eos_type,iprint)
 
  case(24)
     write(iprint,"(/,a,a)") 'Using tabulated Eos from file:', eos_file, 'and calculated gamma.'
+ case(25)
+    write(*,'(1x,a,i1,a)') 'Using zero temperature EoS, assuming mu_electron=2'
+
  end select
  write(iprint,*)
 

--- a/src/main/eos.f90
+++ b/src/main/eos.f90
@@ -937,7 +937,7 @@ end function get_u_from_rhoT
 !
 !  Note on composition:
 !  For ieos=2, 5 and 12, mu_local is an input, X & Z are not used
-!  For ieos=10, mu_local is not used
+!  For ieos=10,25 mu_local is not used
 !  For ieos=20, mu_local is not used but available as an output
 !+
 !-----------------------------------------------------------------------
@@ -1004,7 +1004,7 @@ end subroutine calc_temp_and_ene
 !
 !  Note on composition:
 !  For ieos=2, 5 and 12, mu_local is an input, X & Z are not used
-!  For ieos=10, mu_local is not used
+!  For ieos=10,25 mu_local is not used
 !  For ieos=20, mu_local is not used but available as an output
 !+
 !-----------------------------------------------------------------------
@@ -1013,6 +1013,7 @@ subroutine calc_rho_from_PT(eos_type,pres,temp,rho,ierr,mu_local,X_local,Z_local
  use eos_idealplusrad, only:get_idealplusrad_rhofrompresT
  use eos_mesa,         only:get_eos_eT_from_rhop_mesa
  use eos_gasradrec,    only:calc_uT_from_rhoP_gasradrec
+ use eos_zerotemp,     only:get_zerotemp_rhofrompres
  integer, intent(in)    :: eos_type
  real,    intent(in)    :: pres,temp
  real,    intent(inout) :: rho

--- a/src/main/eos_zerotemp.f90
+++ b/src/main/eos_zerotemp.f90
@@ -10,7 +10,7 @@ module eos_zerotemp
 !
 ! :References: Kippenhahn & Weigert, Stellar Structure and Evolution, section 15.2
 !
-! :Dependencies: infile_utils, io, units, physcon
+! :Dependencies: physcon
 !
  use units, only:unit_density,unit_velocity
  use physcon,  only:pi,atomic_mass_unit, mass_electron_cgs, planckh, c
@@ -18,18 +18,33 @@ module eos_zerotemp
  real, parameter :: mu_e = 2 ! mean molecular weight per free electron
 
 
- public :: f_chandra
+ public :: f_chandra, get_zerotemp_Pressure,get_zerotemp_u, get_zerotemp_spsoundi,&
+           get_zerotemp_rhofrompres
 
  private
 
 contains
+
+!----------------------------------------------------------------
+!+
+!  Chandrasekhar's EOS function
+!+
+!----------------------------------------------------------------
+
+real function f_chandra(x) result(fx)
+ real, intent(in) :: x
+
+ fx = x*(2*x**2 - 3)*sqrt(1+x**2) + 3*log(x + sqrt(1+x**2))
+end function f_chandra
+
+
 
 ! ----------------------------------------------------------------
 !+
 !  Calculates the zero temperature pressure for a fully degenerate electron gas, i.e. a
 !  white dwarf. See Kippenhahn & Weigert, Stellar Structure and Evolution, section 15.2
 !  Note that this is only the electron degeneracy pressure, so does not include the ion
-!+
+!+ input/output is cgs
 ! ----------------------------------------------------------------
 
 subroutine get_zerotemp_Pressure(rhoi,presi)
@@ -57,7 +72,7 @@ end subroutine get_zerotemp_Pressure
 !+!  Inputs and outputs in cgs units
 !+!  get internal energy from density for zero temperature EOS
 !-----------------------------------------------------------------------
-subroutine get_zerotemp_u_from_rho(rhoi,u)
+subroutine get_zerotemp_u(rhoi,u)
  real,    intent(in)    :: rhoi
  real,    intent(out)   :: u
  real :: ne, x, gx
@@ -70,25 +85,12 @@ subroutine get_zerotemp_u_from_rho(rhoi,u)
     gx = (8*x**3)*(sqrt(x**2 + 1)-1)-f_chandra(x)
     u = (pi * mass_electron_cgs**4 * c**5 / (3.0 * planckh**3)) * f_chandra(x)
 
-end subroutine calc_uT_from_rhoP_gasradrec
-
-!----------------------------------------------------------------
-!+
-!  Chandrasekhar's EOS function
-!+
-!----------------------------------------------------------------
-
-real function f_chandra(x) result(fx)
- real, intent(in) :: x
-
- fx = x*(2*x**2 - 3)*sqrt(1+x**2) + 3*log(x + sqrt(1+x**2))
-end function f_chandra
-
+end subroutine get_zerotemp_u
 
 
 !----------------------------------------------------------------
 !+
-!  Calculates sound speed from density (derivative of f(x), analytically found)
+!  Calculates sound speed from density (derivative of f(x), analytically found), input output in cgs
 !+
 !----------------------------------------------------------------
 
@@ -108,47 +110,57 @@ end subroutine get_zerotemp_spsoundi
 
 !----------------------------------------------------------------
 !+
-!  Calculates density from pressure (involves the bisection method)
+!  Calculates density from pressure (involves the bisection method), input output in cgs
 !+
 !----------------------------------------------------------------
 subroutine get_zerotemp_rhofrompres(presi,densi,ierr)
- real, intent(in)  :: presi
- real, intent(out) :: densi
- integer, intent(out)   :: ierr
 
- real :: ne, x, fx
- integer, parameter  :: iter_max = 1000 ! it shouldn't need more than 100
- real, parameter :: tolerance = 1.e-12
+   real, intent(in)  :: presi
+   real, intent(out) :: densi
+   integer, intent(out) :: ierr
 
- fx = P * (3.0*planckh**3)/(pi * mass_electron_cgs**4 * c**5)
-         ! bracket
- xlo = 0.0
- xhi = 1.0
+   real :: ne, x, fx
+   real :: xlo, xhi, xmid
+   integer :: iter
 
- ierr = 0
- iter = 0
+   integer, parameter :: iter_max = 1000
+   real,    parameter :: tolerance = 1.e-12
 
- while f_chandra(xhi) < fx:
-     xhi = 2.0*xhi
+   fx = presi * (3.0*planckh**3) / &
+        (pi*mass_electron_cgs**4*c**5)
 
-    ! bisection
-    do while (iter<iter_max)
-        xmid = 0.5*(xlo + xhi)
+   ! Initial bracket
+   xlo = 0.0
+   xhi = 1.0
 
-        if f_x(xmid) > fx:
-            xhi = xmid
-        else:
-            xlo = xmid
+   do while (f_chandra(xhi) < fx)
+      xhi = 2.0*xhi
+   end do
 
-        if abs(xhi - xlo)/(xmid + 1.0e-300) < tol(1.e-12):
-            break
-        iter
-    x = 0.5*(xlo + xhi)
-    ! print("fx tolerance=",(f_x(x)-fx)/fx)
-    ne = (8*np.pi*m_e**3*c**3/(3*h**3)) * x**3
-    rho_out[j] = ne*(mu_e * m_u)
+   ierr = 0
 
-    if (iter >= iter_max) ierr = 1
+   do iter = 1, iter_max
+
+      xmid = 0.5*(xlo + xhi)
+
+      if (f_chandra(xmid) > fx) then
+         xhi = xmid
+      else
+         xlo = xmid
+      end if
+
+      if (abs(xhi-xlo)/(xmid+1.e-300) < tolerance) exit
+
+   end do
+
+   if (iter == iter_max) ierr = 1
+
+   x = 0.5*(xlo + xhi)
+
+   ne = (8.0*pi*mass_electron_cgs**3*c**3 / &
+        (3.0*planckh**3)) * x**3
+
+   densi = ne * mu_e * atomic_mass_unit
 
 end subroutine get_zerotemp_rhofrompres
 

--- a/src/main/eos_zerotemp.f90
+++ b/src/main/eos_zerotemp.f90
@@ -13,17 +13,153 @@ module eos_zerotemp
 ! :Dependencies: physcon
 !
  use units, only:unit_density,unit_velocity
- use physcon,  only:pi,atomic_mass_unit, mass_electron_cgs, planckh, c
+ use physcon,  only:pi,atomic_mass_unit,mass_electron_cgs,planckh,c
  implicit none
- real, parameter :: mu_e = 2 ! mean molecular weight per free electron
+ real :: mu_e ! mean molecular weight per free electron
 
 
- public :: f_chandra, get_zerotemp_pressure,get_zerotemp_u, get_zerotemp_spsoundi,&
-           get_zerotemp_rhofrompres
+ public :: eos_zerotemp_init,eos_zerotemp_read_options,write_eos_zerotemp_options,&
+           f_chandra,get_zerotemp_pressure,get_zerotemp_u,get_zerotemp_spsoundi,&
+           get_zerotemp_rhofrompres,eos_zerotemp_calc_mu_e,eos_zerotemp_eosinfo
 
  private
 
+  ! these set the mixture of species
+ ! following elements can be set by user at runtime
+ real :: xh  = 0.0
+ real :: xhe = 0.0
+ real :: xc  = 0.5
+ real :: xo  = 0.5
+ real :: xne = 0.0
+ real :: xmg = 0.0 
+ 
+ integer, parameter :: speciesmax = 6
+ character(len=10) :: speciesname(speciesmax)
+ real :: xmass(speciesmax) ! mass fraction of species
+ real :: Aion(speciesmax)  ! number of nucleons
+ real :: Zion(speciesmax)  ! number of protons
+ real :: abar, zbar
 contains
+
+
+!----------------------------------------------------------------
+!+
+!  initialise zero-temperature EOS composition
+!+
+!----------------------------------------------------------------
+subroutine eos_zerotemp_init(ierr)
+
+ use io, only: warning, fatal
+ integer, intent(out) :: ierr
+ integer :: i
+
+ ierr = 0
+
+ !----------------------------
+ ! species definitions
+ !----------------------------
+ speciesname(1) = "hydrogen"
+ speciesname(2) = "helium"
+ speciesname(3) = "carbon"
+ speciesname(4) = "oxygen"
+ speciesname(5) = "neon"
+ speciesname(6) = "magnesium"
+
+ Aion(1) = 1.0   ; Zion(1) = 1.0
+ Aion(2) = 4.0   ; Zion(2) = 2.0
+ Aion(3) = 12.0  ; Zion(3) = 6.0
+ Aion(4) = 16.0  ; Zion(4) = 8.0
+ Aion(5) = 20.0  ; Zion(5) = 10.0
+ Aion(6) = 24.0  ; Zion(6) = 12.0
+
+ !----------------------------
+ ! pack mass fractions
+ !----------------------------
+ xmass(:) = 0.0
+ xmass(1) = xh
+ xmass(2) = xhe
+ xmass(3) = xc
+ xmass(4) = xo
+ xmass(5) = xne
+ xmass(6) = xmg
+
+ if (abs(sum(xmass(:)) - 1.0) > 1e-6) then
+    call warning('eos_zerotemp_init','mass fractions do not sum to 1')
+    ierr = 1
+    return
+ endif
+
+ call eos_zerotemp_calc_mu_e()
+ write(*,'(a,f10.7)') 'mean mu_e = ', mu_e
+end subroutine eos_zerotemp_init
+
+!----------------------------------------------------------------
+!+
+!  read options from input file
+!+
+!----------------------------------------------------------------
+subroutine eos_zerotemp_read_options(db,nerr)
+
+ use infile_utils, only: inopts, read_inopt
+ type(inopts), intent(inout) :: db(:)
+ integer, intent(inout) :: nerr
+
+ call read_inopt(xh ,'xh' ,'Hydrogen mass fraction',db,errcount=nerr,min=0.,max=1.,default=xh)
+ call read_inopt(xhe,'xhe','Helium mass fraction',db,errcount=nerr,min=0.,max=1.,default=xhe)
+ call read_inopt(xc ,'xc' ,'Carbon mass fraction',db,errcount=nerr,min=0.,max=1.,default=xc)
+ call read_inopt(xo ,'xo' ,'Oxygen mass fraction',db,errcount=nerr,min=0.,max=1.,default=xo)
+ call read_inopt(xne,'xne','Neon mass fraction',db,errcount=nerr,min=0.,max=1.,default=xne)
+ call read_inopt(xmg,'xmg','Magnesium mass fraction',db,errcount=nerr,min=0.,max=1.,default=xmg)
+
+end subroutine eos_zerotemp_read_options
+
+!----------------------------------------------------------------
+!+
+!  write options to input file
+!+
+!----------------------------------------------------------------
+subroutine write_eos_zerotemp_options(iunit)
+
+ use infile_utils, only: write_inopt
+ integer, intent(in) :: iunit
+
+ call write_inopt(xh ,'xh' ,'Hydrogen mass fraction',iunit)
+ call write_inopt(xhe,'xhe','Helium mass fraction',iunit)
+ call write_inopt(xc ,'xc' ,'Carbon mass fraction',iunit)
+ call write_inopt(xo ,'xo' ,'Oxygen mass fraction',iunit)
+ call write_inopt(xne,'xne','Neon mass fraction',iunit)
+ call write_inopt(xmg,'xmg','Magnesium mass fraction',iunit)
+
+end subroutine write_eos_zerotemp_options
+!----------------------------------------------------------------
+!+
+!  print eos information
+!+
+!----------------------------------------------------------------
+subroutine eos_zerotemp_eosinfo(iprint)
+ integer, intent(in) :: iprint
+ integer :: i
+
+ write(iprint,"(/,a)") ' Zero temperature equation of state'
+ write(iprint,"(a)") '   mass fractions of each species:'
+ do i=1,speciesmax
+    if (xmass(i) > 0.0) then
+       write(iprint,"(a,a,a,f5.3)") '     ', speciesname(i), ': ', xmass(i)
+    endif
+ enddo
+ write(iprint,'(a,f10.7)') '   mu_e = ', mu_e
+end subroutine eos_zerotemp_eosinfo
+
+!----------------------------------------------------------------
+!+
+!  compute mean molecular weight per electron
+!+
+!----------------------------------------------------------------
+subroutine eos_zerotemp_calc_mu_e()
+
+ mu_e = 1.0 / sum(xmass(:) * Zion(:) / Aion(:))
+
+end subroutine eos_zerotemp_calc_mu_e
 
 !----------------------------------------------------------------
 !+

--- a/src/main/eos_zerotemp.f90
+++ b/src/main/eos_zerotemp.f90
@@ -38,7 +38,6 @@ module eos_zerotemp
  real :: xmass(speciesmax) ! mass fraction of species
  real :: Aion(speciesmax)  ! number of nucleons
  real :: Zion(speciesmax)  ! number of protons
- real :: abar, zbar
 contains
 
 
@@ -51,7 +50,6 @@ subroutine eos_zerotemp_init(ierr)
 
  use io, only: warning, fatal
  integer, intent(out) :: ierr
- integer :: i
 
  ierr = 0
 
@@ -233,15 +231,19 @@ end subroutine get_zerotemp_u
 subroutine get_zerotemp_spsoundi(rhoi,spsoundi)
  real, intent(in)  :: rhoi
  real, intent(out) :: spsoundi
- real :: ne, x, constants_cs
+ real :: ne, x
+
+ if (rhoi <= 0.0) then
+    spsoundi = 0.0
+    return
+ endif
 
  ne = rhoi / (mu_e * atomic_mass_unit)
 
  x = ( (3.0 * ne * planckh**3) / &
         (8.0 * pi * mass_electron_cgs**3 * c**3) )**(1.0/3.0)
 
- constants_cs = (mass_electron_cgs * c**2 / (24.0* atomic_mass_unit*mu_e))
- spsoundi = sqrt(constants_cs * ((6.0 * x**2 - 3.0)*sqrt(1.0 + x**2) + (2.0 * x**4 - 3.0*x**2 +3.0)/sqrt(1.0+x**2))/x**2)
+ spsoundi = sqrt((mass_electron_cgs * c**2 * x**2) / (3.0 * atomic_mass_unit * mu_e * sqrt(1.0 + x**2)))
 end subroutine get_zerotemp_spsoundi
 
 !----------------------------------------------------------------

--- a/src/main/eos_zerotemp.f90
+++ b/src/main/eos_zerotemp.f90
@@ -13,13 +13,12 @@ module eos_zerotemp
 ! :Dependencies: infile_utils, io, units, physcon
 !
  use units, only:unit_density,unit_velocity
- use physcon,  only:pi,atomic_mass_unit, mass_electron_cgs, planckh, c, 
+ use physcon,  only:pi,atomic_mass_unit, mass_electron_cgs, planckh, c
  implicit none
- real, parameter :: tolerance = 1.e-15
+ real, parameter :: mu_e = 2 ! mean molecular weight per free electron
 
- public :: get_idealplusrad_temp,get_idealplusrad_pres,get_idealplusrad_spsoundi,&
-           get_idealgasplusrad_tempfrompres,get_idealplusrad_enfromtemp,&
-           get_idealplusrad_rhofrompresT,egas_from_rhoT,erad_from_rhoT
+
+ public :: f_chandra
 
  private
 
@@ -33,53 +32,125 @@ contains
 !+
 ! ----------------------------------------------------------------
 
-subroutine get_zerotemp_Pressure(rhoi,mu,presi)
- real, intent(in)  :: rhoi,mu
+subroutine get_zerotemp_Pressure(rhoi,presi)
+ real, intent(in)  :: rhoi
  real, intent(out) :: presi
+ real :: ne, x
 
  ! This is the zero temperature pressure for a fully degenerate electron gas, i.e. a white dwarf. See Kippenhahn & Weigert, Stellar Structure and Evolution, section 15.2
- ! Note that this is only the electron degeneracy pressure, so does not include the ion contribution to the pressure. This is a good approximation for white dwarfs where the electrons are highly degenerate but the ions are not.
- ! Note also that this assumes a fully ionised gas, so mu is the mean molecular weight per free electron (e.g. mu=2 for a pure helium gas)
+ ! Note that this is only the electron degeneracy pressure, so does not include the ion contribution to the pressure.
+ ! This is a good approximation for white dwarfs where the electrons are highly degenerate but the ions are not.
+ ! Note also that this assumes a fully ionised gas, so mu is the mean molecular weight per free electron
 
- real :: x
 
-    ! Convert rho to number density of electrons
-    n_e = rhoi / (mu_e * atomic_mass_unit)
+    ne = rhoi / (mu_e * atomic_mass_unit)
 
-    x = cbrt(3*n_e * planckh**3 / (8 * pi * mass_electron_cgs**3 * c**3))
-    fx= x*(2*x**2 - 3)*np.sqrt(x**2 + 1) + 3*np.log(x + np.sqrt(x**2 + 1))
-    presi = (pi*(mass_electron_cgs)**4)*(c**5) * fx/ (3 * planckh**3) 
+    x = ( (3.0 * ne * planckh**3) / &
+        (8.0 * pi * mass_electron_cgs**3 * c**3) )**(1.0/3.0)
+
+    presi = (pi * mass_electron_cgs**4 * c**5 / (3.0 * planckh**3)) * f_chandra(x)
 
 end subroutine get_zerotemp_Pressure
 
 
+!-----------------------------------------------------------------------
+!+!  Inputs and outputs in cgs units
+!+!  get internal energy from density for zero temperature EOS
+!-----------------------------------------------------------------------
+subroutine get_zerotemp_u_from_rho(rhoi,u)
+ real,    intent(in)    :: rhoi
+ real,    intent(out)   :: u
+ real :: ne, x, gx
+
+    ne = rhoi / (mu_e * atomic_mass_unit)
+
+    x = ( (3.0 * ne * planckh**3) / &
+        (8.0 * pi * mass_electron_cgs**3 * c**3) )**(1.0/3.0)
+
+    gx = (8*x**3)*(sqrt(x**2 + 1)-1)-f_chandra(x)
+    u = (pi * mass_electron_cgs**4 * c**5 / (3.0 * planckh**3)) * f_chandra(x)
+
+end subroutine calc_uT_from_rhoP_gasradrec
+
 !----------------------------------------------------------------
 !+
-!  Calculates sound speed from density (do we need gamma?)
+!  Chandrasekhar's EOS function
 !+
 !----------------------------------------------------------------
 
+real function f_chandra(x) result(fx)
+ real, intent(in) :: x
 
-subroutine get_zerotemp_spsoundi(rhoi,presi,spsoundi,gammai)
- real, intent(in)  :: rhoi,presi
- real, intent(out) :: spsoundi,gammai
+ fx = x*(2*x**2 - 3)*sqrt(1+x**2) + 3*log(x + sqrt(1+x**2))
+end function f_chandra
 
- gammai = 1. + presi/(eni*rhoi) ! what should I put this?
- spsoundi = sqrt(gammai*presi/rhoi)
 
+
+!----------------------------------------------------------------
+!+
+!  Calculates sound speed from density (derivative of f(x), analytically found)
+!+
+!----------------------------------------------------------------
+
+subroutine get_zerotemp_spsoundi(rhoi,spsoundi)
+ real, intent(in)  :: rhoi
+ real, intent(out) :: spsoundi
+ real :: ne, x
+
+ ne = rhoi / (mu_e * atomic_mass_unit)
+
+ x = ( (3.0 * ne * planckh**3) / &
+        (8.0 * pi * mass_electron_cgs**3 * c**3) )**(1.0/3.0)
+
+ constants_cs = (mass_electron_cgs * c**2 / (24.0* atomic_mass_unit*mu_e))
+ spsoundi = sqrt(constants_cs * ((6.0 * x**2 - 3.0)*sqrt(1.0 + x**2) + (2.0 * x**4 - 3.0*x**2 +3.0)/sqrt(1.0+x**2))/x**2)
 end subroutine get_zerotemp_spsoundi
 
 !----------------------------------------------------------------
 !+
-!  Calculates density from pressure (under construction)
+!  Calculates density from pressure (involves the bisection method)
 !+
 !----------------------------------------------------------------
-subroutine get_zerotemp_rhofrompres(presi,tempi,mu,densi)
- real, intent(in)  :: presi,tempi,mu
+subroutine get_zerotemp_rhofrompres(presi,densi,ierr)
+ real, intent(in)  :: presi
  real, intent(out) :: densi
+ integer, intent(out)   :: ierr
 
- densi = (presi - radconst*tempi**4 /3.) * mu / (Rg*tempi)
+ real :: ne, x, fx
+ integer, parameter  :: iter_max = 1000 ! it shouldn't need more than 100
+ real, parameter :: tolerance = 1.e-12
+
+ fx = P * (3.0*planckh**3)/(pi * mass_electron_cgs**4 * c**5)
+         ! bracket
+ xlo = 0.0
+ xhi = 1.0
+
+ ierr = 0
+ iter = 0
+
+ while f_chandra(xhi) < fx:
+     xhi = 2.0*xhi
+
+    ! bisection
+    do while (iter<iter_max)
+        xmid = 0.5*(xlo + xhi)
+
+        if f_x(xmid) > fx:
+            xhi = xmid
+        else:
+            xlo = xmid
+
+        if abs(xhi - xlo)/(xmid + 1.0e-300) < tol(1.e-12):
+            break
+        iter
+    x = 0.5*(xlo + xhi)
+    ! print("fx tolerance=",(f_x(x)-fx)/fx)
+    ne = (8*np.pi*m_e**3*c**3/(3*h**3)) * x**3
+    rho_out[j] = ne*(mu_e * m_u)
+
+    if (iter >= iter_max) ierr = 1
 
 end subroutine get_zerotemp_rhofrompres
+
 
 end module eos_zerotemp

--- a/src/main/eos_zerotemp.f90
+++ b/src/main/eos_zerotemp.f90
@@ -83,8 +83,8 @@ subroutine get_zerotemp_u(rhoi,u)
         (8.0 * pi * mass_electron_cgs**3 * c**3) )**(1.0/3.0)
 
     gx = (8*x**3)*(sqrt(x**2 + 1)-1)-f_chandra(x)
-    u = (pi * mass_electron_cgs**4 * c**5 / (3.0 * planckh**3)) * f_chandra(x)
-
+    u = (pi * mass_electron_cgs**4 * c**5 / (3.0 * planckh**3)) * gx
+    u = u/rhoi !previous equation is erg/cm^3 so here I convert it
 end subroutine get_zerotemp_u
 
 
@@ -97,7 +97,7 @@ end subroutine get_zerotemp_u
 subroutine get_zerotemp_spsoundi(rhoi,spsoundi)
  real, intent(in)  :: rhoi
  real, intent(out) :: spsoundi
- real :: ne, x
+ real :: ne, x, constants_cs
 
  ne = rhoi / (mu_e * atomic_mass_unit)
 

--- a/src/main/eos_zerotemp.f90
+++ b/src/main/eos_zerotemp.f90
@@ -1,0 +1,85 @@
+!--------------------------------------------------------------------------!
+! The Phantom Smoothed Particle Hydrodynamics code, by Daniel Price et al. !
+! Copyright (c) 2007-2026 The Authors (see AUTHORS)                        !
+! See LICENCE file for usage and distribution conditions                   !
+! http://phantomsph.github.io/                                             !
+!--------------------------------------------------------------------------!
+module eos_zerotemp
+!
+! Implements zero temperature equation of state, e.g. for white dwarfs. Meant to 
+!
+! :References: Kippenhahn & Weigert, Stellar Structure and Evolution, section 15.2
+!
+! :Dependencies: infile_utils, io, units, physcon
+!
+ use units, only:unit_density,unit_velocity
+ use physcon,  only:pi,atomic_mass_unit, mass_electron_cgs, planckh, c, 
+ implicit none
+ real, parameter :: tolerance = 1.e-15
+
+ public :: get_idealplusrad_temp,get_idealplusrad_pres,get_idealplusrad_spsoundi,&
+           get_idealgasplusrad_tempfrompres,get_idealplusrad_enfromtemp,&
+           get_idealplusrad_rhofrompresT,egas_from_rhoT,erad_from_rhoT
+
+ private
+
+contains
+
+! ----------------------------------------------------------------
+!+
+!  Calculates the zero temperature pressure for a fully degenerate electron gas, i.e. a
+!  white dwarf. See Kippenhahn & Weigert, Stellar Structure and Evolution, section 15.2
+!  Note that this is only the electron degeneracy pressure, so does not include the ion
+!+
+! ----------------------------------------------------------------
+
+subroutine get_zerotemp_Pressure(rhoi,mu,presi)
+ real, intent(in)  :: rhoi,mu
+ real, intent(out) :: presi
+
+ ! This is the zero temperature pressure for a fully degenerate electron gas, i.e. a white dwarf. See Kippenhahn & Weigert, Stellar Structure and Evolution, section 15.2
+ ! Note that this is only the electron degeneracy pressure, so does not include the ion contribution to the pressure. This is a good approximation for white dwarfs where the electrons are highly degenerate but the ions are not.
+ ! Note also that this assumes a fully ionised gas, so mu is the mean molecular weight per free electron (e.g. mu=2 for a pure helium gas)
+
+ real :: x
+
+    ! Convert rho to number density of electrons
+    n_e = rhoi / (mu_e * atomic_mass_unit)
+
+    x = cbrt(3*n_e * planckh**3 / (8 * pi * mass_electron_cgs**3 * c**3))
+    fx= x*(2*x**2 - 3)*np.sqrt(x**2 + 1) + 3*np.log(x + np.sqrt(x**2 + 1))
+    presi = (pi*(mass_electron_cgs)**4)*(c**5) * fx/ (3 * planckh**3) 
+
+end subroutine get_zerotemp_Pressure
+
+
+!----------------------------------------------------------------
+!+
+!  Calculates sound speed from density (do we need gamma?)
+!+
+!----------------------------------------------------------------
+
+
+subroutine get_zerotemp_spsoundi(rhoi,presi,spsoundi,gammai)
+ real, intent(in)  :: rhoi,presi
+ real, intent(out) :: spsoundi,gammai
+
+ gammai = 1. + presi/(eni*rhoi) ! what should I put this?
+ spsoundi = sqrt(gammai*presi/rhoi)
+
+end subroutine get_zerotemp_spsoundi
+
+!----------------------------------------------------------------
+!+
+!  Calculates density from pressure (under construction)
+!+
+!----------------------------------------------------------------
+subroutine get_zerotemp_rhofrompres(presi,tempi,mu,densi)
+ real, intent(in)  :: presi,tempi,mu
+ real, intent(out) :: densi
+
+ densi = (presi - radconst*tempi**4 /3.) * mu / (Rg*tempi)
+
+end subroutine get_zerotemp_rhofrompres
+
+end module eos_zerotemp

--- a/src/main/eos_zerotemp.f90
+++ b/src/main/eos_zerotemp.f90
@@ -18,7 +18,7 @@ module eos_zerotemp
  real, parameter :: mu_e = 2 ! mean molecular weight per free electron
 
 
- public :: f_chandra, get_zerotemp_Pressure,get_zerotemp_u, get_zerotemp_spsoundi,&
+ public :: f_chandra, get_zerotemp_pressure,get_zerotemp_u, get_zerotemp_spsoundi,&
            get_zerotemp_rhofrompres
 
  private
@@ -47,7 +47,7 @@ end function f_chandra
 !+ input/output is cgs
 ! ----------------------------------------------------------------
 
-subroutine get_zerotemp_Pressure(rhoi,presi)
+subroutine get_zerotemp_pressure(rhoi,presi)
  real, intent(in)  :: rhoi
  real, intent(out) :: presi
  real :: ne, x
@@ -65,7 +65,7 @@ subroutine get_zerotemp_Pressure(rhoi,presi)
 
     presi = (pi * mass_electron_cgs**4 * c**5 / (3.0 * planckh**3)) * f_chandra(x)
 
-end subroutine get_zerotemp_Pressure
+end subroutine get_zerotemp_pressure
 
 
 !-----------------------------------------------------------------------

--- a/src/main/eos_zerotemp.f90
+++ b/src/main/eos_zerotemp.f90
@@ -18,7 +18,7 @@ module eos_zerotemp
  real :: mu_e ! mean molecular weight per free electron
 
 
- public :: eos_zerotemp_init,eos_zerotemp_read_options,write_eos_zerotemp_options,&
+ public :: eos_zerotemp_init,read_options_eos_zerotemp,write_options_eos_zerotemp,&
            f_chandra,get_zerotemp_pressure,get_zerotemp_u,get_zerotemp_spsoundi,&
            get_zerotemp_rhofrompres,eos_zerotemp_calc_mu_e,eos_zerotemp_eosinfo
 
@@ -98,27 +98,27 @@ end subroutine eos_zerotemp_init
 !  read options from input file
 !+
 !----------------------------------------------------------------
-subroutine eos_zerotemp_read_options(db,nerr)
+subroutine read_options_eos_zerotemp(db,nerr)
 
  use infile_utils, only: inopts, read_inopt
  type(inopts), intent(inout) :: db(:)
  integer, intent(inout) :: nerr
 
- call read_inopt(xh ,'xh' ,'Hydrogen mass fraction',db,errcount=nerr,min=0.,max=1.,default=xh)
- call read_inopt(xhe,'xhe','Helium mass fraction',db,errcount=nerr,min=0.,max=1.,default=xhe)
- call read_inopt(xc ,'xc' ,'Carbon mass fraction',db,errcount=nerr,min=0.,max=1.,default=xc)
- call read_inopt(xo ,'xo' ,'Oxygen mass fraction',db,errcount=nerr,min=0.,max=1.,default=xo)
- call read_inopt(xne,'xne','Neon mass fraction',db,errcount=nerr,min=0.,max=1.,default=xne)
- call read_inopt(xmg,'xmg','Magnesium mass fraction',db,errcount=nerr,min=0.,max=1.,default=xmg)
+ call read_inopt(xh ,'xh',db,nerr)
+ call read_inopt(xhe,'xhe',db,nerr)
+ call read_inopt(xc ,'xc',db,nerr)
+ call read_inopt(xo ,'xo',db,nerr)
+ call read_inopt(xne,'xne',db,nerr)
+ call read_inopt(xmg,'xmg',db,nerr)
 
-end subroutine eos_zerotemp_read_options
+end subroutine read_options_eos_zerotemp
 
 !----------------------------------------------------------------
 !+
 !  write options to input file
 !+
 !----------------------------------------------------------------
-subroutine write_eos_zerotemp_options(iunit)
+subroutine write_options_eos_zerotemp(iunit)
 
  use infile_utils, only: write_inopt
  integer, intent(in) :: iunit
@@ -130,7 +130,7 @@ subroutine write_eos_zerotemp_options(iunit)
  call write_inopt(xne,'xne','Neon mass fraction',iunit)
  call write_inopt(xmg,'xmg','Magnesium mass fraction',iunit)
 
-end subroutine write_eos_zerotemp_options
+end subroutine write_options_eos_zerotemp
 !----------------------------------------------------------------
 !+
 !  print eos information

--- a/src/tests/test_setstar.f90
+++ b/src/tests/test_setstar.f90
@@ -378,8 +378,8 @@ subroutine test_whitedwarf(ntests,npass)
  use dim,       only:do_radiation
  use datafiles, only:find_phantom_datafile
  use part,      only:init_part,npart,npartoftype,xyzh,vxyzu,eos_vars,rad,massoftype,hfact,&
-                     xyzmh_ptmass,vxyz_ptmass,nptmass,rhoh,igas,igasP,imu,iX,iZ,iradxi,&
-                     eos_vars,itemp
+                     xyzmh_ptmass,vxyz_ptmass,nptmass,rhoh,igas,&
+                     eos_vars
  use mpidomain, only:i_belong
  use options,   only:ieos
  use physcon,   only:solarr,solarm

--- a/src/tests/test_setstar.f90
+++ b/src/tests/test_setstar.f90
@@ -361,4 +361,120 @@ subroutine test_redsupergiant(ntests,npass)
 
 end subroutine test_redsupergiant
 
+
+
+!-----------------------------------------------------------------------
+!+
+!   test that we can successfully relax a white dwarf with the 
+!   zero temperature EoS and Helmholtz eos(Ali Pourmand, similar to test_redsupergiant)
+!+
+!-----------------------------------------------------------------------
+subroutine test_whitedwarf(ntests,npass)
+ use io,        only:id,master,iverbose,warning
+ use dim,       only:do_radiation
+ use datafiles, only:find_phantom_datafile
+ use part,      only:init_part,npart,npartoftype,xyzh,vxyzu,eos_vars,rad,massoftype,hfact,&
+                     xyzmh_ptmass,vxyz_ptmass,nptmass,rhoh,igas,igasP,imu,iX,iZ,iradxi,&
+                     eos_vars,itemp
+ use mpidomain, only:i_belong
+ use options,   only:ieos
+ use physcon,   only:solarr,solarm
+ use eos,       only:init_eos,gamma,gmw,X_in,Z_in,irecomb,eos_works_with_radiation
+ use setstar,   only:star_t,set_star,set_defaults_star,imesa,ierr_radiation_conflict
+ use units,     only:set_units
+ use relaxstar, only:maxits
+ use checksetup,  only:check_setup
+ use testutils,   only:checkvalbuf,checkvalbuf_end
+ use table_utils, only:yinterp
+ use readwrite_mesa,  only:read_mesa
+ integer, intent(inout) :: ntests,npass
+ type(star_t) :: star
+ character(len=500) :: filepath
+ real :: rhozero,rmserr,rmserr_mu,rmserr_X,rmserr_Z,ekin,x0(3),errmax(2)
+ real :: Mstar,tolprof,tolcomposition,rhoj,rhoj_mesa,rj,Tgas,Trad
+ integer(kind=8) :: ntot
+ integer :: ierr,nfail(2),ncheck(2),i,j,nerror,nwarn,iunit,expected_error
+ logical :: relax_star,var_comp
+ real, allocatable :: r(:),den(:),pres(:),temp(:),en(:),mtab(:),Xfrac(:),Yfrac(:),Zfrac(:),mu(:)
+
+ filepath = find_phantom_datafile('pourmandwd.data','star_data_files')
+ open(newunit=iunit,file=filepath,status="old",iostat=ierr)
+ if (ierr /= 0) then
+    call warning('test_setstar','pourmandwd.data not found, skipping white dwarf test')
+    return
+ else
+    close(unit=iunit)
+ endif
+
+ iverbose = 0
+ call set_units(dist=solarr,mass=solarm,G=1.d0)
+ relax_star = .true.
+ maxits = 2000
+ var_comp = .false.
+ call set_defaults_star(star)
+ star%np             = 10000
+ star%input_profile  = trim(filepath)
+ star%iprofile = imesa
+ x0 = 0.
+
+ nfail = 0; ncheck = 0; errmax = 0.
+ tolprof = 0.08
+ tolcomposition = 0.08
+
+ call read_mesa(filepath,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mstar,ierr)
+ Zfrac = 1.-Xfrac-Yfrac
+
+ do i=1,4
+    call init_part()
+    if (i==1) then  ! EOS Helmholtz
+       ieos = 15
+    elseif (i==2) then  ! zero Temperature EOS
+       ieos = 25
+    endif
+
+    if (id==master) write(*,"(/,a,i2/)") '--> Testing ieos = ',ieos
+    call init_eos(ieos,ierr)
+
+    rmserr = 0.
+    call set_star(id,master,star,xyzh,vxyzu,eos_vars,rad,&
+               npart,npartoftype,massoftype,hfact,&
+               xyzmh_ptmass,vxyz_ptmass,nptmass,ieos,gamma,X_in,Z_in,&
+               relax=relax_star,use_var_comp=var_comp,write_rho_to_file=.false.,&
+               rhozero=rhozero,npart_total=ntot,mask=i_belong,ierr=ierr,&
+               write_files=.false.,density_error=rmserr,energy_error=ekin)
+
+  
+    call checkval(ierr,expected_error,0,nfail(1),'set_star runs with expected ierr')
+    call update_test_scores(ntests,nfail,npass)
+
+    call check_setup(nerror,nwarn,restart=.false.)
+    call checkval(nerror+nwarn,0,0,nfail(1),'no errors or warnings')
+    call update_test_scores(ntests,nfail,npass)
+   
+    call checkval(rmserr,0.0,0.04,nfail(1),'error in density profile')
+    call update_test_scores(ntests,nfail,npass)
+
+    call checkval(ekin,0.,5e-6,nfail(1),'ekin/epot < 1.e-7')
+    call update_test_scores(ntests,nfail,npass)
+
+    rmserr = 0.
+    do j=1,npart
+       rj = sqrt(dot_product(xyzh(1:3,j),xyzh(1:3,j)))
+       rhoj = rhoh(xyzh(4,j),massoftype(igas))
+       rhoj_mesa = yinterp(den,r,rj)
+       rmserr = rmserr + (1-rhoj/rhoj_mesa)**2
+
+    enddo
+    rmserr = sqrt(rmserr/npart)  ! root mean square relative error
+    call checkval(rmserr,0.,tolprof,nfail(1),'density matches MESA profile')
+    call update_test_scores(ntests,nfail,npass)
+
+    call update_test_scores(ntests,nfail,npass)
+
+ enddo
+
+end subroutine test_whitedwarf
+
+
+
 end module testsetstar

--- a/src/tests/test_setstar.f90
+++ b/src/tests/test_setstar.f90
@@ -394,7 +394,7 @@ subroutine test_whitedwarf(ntests,npass)
  integer, intent(inout) :: ntests,npass
  type(star_t) :: star
  character(len=500) :: filepath
- real :: rhozero,rmserr,rmserr_mu,ekin,x0(3),errmax(2)
+ real :: rhozero,rmserr,ekin,x0(3),errmax(2)
  real :: Mstar,tolprof,rhoj,rhoj_mesa,rj
  integer(kind=8) :: ntot
  integer :: ierr,nfail(2),ncheck(2),i,j,nerror,nwarn,iunit,expected_error
@@ -473,8 +473,6 @@ subroutine test_whitedwarf(ntests,npass)
     enddo
     rmserr = sqrt(rmserr/npart)  ! root mean square relative error
     call checkval(rmserr,0.,tolprof,nfail(1),'density matches MESA profile')
-    call update_test_scores(ntests,nfail,npass)
-
     call update_test_scores(ntests,nfail,npass)
 
  enddo

--- a/src/tests/test_setstar.f90
+++ b/src/tests/test_setstar.f90
@@ -395,7 +395,7 @@ subroutine test_whitedwarf(ntests,npass)
  type(star_t) :: star
  character(len=500) :: filepath
  real :: rhozero,rmserr,rmserr_mu,rmserr_X,rmserr_Z,ekin,x0(3),errmax(2)
- real :: Mstar,tolprof,tolcomposition,rhoj,rhoj_mesa,rj,Tgas,Trad
+ real :: Mstar,tolprof,rhoj,rhoj_mesa,rj
  integer(kind=8) :: ntot
  integer :: ierr,nfail(2),ncheck(2),i,j,nerror,nwarn,iunit,expected_error
  logical :: relax_star,var_comp
@@ -416,7 +416,7 @@ subroutine test_whitedwarf(ntests,npass)
  X_in = 0.
  Z_in = 1.
  relax_star = .true.
- maxits = 2000
+ maxits = 1500
  var_comp = .false.
  call set_defaults_star(star)
  star%np             = 10000
@@ -425,13 +425,12 @@ subroutine test_whitedwarf(ntests,npass)
  x0 = 0.
 
  nfail = 0; ncheck = 0; errmax = 0.
- tolprof = 0.08
- tolcomposition = 0.08
+ tolprof = 0.1
 
  call read_mesa(filepath,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mstar,ierr)
  Zfrac = 1.-Xfrac-Yfrac
 
- do i=1,4
+ do i=1,2
     call init_part()
     if (i==1) then  ! EOS Helmholtz
        ieos = 15
@@ -458,7 +457,7 @@ subroutine test_whitedwarf(ntests,npass)
     call checkval(nerror+nwarn,0,0,nfail(1),'no errors or warnings')
     call update_test_scores(ntests,nfail,npass)
    
-    call checkval(rmserr,0.0,0.04,nfail(1),'error in density profile')
+    call checkval(rmserr,0.0,0.05,nfail(1),'error in density profile')
     call update_test_scores(ntests,nfail,npass)
 
     call checkval(ekin,0.,5e-6,nfail(1),'ekin/epot < 1.e-7')

--- a/src/tests/test_setstar.f90
+++ b/src/tests/test_setstar.f90
@@ -397,7 +397,7 @@ subroutine test_whitedwarf(ntests,npass)
  real :: rhozero,rmserr,ekin,x0(3),errmax(2)
  real :: Mstar,tolprof,rhoj,rhoj_mesa,rj
  integer(kind=8) :: ntot
- integer :: ierr,nfail(2),ncheck(2),i,j,nerror,nwarn,iunit,expected_error
+ integer :: ierr,nfail(2),ncheck(2),i,j,nerror,nwarn,iunit
  logical :: relax_star,var_comp
  real, allocatable :: r(:),den(:),pres(:),temp(:),en(:),mtab(:),Xfrac(:),Yfrac(:),Zfrac(:),mu(:)
 

--- a/src/tests/test_setstar.f90
+++ b/src/tests/test_setstar.f90
@@ -394,7 +394,7 @@ subroutine test_whitedwarf(ntests,npass)
  integer, intent(inout) :: ntests,npass
  type(star_t) :: star
  character(len=500) :: filepath
- real :: rhozero,rmserr,rmserr_mu,rmserr_X,rmserr_Z,ekin,x0(3),errmax(2)
+ real :: rhozero,rmserr,rmserr_mu,ekin,x0(3),errmax(2)
  real :: Mstar,tolprof,rhoj,rhoj_mesa,rj
  integer(kind=8) :: ntot
  integer :: ierr,nfail(2),ncheck(2),i,j,nerror,nwarn,iunit,expected_error

--- a/src/tests/test_setstar.f90
+++ b/src/tests/test_setstar.f90
@@ -52,6 +52,10 @@ subroutine test_setstar(ntests,npass)
  ! test red supergiant
  call test_redsupergiant(ntests,npass)
 
+
+ ! test white dwarf
+ call test_whitedwarf(ntests,npass)
+
 end subroutine test_setstar
 
 !-----------------------------------------------------------------------
@@ -379,7 +383,7 @@ subroutine test_whitedwarf(ntests,npass)
  use mpidomain, only:i_belong
  use options,   only:ieos
  use physcon,   only:solarr,solarm
- use eos,       only:init_eos,gamma,gmw,X_in,Z_in,irecomb,eos_works_with_radiation
+ use eos,       only:init_eos,gamma,X_in,Z_in,irecomb,eos_works_with_radiation
  use setstar,   only:star_t,set_star,set_defaults_star,imesa,ierr_radiation_conflict
  use units,     only:set_units
  use relaxstar, only:maxits
@@ -408,6 +412,9 @@ subroutine test_whitedwarf(ntests,npass)
 
  iverbose = 0
  call set_units(dist=solarr,mass=solarm,G=1.d0)
+ gamma = 5./3.
+ X_in = 0.
+ Z_in = 1.
  relax_star = .true.
  maxits = 2000
  var_comp = .false.

--- a/src/tests/test_setstar.f90
+++ b/src/tests/test_setstar.f90
@@ -397,7 +397,7 @@ subroutine test_whitedwarf(ntests,npass)
  real :: rhozero,rmserr,ekin,x0(3),errmax(2)
  real :: Mstar,tolprof,rhoj,rhoj_mesa,rj
  integer(kind=8) :: ntot
- integer :: ierr,nfail(2),ncheck(2),i,j,nerror,nwarn,iunit
+ integer :: ierr,nfail(2),ncheck(2),i,j,nerror,nwarn,iunit,expected_error
  logical :: relax_star,var_comp
  real, allocatable :: r(:),den(:),pres(:),temp(:),en(:),mtab(:),Xfrac(:),Yfrac(:),Zfrac(:),mu(:)
 

--- a/src/tests/test_setstar.f90
+++ b/src/tests/test_setstar.f90
@@ -383,8 +383,8 @@ subroutine test_whitedwarf(ntests,npass)
  use mpidomain, only:i_belong
  use options,   only:ieos
  use physcon,   only:solarr,solarm
- use eos,       only:init_eos,gamma,X_in,Z_in,irecomb,eos_works_with_radiation
- use setstar,   only:star_t,set_star,set_defaults_star,imesa,ierr_radiation_conflict
+ use eos,       only:init_eos,gamma,X_in,Z_in
+ use setstar,   only:star_t,set_star,set_defaults_star,imesa
  use units,     only:set_units
  use relaxstar, only:maxits
  use checksetup,  only:check_setup


### PR DESCRIPTION
Description:
A new module has been added: the zero temperature equation of state (see Kippenhahn 15.2). This is only considering degenerate pressure and internal energy. It is implemented mainly comparison purposes; the more accurate form of this is the Helmholtz EOS.

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Setup (src/setup)
- [ x] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [ ] Test suite (src/tests)
- [ ] Documentation (docs/)
- [x ] Build/CI (build/ or github actions)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Bug fix
- [ x] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [ ] Better testing
- [ ] Code cleanup / refactor
- [ ] Other (please describe)

Testing:
Relaxed and tested two different WD masses. They matched expectations

Did you run the bots? no
Did you update relevant documentation in the docs directory?no

Did you add comments such that the purpose of the code is understandable? yes

Is there a unit test that could be added for this feature/bug? maybe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added a new zero-temperature equation of state option (`ieos=25`), including configurable species mass fractions and EOS calculations with reporting.

* **Enhancements**
  * Updated Phantom data directory mapping to recognize `data/star_data_files` and link it to the correct external dataset.

* **Tests**
  * Added a white-dwarf relaxation test that exercises initialization under both `ieos=15` and `ieos=25`, validating error metrics and skipping with a warning when the dataset is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->