### PR TITLE
corrected entropy units in eos.f90

### DIFF
--- a/src/main/eos.f90
+++ b/src/main/eos.f90
@@ -1179,7 +1179,7 @@ subroutine get_p_from_rho_s(ieos,S,rho,mu,P,temp,niter_out)
  use physcon, only:Rg,mass_proton_cgs
  use io,      only:fatal
  use eos_idealplusrad, only:get_idealplusrad_tempfromrhoS
- use units,   only:unit_density,unit_pressure,unit_ergg
+ use units,   only:unit_density,unit_pressure,unit_ergg,umass
  real,    intent(in)    :: S,mu,rho
  real,    intent(inout) :: temp
  real,    intent(out)   :: P
@@ -1189,7 +1189,7 @@ subroutine get_p_from_rho_s(ieos,S,rho,mu,P,temp,niter_out)
 
  ! change to cgs unit
  cgsrho = rho*unit_density
- cgss   = s*unit_ergg
+ cgss   = s/umass
  if (present(niter_out)) niter_out = 0
 
  select case (ieos)

--- a/src/main/eos.f90
+++ b/src/main/eos.f90
@@ -1116,8 +1116,9 @@ function entropy(rho,pres,mu_in,ientropy,eint_in,ierr,T_in,Trad_in)
 
 end function entropy
 
+! ---- input and output in code units
 real function get_entropy(rho,pres,mu_in,ieos)
- use units,   only:unit_density,unit_pressure,unit_ergg
+ use units,   only:unit_density,unit_pressure,umass
  use physcon, only:kboltz
  integer, intent(in) :: ieos
  real,    intent(in) :: rho,pres,mu_in
@@ -1133,8 +1134,8 @@ real function get_entropy(rho,pres,mu_in,ieos)
  case default
     cgss = entropy(cgsrho,cgspres,mu_in,1)
  end select
- cgss = cgss/kboltz ! s/kb
- get_entropy = cgss/unit_ergg
+ cgss = cgss/kboltz ! s/kb: units are 1/g
+ get_entropy = cgss*umass 
 
 end function get_entropy
 

--- a/src/main/eos.f90
+++ b/src/main/eos.f90
@@ -1179,7 +1179,7 @@ subroutine get_p_from_rho_s(ieos,S,rho,mu,P,temp,niter_out)
  use physcon, only:Rg,mass_proton_cgs
  use io,      only:fatal
  use eos_idealplusrad, only:get_idealplusrad_tempfromrhoS
- use units,   only:unit_density,unit_pressure,unit_ergg,umass
+ use units,   only:unit_density,unit_pressure,umass
  real,    intent(in)    :: S,mu,rho
  real,    intent(inout) :: temp
  real,    intent(out)   :: P


### PR DESCRIPTION
Description:
corrected entropy units in eos.f90

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Setup (src/setup)
- [ x] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [ ] Test suite (src/tests)
- [ ] Documentation (docs/)
- [ ] Build/CI (build/ or github actions)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [ x] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [ ] Better testing
- [ ] Code cleanup / refactor
- [ ] Other (please describe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected entropy unit handling to use the intended internal code-unit convention.
  * Updated entropy-related scaling so computed entropy values now reflect the correct magnitude.
  * Kept the inverse reconstruction path consistent with the revised entropy units, improving pressure/temperature consistency.

* **Documentation**
  * Clarified the entropy function’s input/output unit conventions to match the updated behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->