### PR TITLE
fixed bug in moddump_flyby where secondary's orbit was not being set properly

### DIFF
--- a/src/utils/moddump_addflyby.f90
+++ b/src/utils/moddump_addflyby.f90
@@ -80,12 +80,24 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
  nptmass_in = 0
  call set_orbit(orbit,m1,m2,hacc1,accr2,xyzmh_ptmass_in,vxyz_ptmass_in,&
                         nptmass_in,(id==master),ierr)
+
  nptmass = nptmass + 1
  if (nptmass > size(xyzmh_ptmass, 2)) then
     call fatal('moddump', 'Not enough space in xyzmh_ptmass for another sink particle')
  endif
+
+! translate the secondary so that it is correctly set relative to the primary
  xyzmh_ptmass(:,nptmass) = xyzmh_ptmass_in(:,2)
- vxyz_ptmass(:,nptmass)  = vxyz_ptmass_in(:,2)
+
+ xyzmh_ptmass(1:3,nptmass) = xyzmh_ptmass(1:3,nptmass) &
+                          + xyzmh_ptmass(1:3,1) &
+                          - xyzmh_ptmass_in(1:3,1)
+
+ vxyz_ptmass(:,nptmass) = vxyz_ptmass_in(:,2)
+
+ vxyz_ptmass(:,nptmass) = vxyz_ptmass(:,nptmass) &
+                       + vxyz_ptmass(:,1) &
+                       - vxyz_ptmass_in(:,1)
 
  call reset_centreofmass(npart,xyzh,vxyzu,nptmass,xyzmh_ptmass,vxyz_ptmass)
 

--- a/src/utils/moddump_addflyby.f90
+++ b/src/utils/moddump_addflyby.f90
@@ -77,6 +77,8 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
 
  if (ierr /= 0) stop 'run phantommoddump again with new .moddump file'
 
+ xyzmh_ptmass_in = 0.
+ vxyz_ptmass_in = 0.
  nptmass_in = 0
  call set_orbit(orbit,m1,m2,hacc1,accr2,xyzmh_ptmass_in,vxyz_ptmass_in,&
                         nptmass_in,(id==master),ierr)
@@ -93,9 +95,7 @@ subroutine modify_dump(npart,npartoftype,massoftype,xyzh,vxyzu)
                           + xyzmh_ptmass(1:3,1) &
                           - xyzmh_ptmass_in(1:3,1)
 
- vxyz_ptmass(:,nptmass) = vxyz_ptmass_in(:,2)
-
- vxyz_ptmass(:,nptmass) = vxyz_ptmass(:,nptmass) &
+ vxyz_ptmass(:,nptmass) = vxyz_ptmass_in(:,2) &
                        + vxyz_ptmass(:,1) &
                        - vxyz_ptmass_in(:,1)
 


### PR DESCRIPTION
Description:
<!-- The flyby's generated orbit was not set relative to the primary. The position and velocity are now shifted relative to the primary before insertion to the simulation.-->

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Setup (src/setup)
- [ ] Main code (src/main)
- [x] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [ ] Test suite (src/tests)
- [ ] Documentation (docs/)
- [ ] Build/CI (build/ or github actions)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [x] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [ ] Better testing
- [ ] Code cleanup / refactor
- [ ] Other (please describe)

Testing:
I calculated the secondary's orbital elements using the xyzvxyz data from a dump file, and I confirmed this was the same as the orbital parameters I input in flyby.moddump. I tested this for bound and unbound case. 

Did you run the bots? no

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? yes

Is there a unit test that could be added for this feature/bug? yes

If so, please describe what a unit test might check:
We can test that running this moddump will add a star at the correct orbit for all of the 4 options (bound, unbound, orbit reconstructor, observed dx dy). 

<!-- If this PR is related to an issue, please link it here -->
Related issues: #851 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected flyby sink placement when modifying dumps.
  * Flyby positions and velocities are now translated relative to the current primary sink, preserving the intended relative motion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->