### PR TITLE
Aton reader module added (similar to MESA reader)

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -634,7 +634,7 @@ libsetup: $(OBJLIBSETUP)
 .PHONY: phantomsetup
 phantomsetup: setup
 
-SRCSETSTAR= prompting.f90 density_profiles.f90 readwrite_kepler.f90 readwrite_mesa.f90 \
+SRCSETSTAR= prompting.f90 density_profiles.f90 readwrite_kepler.f90 readwrite_mesa.f90 readwrite_aton.f90 \
             set_cubic_core.f90 set_fixedentropycore.f90 set_softened_core.f90 \
             set_star_utils.f90 relax_star.f90 set_star.f90 set_orbit.f90
 

--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "fortran.fortls.disabled": true
+}

--- a/src/setup/readwrite_aton.f90
+++ b/src/setup/readwrite_aton.f90
@@ -14,7 +14,7 @@ module readwrite_aton
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: datafiles, fileutils, physcon, units
+! :Dependencies: datafiles, fileutils, physcon, units, table_utils
 !
  implicit none
 
@@ -42,7 +42,7 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
  real,              intent(out) :: Mstar
  logical,           intent(in), optional :: cgsunits
  integer                                    :: lines,i,ncols,nheaderlines,nlabels
- integer                                    :: idir,iu
+ integer                                    :: iu
  character(len=120)                         :: fullfilepath
  character(len=24), allocatable              :: header(:)
  logical                                    :: iexist,usecgs,isatonfile,got_column
@@ -61,7 +61,6 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
     return
  endif
  lines = get_nlines(fullfilepath) ! total number of lines in file
- write(*,*)'I am after get_nlines', lines 
 
  open(newunit=iu,file=fullfilepath,status='old',iostat=ierr)
  if (ierr /= 0) then
@@ -70,13 +69,7 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
  endif
 
  call get_ncolumns(iu,ncols,nheaderlines)
- write(*,*)'I am after get_ncolummns in ATON. This is nheaderlines', nheaderlines
  lines = lines - nheaderlines
- if (nheaderlines == 5) then ! Assume file has 5 header lines if formatted as standard profile 
-    isatonfile = .true.
- else
-    isatonfile = .false.
- endif
  if (lines <= 0) then ! file not found
     ierr = 1
     return
@@ -85,7 +78,10 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
  ! extract column labels from the file header
  allocate(header(ncols),dat(lines,ncols))
  call read_column_labels(iu,nheaderlines,ncols,nlabels,header)
- write(*,*)'I am after read_column_labels', nlabels,ncols  
+ isatonfile = .false.
+ do i = 1,ncols
+    if (trim(lcase(header(i))) == '#m/msun' .or. trim(lcase(header(i))) == 'm/msun') isatonfile = .true.
+ enddo
  if (nlabels /= ncols) print*,'WARNING: got ',nlabels,' labels for ',ncols,' columns'
 
  allocate(m(lines))
@@ -94,7 +90,6 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
 
  
     ! read file forwards, from centre to surface
-    write(*,*) 'Reading ATON from centre to surface'
     do i = 1,lines
        read(iu,*,iostat=ierr) dat(i,1:ncols)
     enddo
@@ -107,7 +102,6 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
     Xfrac = X_in
     Yfrac = 1. - X_in - Z_in
     mu = 0.
-    idir = 1
     do i = 1,ncols
        if (header(i)(1:1) == '#' .and. .not. trim(lcase(header(i)))=='#mass' &
            .and. .not. trim(lcase(header(i)))=='#m/msun') then
@@ -165,18 +159,13 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
        case default
           got_column = .false.
        end select
-       if (got_column .and. idir==1) print "(1x,i0,': ',a)",i,trim(header(i))
+       if (got_column) print "(1x,i0,': ',a)",i,trim(header(i))
     enddo
-    if (idir==1) print "(a)"
+    print "(a)"
 
-    ! otherwise rewind and re-skip header
-    rewind(iu)
-    do i=1,nheaderlines
-       read(iu,*,iostat=ierr)
-    enddo
  close(iu)
 
- if (min(minval(pres),minval(rho))<0d0) ierr = 1
+ if (min(minval(pres),minval(rho),minval(r),minval(m)) < 0d0) ierr = 4
 
  if (ierr /= 0) then
     print "(a,/)",' ERROR reading ATON file [missing required columns]'

--- a/src/setup/readwrite_aton.f90
+++ b/src/setup/readwrite_aton.f90
@@ -175,7 +175,7 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
  endif
 
  call get_ncolumns(iu,ncols,nheaderlines)
- wirte(*,*)'I am in get_ncolummns'
+ write(*,*)'I am in get_ncolummns', nheaderlines
  if (nheaderlines == 4) then ! Assume file has 4 header lines if formatted as standard profile
     read(iu,'()',iostat=ierr)
     read(iu,'()',iostat=ierr)

--- a/src/setup/readwrite_aton.f90
+++ b/src/setup/readwrite_aton.f90
@@ -18,118 +18,11 @@ module readwrite_aton
 !
  implicit none
 
- public :: read_aton,write_aton,read_masstransferrate
+ public :: read_aton,write_aton
 
  private
 
 contains
-
-!-----------------------------------------------------------------------
-!+
-!  Reads mass transfer rate vs. time data.
-!  Assumes input time data are in years and Mdot data in Msun/yr, outputs
-!  columns in code units.
-!+
-!-----------------------------------------------------------------------
-subroutine read_masstransferrate(filepath,time,mdot,ierr)
- use physcon,   only:solarm,solarr,years
- use fileutils, only:get_nlines,get_ncolumns,string_delete,lcase,read_column_labels
- use datafiles, only:find_phantom_datafile
- use units,     only:umass,utime
- character(len=*),  intent(in)  :: filepath
- real, allocatable, intent(out) :: time(:),mdot(:)
- integer,           intent(out) :: ierr
- integer                                    :: lines,i,ncols,nheaderlines,nlabels
- integer                                    :: iu
- character(len=120)                         :: fullfilepath
- character(len=24), allocatable              :: header(:)
- logical                                    :: iexist,got_column
- real, allocatable :: dat(:,:)
-
- !
- !--Get path name
- !
- ierr = 0
- fullfilepath = find_phantom_datafile(filepath,'star_data_files')
- inquire(file=trim(fullfilepath),exist=iexist)
- if (.not.iexist) then
-    ierr = 1
-    return
- endif
- lines = get_nlines(fullfilepath) ! total number of lines in file
-
- print "(1x,a)",trim(fullfilepath)
- open(newunit=iu,file=fullfilepath,status='old',iostat=ierr)
- if (ierr /= 0) then
-    print "(a,/)",' ERROR opening file '//trim(fullfilepath)
-    return
- endif
-
- print*,lines, 'LINES'
-
- call get_ncolumns(iu,ncols,nheaderlines)
- read(iu,*,iostat=ierr) lines,lines
- read(iu,'()',iostat=ierr)
-
- lines = lines - nheaderlines
- if (ierr /= 0) then
-    print "(a,/)",' ERROR reading ATON file header'
-    return
- endif
-
- if (lines <= 0) then ! file not found
-    ierr = 1
-    return
- endif
-
- ! extract column labels from the file header
- allocate(header(ncols),dat(lines,ncols))
- call read_column_labels(iu,nheaderlines,ncols,nlabels,header)
- if (nlabels /= ncols) print*,' WARNING: different number of labels compared to columns'
-
- allocate(time(lines),mdot(lines))
-
- ! read file forwards, from centre to surface
- do i = 1,lines
-    read(iu,*,iostat=ierr) dat(i,1:ncols)
- enddo
-
- if (ierr /= 0) then
-    print "(a,/)",' ERROR reading data from file: reached end of file?'
-    return
- endif
-
- do i = 1,ncols
-    if (header(i)(1:1) == '#' .and. .not. trim(lcase(header(i)))=='#mass' &
-        .and. .not. trim(lcase(header(i)))=='#m/msun') then
-       print '("Detected wrong header entry : ",a," in file ",a)',trim(lcase(header(i))),trim(fullfilepath)
-       ierr = 2
-       return
-    endif
-    got_column = .true.
-    select case(trim(lcase(header(i))))
-    case('tiempo')
-       time = dat(1:lines,i)
-    case('mdot')
-       mdot = dat(1:lines,i)
-    case default
-       got_column = .false.
-    end select
-    if (got_column) print "(1x,i0,': ',a)",i,trim(header(i))
- enddo
- print "(a)"
-
- close(iu)
-
- if (ierr /= 0) then
-    print "(a,/)",' ERROR reading ATON file [missing required columns]'
-    return
- endif
-
- time = time * years / utime
- mdot = mdot * (solarm / years) * utime / umass
-
-end subroutine read_masstransferrate
 
 !-----------------------------------------------------------------------
 !+
@@ -139,6 +32,7 @@ end subroutine read_masstransferrate
 subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mstar,ierr,cgsunits)
  use physcon,   only:solarm,solarr
  use fileutils, only:get_nlines,get_ncolumns,string_delete,lcase,read_column_labels
+ use table_utils, only:flip_array
  use datafiles, only:find_phantom_datafile
  use units,     only:udist,umass,unit_density,unit_pressure,unit_ergg
  character(len=*),  intent(in)  :: filepath
@@ -177,27 +71,11 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
 
  call get_ncolumns(iu,ncols,nheaderlines)
  write(*,*)'I am after get_ncolummns in ATON. This is nheaderlines', nheaderlines
- if (nheaderlines == 5) then ! Assume file has 5 header lines if formatted as standard profile
-    read(iu,'()',iostat=ierr)
-    read(iu,'()',iostat=ierr)
-    read(iu,*,iostat=ierr) lines,lines
-    read(iu,'()',iostat=ierr)
-    read(iu,'()',iostat=ierr)
-    if (ierr /= 0) then
-       print "(a,/)",' ERROR reading ATON file header'
-       return
-    endif
+ lines = lines - nheaderlines
+ if (nheaderlines == 5) then ! Assume file has 5 header lines if formatted as standard profile 
     isatonfile = .true.
  else
     isatonfile = .false.
-    lines = lines - nheaderlines
-    do i = 1,nheaderlines-1
-       read(iu,'()',iostat=ierr)
-    enddo
-    if (ierr /= 0) then
-       print "(a,/)",' ERROR reading file header [not ATON format]'
-       return
-    endif
  endif
  if (lines <= 0) then ! file not found
     ierr = 1
@@ -214,23 +92,14 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
  m = -1.
  allocate(r,pres,rho,ene,temp,Xfrac,Yfrac,mu,source=m)
 
- over_directions: do idir=1,2   ! try backwards, then forwards
-    write(*,*) 'idir is:',idir
-    if (idir==1) then
-      write(*,*) 'I am in backward mode'
-       ! read ATON file backwards, from surface to centre
-       do i = 1,lines
-          read(iu,*,iostat=ierr) dat(lines-i+1,1:ncols)
-       enddo
-    else
-      write(*,*) 'I am in forward mode'
-       ! read file forwards, from centre to surface
-       do i = 1,lines
-          read(iu,*,iostat=ierr) dat(i,1:ncols)
-       enddo
-    endif
+ 
+    ! read file forwards, from centre to surface
+    write(*,*) 'Reading ATON from centre to surface'
+    do i = 1,lines
+       read(iu,*,iostat=ierr) dat(i,1:ncols)
+    enddo
     if (ierr /= 0) then
-       print "(a,/)",' ERROR reading data from file: reached end of file?'
+       print "(a,/)",' ERROR reading data from ATON file (new statement)'
        return
     endif
 
@@ -238,6 +107,7 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
     Xfrac = X_in
     Yfrac = 1. - X_in - Z_in
     mu = 0.
+    idir = 1
     do i = 1,ncols
        if (header(i)(1:1) == '#' .and. .not. trim(lcase(header(i)))=='#mass' &
            .and. .not. trim(lcase(header(i)))=='#m/msun') then
@@ -269,7 +139,7 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
           r = dat(1:lines,i) * 1e5
        case('radius','r')
           r = dat(1:lines,i)
-          if (isatonfile .or. maxval(r) < 1e-5*solarr) r = r * solarr
+          if (maxval(r) < 1e-5*solarr) r = r * solarr
        case('logr')
           r = (10**dat(1:lines,i)) * solarr
        case('logr_cm')
@@ -299,15 +169,11 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
     enddo
     if (idir==1) print "(a)"
 
-    ! quit the loop over directions if the radius increases
-    if (idir==1 .and. r(2) > r(1)) exit over_directions
-
     ! otherwise rewind and re-skip header
     rewind(iu)
     do i=1,nheaderlines
        read(iu,*,iostat=ierr)
     enddo
- enddo over_directions
  close(iu)
 
  if (min(minval(pres),minval(rho))<0d0) ierr = 1
@@ -325,6 +191,18 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
     ene = ene / unit_ergg
  endif
 
+ if (r(1) > r(lines)) then
+    call flip_array(r)
+    call flip_array(m)
+    call flip_array(rho)
+    call flip_array(pres)
+    call flip_array(ene)
+    call flip_array(temp)
+    call flip_array(Xfrac)
+    call flip_array(Yfrac)
+    call flip_array(mu)
+ endif
+
  Mstar = m(lines)
 
 end subroutine read_aton
@@ -335,7 +213,8 @@ end subroutine read_aton
 !  used in star setup to write softened stellar profile.
 !+
 !----------------------------------------------------------------
-subroutine write_aton(outputpath,m,pres,temp,r,rho,ene,Xfrac,Yfrac,csound,mu)
+ subroutine write_aton(outputpath,m,pres,temp,r,rho,ene,Xfrac,Yfrac,csound,mu)
+ use physcon, only:solarm
  real,               intent(in) :: m(:),rho(:),pres(:),r(:),ene(:),temp(:)
  character(len=120), intent(in) :: outputpath
  real,               intent(in), optional :: Xfrac(:),Yfrac(:),csound(:),mu(:)
@@ -345,8 +224,8 @@ subroutine write_aton(outputpath,m,pres,temp,r,rho,ene,Xfrac,Yfrac,csound,mu)
  character(len=*), parameter     :: fmtstring = "(5(es24.16e3,2x),es24.16e3)"
 
  ncols = 6
- headers(1:ncols) = (/'          M/Msun','          radius','         density', &
-                      ' internal energy','     temperature','        pressure'/)
+ headers(1:ncols) = (/'         #M/Msun','       radius_cm','         density', &
+                      ' internal_energy','     temperature','        pressure'/)
 
  ! Add optional columns
  noptionalcols = 0
@@ -363,12 +242,12 @@ subroutine write_aton(outputpath,m,pres,temp,r,rho,ene,Xfrac,Yfrac,csound,mu)
  endif
  if (present(mu)) then
     noptionalcols = noptionalcols + 1
-    headers(noptionalcols+ncols) = 'molecular weight'
+    headers(noptionalcols+ncols) = 'molecular_weight'
     optionalcols(:,noptionalcols) = mu
  endif
  if (present(csound)) then
     noptionalcols = noptionalcols + 1
-    headers(noptionalcols+ncols) = '     Sound speed'
+    headers(noptionalcols+ncols) = '          csound'
     optionalcols(:,noptionalcols) = csound
  endif
 
@@ -377,17 +256,16 @@ subroutine write_aton(outputpath,m,pres,temp,r,rho,ene,Xfrac,Yfrac,csound,mu)
  write(iu,'(a)') '# Header line'
  write(iu,'(a)') '# Header line'
  write(iu,'(a)') '# Header line'
- write(iu,'(a)',advance="no") '# '
  do i = 1,noptionalcols+ncols-1
-    write(iu,'(a16,2x)',advance="no") trim(headers(i))
+    write(iu,'(a24,2x)',advance="no") trim(adjustl(headers(i)))
  enddo
- write(iu,'(a16)') trim(headers(noptionalcols+ncols))
+ write(iu,'(a24)') trim(adjustl(headers(noptionalcols+ncols)))
 
  do i=1,size(r)
     if (noptionalcols <= 0) then
-       write(iu,fmtstring) m(i),r(i),rho(i),ene(i),temp(i),pres(i)
+       write(iu,fmtstring) m(i)/solarm,r(i),rho(i),ene(i),temp(i),pres(i)
     else
-       write(iu,fmtstring,advance="no") m(i),r(i),rho(i),ene(i),temp(i),pres(i)
+       write(iu,fmtstring,advance="no") m(i)/solarm,r(i),rho(i),ene(i),temp(i),pres(i)
        do j=1,noptionalcols
           if (j==noptionalcols) then
              write(iu,'(2x,es24.16e3)') optionalcols(i,j)

--- a/src/setup/readwrite_aton.f90
+++ b/src/setup/readwrite_aton.f90
@@ -175,7 +175,7 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
  endif
 
  call get_ncolumns(iu,ncols,nheaderlines)
- if (nheaderlines == 6) then ! Assume file has 6 header lines if formatted as standard profile
+ if (nheaderlines == 4) then ! Assume file has 4 header lines if formatted as standard profile
     read(iu,'()',iostat=ierr)
     read(iu,'()',iostat=ierr)
     read(iu,*,iostat=ierr) lines,lines

--- a/src/setup/readwrite_aton.f90
+++ b/src/setup/readwrite_aton.f90
@@ -14,7 +14,7 @@ module readwrite_aton
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: datafiles, fileutils, physcon, units, table_utils
+! :Dependencies: datafiles, fileutils, physcon, table_utils, units
 !
  implicit none
 
@@ -80,7 +80,8 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
  call read_column_labels(iu,nheaderlines,ncols,nlabels,header)
  isatonfile = .false.
  do i = 1,ncols
-    if (trim(lcase(header(i))) == '#m/msun' .or. trim(lcase(header(i))) == 'm/msun') isatonfile = .true.
+    if (trim(lcase(header(i))) == '#m/msun' .or. &
+        trim(lcase(header(i))) == 'm/msun') isatonfile = .true.
  enddo
  if (nlabels /= ncols) print*,'WARNING: got ',nlabels,' labels for ',ncols,' columns'
 

--- a/src/setup/readwrite_aton.f90
+++ b/src/setup/readwrite_aton.f90
@@ -215,11 +215,13 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
 
  over_directions: do idir=1,2   ! try backwards, then forwards
     if (idir==1) then
+      write(*,*) 'I am in backward mode'
        ! read ATON file backwards, from surface to centre
        do i = 1,lines
           read(iu,*,iostat=ierr) dat(lines-i+1,1:ncols)
        enddo
     else
+      write(*,*) 'I am in forward mode'
        ! read file forwards, from centre to surface
        do i = 1,lines
           read(iu,*,iostat=ierr) dat(i,1:ncols)

--- a/src/setup/readwrite_aton.f90
+++ b/src/setup/readwrite_aton.f90
@@ -176,7 +176,7 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
 
  call get_ncolumns(iu,ncols,nheaderlines)
  write(*,*)'I am in get_ncolummns', nheaderlines
- if (nheaderlines == 4) then ! Assume file has 4 header lines if formatted as standard profile
+ if (nheaderlines == 5) then ! Assume file has 4 header lines if formatted as standard profile
     read(iu,'()',iostat=ierr)
     read(iu,'()',iostat=ierr)
     read(iu,*,iostat=ierr) lines,lines
@@ -206,6 +206,7 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
  ! extract column labels from the file header
  allocate(header(ncols),dat(lines,ncols))
  call read_column_labels(iu,nheaderlines,ncols,nlabels,header)
+ write(*,*)'I am after read_column_labels', nlabels,ncols  
  if (nlabels /= ncols) print*,'WARNING: got ',nlabels,' labels for ',ncols,' columns'
 
  allocate(m(lines))

--- a/src/setup/readwrite_aton.f90
+++ b/src/setup/readwrite_aton.f90
@@ -1,0 +1,398 @@
+!--------------------------------------------------------------------------!
+! The Phantom Smoothed Particle Hydrodynamics code, by Daniel Price et al. !
+! Copyright (c) 2007-2026 The Authors (see AUTHORS)                        !
+! See LICENCE file for usage and distribution conditions                   !
+! http://phantomsph.github.io/                                             !
+!--------------------------------------------------------------------------!
+module readwrite_aton
+!
+! Utility routines for reading stellar profiles from the ATON code
+!
+! :References: Ventura et al. (1998)
+!
+! :Owner: Daniel Price
+!
+! :Runtime parameters: None
+!
+! :Dependencies: datafiles, fileutils, physcon, units
+!
+ implicit none
+
+ public :: read_aton,write_aton,read_masstransferrate
+
+ private
+
+contains
+
+!-----------------------------------------------------------------------
+!+
+!  Reads mass transfer rate vs. time data.
+!  Assumes input time data are in years and Mdot data in Msun/yr, outputs
+!  columns in code units.
+!+
+!-----------------------------------------------------------------------
+subroutine read_masstransferrate(filepath,time,mdot,ierr)
+ use physcon,   only:solarm,solarr,years
+ use fileutils, only:get_nlines,get_ncolumns,string_delete,lcase,read_column_labels
+ use datafiles, only:find_phantom_datafile
+ use units,     only:umass,utime
+ character(len=*),  intent(in)  :: filepath
+ real, allocatable, intent(out) :: time(:),mdot(:)
+ integer,           intent(out) :: ierr
+ integer                                    :: lines,i,ncols,nheaderlines,nlabels
+ integer                                    :: iu
+ character(len=120)                         :: fullfilepath
+ character(len=24), allocatable              :: header(:)
+ logical                                    :: iexist,got_column
+ real, allocatable :: dat(:,:)
+
+ !
+ !--Get path name
+ !
+ ierr = 0
+ fullfilepath = find_phantom_datafile(filepath,'star_data_files')
+ inquire(file=trim(fullfilepath),exist=iexist)
+ if (.not.iexist) then
+    ierr = 1
+    return
+ endif
+ lines = get_nlines(fullfilepath) ! total number of lines in file
+
+ print "(1x,a)",trim(fullfilepath)
+ open(newunit=iu,file=fullfilepath,status='old',iostat=ierr)
+ if (ierr /= 0) then
+    print "(a,/)",' ERROR opening file '//trim(fullfilepath)
+    return
+ endif
+
+ print*,lines, 'LINES'
+
+ call get_ncolumns(iu,ncols,nheaderlines)
+ read(iu,*,iostat=ierr) lines,lines
+ read(iu,'()',iostat=ierr)
+
+ lines = lines - nheaderlines
+ if (ierr /= 0) then
+    print "(a,/)",' ERROR reading ATON file header'
+    return
+ endif
+
+ if (lines <= 0) then ! file not found
+    ierr = 1
+    return
+ endif
+
+ ! extract column labels from the file header
+ allocate(header(ncols),dat(lines,ncols))
+ call read_column_labels(iu,nheaderlines,ncols,nlabels,header)
+ if (nlabels /= ncols) print*,' WARNING: different number of labels compared to columns'
+
+ allocate(time(lines),mdot(lines))
+
+ ! read file forwards, from centre to surface
+ do i = 1,lines
+    read(iu,*,iostat=ierr) dat(i,1:ncols)
+ enddo
+
+ if (ierr /= 0) then
+    print "(a,/)",' ERROR reading data from file: reached end of file?'
+    return
+ endif
+
+ do i = 1,ncols
+    if (header(i)(1:1) == '#' .and. .not. trim(lcase(header(i)))=='#mass' &
+        .and. .not. trim(lcase(header(i)))=='#m/msun') then
+       print '("Detected wrong header entry : ",a," in file ",a)',trim(lcase(header(i))),trim(fullfilepath)
+       ierr = 2
+       return
+    endif
+    got_column = .true.
+    select case(trim(lcase(header(i))))
+    case('tiempo')
+       time = dat(1:lines,i)
+    case('mdot')
+       mdot = dat(1:lines,i)
+    case default
+       got_column = .false.
+    end select
+    if (got_column) print "(1x,i0,': ',a)",i,trim(header(i))
+ enddo
+ print "(a)"
+
+ close(iu)
+
+ if (ierr /= 0) then
+    print "(a,/)",' ERROR reading ATON file [missing required columns]'
+    return
+ endif
+
+ time = time * years / utime
+ mdot = mdot * (solarm / years) * utime / umass
+
+end subroutine read_masstransferrate
+
+!-----------------------------------------------------------------------
+!+
+!  Read quantities from ATON profile (e.g. ATONStar.txt)
+!+
+!-----------------------------------------------------------------------
+subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mstar,ierr,cgsunits)
+ use physcon,   only:solarm,solarr
+ use fileutils, only:get_nlines,get_ncolumns,string_delete,lcase,read_column_labels
+ use datafiles, only:find_phantom_datafile
+ use units,     only:udist,umass,unit_density,unit_pressure,unit_ergg
+ character(len=*),  intent(in)  :: filepath
+ integer,           intent(out) :: ierr
+ real,              intent(in)  :: X_in,Z_in
+ real, allocatable, intent(out) :: rho(:),r(:),pres(:),m(:),ene(:),temp(:),Xfrac(:),Yfrac(:),mu(:)
+ real,              intent(out) :: Mstar
+ logical,           intent(in), optional :: cgsunits
+ integer                                    :: lines,i,ncols,nheaderlines,nlabels
+ integer                                    :: idir,iu
+ character(len=120)                         :: fullfilepath
+ character(len=24), allocatable              :: header(:)
+ logical                                    :: iexist,usecgs,isatonfile,got_column
+ real, allocatable :: dat(:,:)
+
+ usecgs = .false.
+ if (present(cgsunits)) usecgs = cgsunits
+ !
+ !--Get path name
+ !
+ ierr = 0
+ fullfilepath = find_phantom_datafile(filepath,'star_data_files')
+ inquire(file=trim(fullfilepath),exist=iexist)
+ if (.not.iexist) then
+    ierr = 1
+    return
+ endif
+ lines = get_nlines(fullfilepath) ! total number of lines in file
+
+ open(newunit=iu,file=fullfilepath,status='old',iostat=ierr)
+ if (ierr /= 0) then
+    print "(a,/)",' ERROR opening file '//trim(fullfilepath)
+    return
+ endif
+
+ call get_ncolumns(iu,ncols,nheaderlines)
+ if (nheaderlines == 6) then ! Assume file has 6 header lines if formatted as standard profile
+    read(iu,'()',iostat=ierr)
+    read(iu,'()',iostat=ierr)
+    read(iu,*,iostat=ierr) lines,lines
+    read(iu,'()',iostat=ierr)
+    read(iu,'()',iostat=ierr)
+    if (ierr /= 0) then
+       print "(a,/)",' ERROR reading ATON file header'
+       return
+    endif
+    isatonfile = .true.
+ else
+    isatonfile = .false.
+    lines = lines - nheaderlines
+    do i = 1,nheaderlines-1
+       read(iu,'()',iostat=ierr)
+    enddo
+    if (ierr /= 0) then
+       print "(a,/)",' ERROR reading file header [not ATON format]'
+       return
+    endif
+ endif
+ if (lines <= 0) then ! file not found
+    ierr = 1
+    return
+ endif
+
+ ! extract column labels from the file header
+ allocate(header(ncols),dat(lines,ncols))
+ call read_column_labels(iu,nheaderlines,ncols,nlabels,header)
+ if (nlabels /= ncols) print*,'WARNING: got ',nlabels,' labels for ',ncols,' columns'
+
+ allocate(m(lines))
+ m = -1.
+ allocate(r,pres,rho,ene,temp,Xfrac,Yfrac,mu,source=m)
+
+ over_directions: do idir=1,2   ! try backwards, then forwards
+    if (idir==1) then
+       ! read ATON file backwards, from surface to centre
+       do i = 1,lines
+          read(iu,*,iostat=ierr) dat(lines-i+1,1:ncols)
+       enddo
+    else
+       ! read file forwards, from centre to surface
+       do i = 1,lines
+          read(iu,*,iostat=ierr) dat(i,1:ncols)
+       enddo
+    endif
+    if (ierr /= 0) then
+       print "(a,/)",' ERROR reading data from file: reached end of file?'
+       return
+    endif
+
+    ! Set mass fractions to fixed inputs if not in file
+    Xfrac = X_in
+    Yfrac = 1. - X_in - Z_in
+    mu = 0.
+    do i = 1,ncols
+       if (header(i)(1:1) == '#' .and. .not. trim(lcase(header(i)))=='#mass' &
+           .and. .not. trim(lcase(header(i)))=='#m/msun') then
+          print '("Detected wrong header entry : ",a," in file ",a)',trim(lcase(header(i))),trim(fullfilepath)
+          ierr = 2
+          return
+       endif
+       got_column = .true.
+       select case(trim(lcase(header(i))))
+       case('mass_grams')
+          m = dat(1:lines,i)
+       case('mass','#mass','m','m/msun','#m/msun')
+          m = dat(1:lines,i)
+          if (isatonfile .or. maxval(m) < 1.e-10*solarm) m = m * solarm  ! If reading ATON profile, 'mass' or 'M/Msun' is in units of Msun
+       case('logm','log_mass')
+          m = 10**dat(1:lines,i)
+          if (isatonfile .or. maxval(m) < 1.e-10*solarm) m = m * solarm
+       case('rho','density')
+          rho = dat(1:lines,i)
+       case('logrho')
+          rho = 10**(dat(1:lines,i))
+       case('energy','e_int','e_internal','cell_specific_ie','internal energy','internal_energy')
+          ene = dat(1:lines,i)
+       case('loge')
+          ene = 10**dat(1:lines,i)
+       case('radius_cm')
+          r = dat(1:lines,i)
+       case('radius_km')
+          r = dat(1:lines,i) * 1e5
+       case('radius','r')
+          r = dat(1:lines,i)
+          if (isatonfile .or. maxval(r) < 1e-5*solarr) r = r * solarr
+       case('logr')
+          r = (10**dat(1:lines,i)) * solarr
+       case('logr_cm')
+          r = 10**dat(1:lines,i)
+       case('pressure','p')
+          pres = dat(1:lines,i)
+       case('logp')
+          pres = 10**dat(1:lines,i)
+       case('temperature','t')
+          temp = dat(1:lines,i)
+       case('logt')
+          temp = 10**dat(1:lines,i)
+       case('x_mass_fraction_h','x','xfrac','h1','hydrogen')
+          Xfrac = dat(1:lines,i)
+       case('log_x')
+          Xfrac = 10**dat(1:lines,i)
+       case('y_mass_fraction_he','y','yfrac','he4','helium')
+          Yfrac = dat(1:lines,i)
+       case('log_y')
+          Yfrac = 10**dat(1:lines,i)
+       case('mu','molecular weight','molecular_weight')
+          mu = dat(1:lines,i)
+       case default
+          got_column = .false.
+       end select
+       if (got_column .and. idir==1) print "(1x,i0,': ',a)",i,trim(header(i))
+    enddo
+    if (idir==1) print "(a)"
+
+    ! quit the loop over directions if the radius increases
+    if (idir==1 .and. r(2) > r(1)) exit over_directions
+
+    ! otherwise rewind and re-skip header
+    rewind(iu)
+    do i=1,nheaderlines
+       read(iu,*,iostat=ierr)
+    enddo
+ enddo over_directions
+ close(iu)
+
+ if (min(minval(pres),minval(rho))<0d0) ierr = 1
+
+ if (ierr /= 0) then
+    print "(a,/)",' ERROR reading ATON file [missing required columns]'
+    return
+ endif
+
+ if (.not. usecgs) then
+    m = m / umass
+    r = r / udist
+    pres = pres / unit_pressure
+    rho = rho / unit_density
+    ene = ene / unit_ergg
+ endif
+
+ Mstar = m(lines)
+
+end subroutine read_aton
+
+!----------------------------------------------------------------
+!+
+!  Write stellar profile in format readable by read_aton;
+!  used in star setup to write softened stellar profile.
+!+
+!----------------------------------------------------------------
+subroutine write_aton(outputpath,m,pres,temp,r,rho,ene,Xfrac,Yfrac,csound,mu)
+ real,               intent(in) :: m(:),rho(:),pres(:),r(:),ene(:),temp(:)
+ character(len=120), intent(in) :: outputpath
+ real,               intent(in), optional :: Xfrac(:),Yfrac(:),csound(:),mu(:)
+ character(len=200)              :: headers(100)
+ integer                         :: i,ncols,noptionalcols,j,iu
+ real, allocatable               :: optionalcols(:,:)
+ character(len=*), parameter     :: fmtstring = "(5(es24.16e3,2x),es24.16e3)"
+
+ ncols = 6
+ headers(1:ncols) = (/'          M/Msun','          radius','         density', &
+                      ' internal energy','     temperature','        pressure'/)
+
+ ! Add optional columns
+ noptionalcols = 0
+ allocate(optionalcols(size(r),10))
+ if (present(Xfrac)) then
+    noptionalcols = noptionalcols + 1
+    headers(noptionalcols+ncols) = '        hydrogen'
+    optionalcols(:,noptionalcols) = Xfrac
+ endif
+ if (present(Yfrac)) then
+    noptionalcols = noptionalcols + 1
+    headers(noptionalcols+ncols) = '          helium'
+    optionalcols(:,noptionalcols) = Yfrac
+ endif
+ if (present(mu)) then
+    noptionalcols = noptionalcols + 1
+    headers(noptionalcols+ncols) = 'molecular weight'
+    optionalcols(:,noptionalcols) = mu
+ endif
+ if (present(csound)) then
+    noptionalcols = noptionalcols + 1
+    headers(noptionalcols+ncols) = '     Sound speed'
+    optionalcols(:,noptionalcols) = csound
+ endif
+
+ open(newunit=iu,file=outputpath,status='replace')
+ write(iu,'(a)') '# ATON stellar profile written by Phantom'
+ write(iu,'(a)') '# Header line'
+ write(iu,'(a)') '# Header line'
+ write(iu,'(a)') '# Header line'
+ write(iu,'(a)',advance="no") '# '
+ do i = 1,noptionalcols+ncols-1
+    write(iu,'(a16,2x)',advance="no") trim(headers(i))
+ enddo
+ write(iu,'(a16)') trim(headers(noptionalcols+ncols))
+
+ do i=1,size(r)
+    if (noptionalcols <= 0) then
+       write(iu,fmtstring) m(i),r(i),rho(i),ene(i),temp(i),pres(i)
+    else
+       write(iu,fmtstring,advance="no") m(i),r(i),rho(i),ene(i),temp(i),pres(i)
+       do j=1,noptionalcols
+          if (j==noptionalcols) then
+             write(iu,'(2x,es24.16e3)') optionalcols(i,j)
+          else
+             write(iu,'(2x,es24.16e3)',advance="no") optionalcols(i,j)
+          endif
+       enddo
+    endif
+ enddo
+ close(iu)
+
+end subroutine write_aton
+
+end module readwrite_aton

--- a/src/setup/readwrite_aton.f90
+++ b/src/setup/readwrite_aton.f90
@@ -167,6 +167,7 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
     return
  endif
  lines = get_nlines(fullfilepath) ! total number of lines in file
+ write(*,*)'I am after get_nlines', lines 
 
  open(newunit=iu,file=fullfilepath,status='old',iostat=ierr)
  if (ierr /= 0) then
@@ -175,8 +176,8 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
  endif
 
  call get_ncolumns(iu,ncols,nheaderlines)
- write(*,*)'I am in get_ncolummns', nheaderlines
- if (nheaderlines == 5) then ! Assume file has 4 header lines if formatted as standard profile
+ write(*,*)'I am after get_ncolummns in ATON. This is nheaderlines', nheaderlines
+ if (nheaderlines == 5) then ! Assume file has 5 header lines if formatted as standard profile
     read(iu,'()',iostat=ierr)
     read(iu,'()',iostat=ierr)
     read(iu,*,iostat=ierr) lines,lines
@@ -214,6 +215,7 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
  allocate(r,pres,rho,ene,temp,Xfrac,Yfrac,mu,source=m)
 
  over_directions: do idir=1,2   ! try backwards, then forwards
+    write(*,*) 'idir is:',idir
     if (idir==1) then
       write(*,*) 'I am in backward mode'
        ! read ATON file backwards, from surface to centre

--- a/src/setup/readwrite_aton.f90
+++ b/src/setup/readwrite_aton.f90
@@ -175,6 +175,7 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
  endif
 
  call get_ncolumns(iu,ncols,nheaderlines)
+ wirte(*,*)'I am in get_ncolummns'
  if (nheaderlines == 4) then ! Assume file has 4 header lines if formatted as standard profile
     read(iu,'()',iostat=ierr)
     read(iu,'()',iostat=ierr)

--- a/src/setup/readwrite_mesa.f90
+++ b/src/setup/readwrite_mesa.f90
@@ -175,6 +175,7 @@ subroutine read_mesa(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
  endif
 
  call get_ncolumns(iu,ncols,nheaderlines)
+ write(*,*)'ncols, nheaderlines',ncols, nheaderlines
  if (nheaderlines == 6) then ! Assume file is a MESA profile, and so it has 6 header lines, and (row=3, col=2) = number of zones
     read(iu,'()',iostat=ierr)
     read(iu,'()',iostat=ierr)

--- a/src/setup/readwrite_mesa.f90
+++ b/src/setup/readwrite_mesa.f90
@@ -10,7 +10,7 @@ module readwrite_mesa
 !
 ! :References: Paxton et al. (2011), ApJS 192, 3
 !
-! :Owner: Daniel Price
+! :OWner: Daniel Price
 !
 ! :Runtime parameters: None
 !
@@ -175,7 +175,6 @@ subroutine read_mesa(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
  endif
 
  call get_ncolumns(iu,ncols,nheaderlines)
- write(*,*)'ncols, nheaderlines',ncols, nheaderlines
  if (nheaderlines == 6) then ! Assume file is a MESA profile, and so it has 6 header lines, and (row=3, col=2) = number of zones
     read(iu,'()',iostat=ierr)
     read(iu,'()',iostat=ierr)

--- a/src/setup/set_star.f90
+++ b/src/setup/set_star.f90
@@ -1177,7 +1177,8 @@ subroutine read_options_stars_eos(nstars,star,label,ieos,db,nerr)
 
  ! equation of state
  call read_inopt(ieos,'ieos',db,errcount=nerr)
- if (any(star(:)%iprofile==imesa .or. star(:)%iprofile==iaton)) call read_inopt(use_var_comp,'use_var_comp',db,errcount=nerr)
+ if (any(star(:)%iprofile==imesa .or. star(:)%iprofile==iaton)) &
+ call read_inopt(use_var_comp,'use_var_comp',db,errcount=nerr)
 
  select case(ieos)
  case(9)
@@ -1218,7 +1219,8 @@ subroutine set_star_eos_interactive(ieos,star)
 
  ! equation of state
  call prompt('Enter the desired EoS (1=isothermal,2=idealgas,10=MESA,12=idealplusrad)',ieos)
- if (any(star(:)%iprofile==imesa .or. star(:)%iprofile==iaton)) call prompt('Use variable composition?',use_var_comp)
+ if (any(star(:)%iprofile==imesa .or. star(:)%iprofile==iaton)) &
+    call prompt('Use variable composition?',use_var_comp)
 
  select case(ieos)
  case(9)

--- a/src/setup/set_star.f90
+++ b/src/setup/set_star.f90
@@ -1177,8 +1177,10 @@ subroutine read_options_stars_eos(nstars,star,label,ieos,db,nerr)
 
  ! equation of state
  call read_inopt(ieos,'ieos',db,errcount=nerr)
- if (any(star(:)%iprofile==imesa .or. star(:)%iprofile==iaton)) &
- call read_inopt(use_var_comp,'use_var_comp',db,errcount=nerr)
+ if (any(star(:)%iprofile==imesa .or. &
+         star(:)%iprofile==iaton)) then
+  call read_inopt(use_var_comp,'use_var_comp',db,errcount=nerr)
+ endif 
 
  select case(ieos)
  case(9)
@@ -1219,8 +1221,10 @@ subroutine set_star_eos_interactive(ieos,star)
 
  ! equation of state
  call prompt('Enter the desired EoS (1=isothermal,2=idealgas,10=MESA,12=idealplusrad)',ieos)
- if (any(star(:)%iprofile==imesa .or. star(:)%iprofile==iaton)) &
-    call prompt('Use variable composition?',use_var_comp)
+ if (any(star(:)%iprofile==imesa .or. &
+         star(:)%iprofile==iaton)) then
+  call prompt('Use variable composition?',use_var_comp)
+ endif 
 
  select case(ieos)
  case(9)

--- a/src/setup/set_star.f90
+++ b/src/setup/set_star.f90
@@ -32,7 +32,7 @@ module setstar
 !   infile_utils, io, mpiutils, part, physcon, prompting, relaxstar,
 !   setstar_utils, unifdis, units, vectorutils
 !
- use setstar_utils, only:ikepler,imesa,ibpwpoly,ipoly,iuniform,ifromfile,ievrard,&
+ use setstar_utils, only:ikepler,imesa,iaton,ibpwpoly,ipoly,iuniform,ifromfile,ievrard,&
                          need_polyk,need_mu
  implicit none
 
@@ -63,7 +63,7 @@ module setstar
  public :: write_options_star,write_options_stars
  public :: read_options_star,read_options_stars
  public :: set_stars_interactive
- public :: ikepler,imesa,ibpwpoly,ipoly,iuniform,ifromfile,ievrard
+ public :: ikepler,imesa,iaton,ibpwpoly,ipoly,iuniform,ifromfile,ievrard
  public :: need_polyk
 
  integer, parameter :: istar_offset = 3 ! offset for particle type to distinguish particles
@@ -341,7 +341,7 @@ subroutine set_star(id,master,star,xyzh,vxyzu,eos_vars,rad,&
     if (reduceall_mpi('+',npart)==npart) then
        polyk_eos = star%polyk
 
-       if (star%iprofile == imesa .or. star%iprofile == ikepler) then
+       if (star%iprofile == imesa .or. star%iprofile == ikepler .or. star%iprofile == iaton) then
           !
           ! if a MESA profile is used, we supply the mtab array for the
           ! mass profile in relax_star rather than integrating it manually
@@ -673,6 +673,9 @@ subroutine set_defaults_given_profile(iprofile,filename,mstar,polyk)
     ! sets up a star from a 1D MESA code output
     !  Original Author: Roberto Iaconi
     filename = 'P12_Phantom_Profile.data'
+ case(iaton)
+    ! sets up a star from a 1D ATON code output
+    filename = 'ATONStar.txt'
  case(ikepler)
     ! sets up a star from a 1D KEPLER code output
     !  Original Author: Nicole Rodrigues and Megha Sharma
@@ -728,7 +731,7 @@ subroutine set_star_interactive(star)
  endif
 
  select case (star%iprofile)
- case(imesa,ikepler)
+ case(imesa,ikepler,iaton)
     print*,'Soften the core density profile and add a sink particle core?'
     print "(3(/,a))",'0: Do not soften profile', &
                      '1: Use cubic softened density profile', &
@@ -863,7 +866,7 @@ subroutine write_options_star(star,iunit,label)
  endif
 
  select case(star%iprofile)
- case(imesa,ikepler)
+ case(imesa,ikepler,iaton)
     call write_inopt(star%isoftcore,'isoftcore'//trim(c),&
                      '0=no core softening, 1=cubic, 2=const. entropy',iunit)
 
@@ -957,7 +960,7 @@ subroutine read_options_star(star,db,nerr,label)
  endif
 
  select case(star%iprofile)
- case(imesa,ikepler)
+ case(imesa,ikepler,iaton)
     call read_inopt(star%isoftcore,'isoftcore'//trim(c),db,errcount=nerr,min=0)
 
     if (star%isoftcore <= 0) then ! sink particle core without softening
@@ -1127,7 +1130,7 @@ subroutine write_options_stars_eos(nstars,star,label,ieos,iunit)
  write(iunit,"(/,a)") '# equation of state used to set the thermal energy profile'
  call write_inopt(ieos,'ieos','1=isothermal,2=idealgas,10=MESA,12=idealplusrad,23=Tillotson',iunit)
 
- if (any(star(:)%iprofile==imesa)) then
+ if (any(star(:)%iprofile==imesa .or. star(:)%iprofile==iaton)) then
     call write_inopt(use_var_comp,'use_var_comp','Use variable composition (X, Z, mu)',iunit)
  endif
 
@@ -1174,7 +1177,7 @@ subroutine read_options_stars_eos(nstars,star,label,ieos,db,nerr)
 
  ! equation of state
  call read_inopt(ieos,'ieos',db,errcount=nerr)
- if (any(star(:)%iprofile==imesa)) call read_inopt(use_var_comp,'use_var_comp',db,errcount=nerr)
+ if (any(star(:)%iprofile==imesa .or. star(:)%iprofile==iaton)) call read_inopt(use_var_comp,'use_var_comp',db,errcount=nerr)
 
  select case(ieos)
  case(9)
@@ -1215,7 +1218,7 @@ subroutine set_star_eos_interactive(ieos,star)
 
  ! equation of state
  call prompt('Enter the desired EoS (1=isothermal,2=idealgas,10=MESA,12=idealplusrad)',ieos)
- if (any(star(:)%iprofile==imesa)) call prompt('Use variable composition?',use_var_comp)
+ if (any(star(:)%iprofile==imesa .or. star(:)%iprofile==iaton)) call prompt('Use variable composition?',use_var_comp)
 
  select case(ieos)
  case(9)

--- a/src/setup/set_star_utils.f90
+++ b/src/setup/set_star_utils.f90
@@ -15,17 +15,18 @@ module setstar_utils
 ! :Runtime parameters: None
 !
 ! :Dependencies: dim, eos, eos_piecewise, extern_densprofile, io, kernel,
-!   part, physcon, radiation_utils, readwrite_kepler, readwrite_mesa,
-!   rho_profile, setsoftenedcore, sortutils, spherical, table_utils,
-!   unifdis, units
+!   part, physcon, radiation_utils, readwrite_aton, readwrite_kepler,
+!   readwrite_mesa, rho_profile, setsoftenedcore, sortutils, spherical,
+!   table_utils, unifdis, units
 !
  use extern_densprofile, only:nrhotab
  use readwrite_kepler,   only:write_kepler_comp
+ use readwrite_aton,     only:read_aton,write_aton
  implicit none
  !
  ! Index of setup options
  !
- integer, parameter, public :: nprofile_opts =  7 ! maximum number of initial configurations
+ integer, parameter, public :: nprofile_opts =  8 ! maximum number of initial configurations
  integer, parameter, public :: ipointmass = 0
  integer, parameter, public :: iuniform   = 1
  integer, parameter, public :: ipoly      = 2
@@ -34,6 +35,7 @@ module setstar_utils
  integer, parameter, public :: imesa      = 5
  integer, parameter, public :: ibpwpoly   = 6
  integer, parameter, public :: ievrard    = 7
+ integer, parameter, public :: iaton      = 8
 
  character(len=*), parameter, public :: profile_opt(0:nprofile_opts) = &
     (/'Sink particle/point mass    ', &
@@ -43,7 +45,8 @@ module setstar_utils
       'KEPLER star from file       ', &
       'MESA star from file         ', &
       'Piecewise polytrope         ', &
-      'Evrard collapse             '/)
+      'Evrard collapse             ', &
+      'ATON star from file         '/)
 
  public :: read_star_profile
  public :: set_star_density
@@ -125,11 +128,13 @@ subroutine read_star_profile(iprofile,ieos,input_profile,gamma,polyk,ui_coef,&
     rmin  = r(1)
     Rstar = r(npts)
     pres = polyk*den**gamma
- case(imesa,ikepler)
+ case(imesa,ikepler,iaton)
     deallocate(r,den,pres,temp,en,mtab)
     if (isoftcore > 0) then
        if (iprofile == imesa) then
           call read_mesa(input_profile,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mstar,ierr,cgsunits=.true.)
+       else if (iprofile == iaton) then
+          call read_aton(input_profile,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mstar,ierr,cgsunits=.true.)
        else
           call read_kepler_file(trim(input_profile),ng_max,npts,r,den,pres,mtab,temp,en,&
                            Mstar,composition,comp_label,Xfrac,Yfrac,columns_compo,ierr,cgsunits=.true.)
@@ -149,12 +154,20 @@ subroutine read_star_profile(iprofile,ieos,input_profile,gamma,polyk,ui_coef,&
        hsoft = rcore/radkern
 
        call solve_uT_profiles(eos_type,r,den,pres,Xfrac,Yfrac,regrid_core,temp,en,mu)
-       call write_mesa(outputfilename,mtab,pres,temp,r,den,en,Xfrac,Yfrac,mu=mu)
-       ! now read the softened profile instead
-       call read_mesa(outputfilename,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mstar,ierr)
+       if (iprofile == iaton) then
+          call write_aton(outputfilename,mtab,pres,temp,r,den,en,Xfrac,Yfrac,mu=mu)
+          ! now read the softened profile instead
+          call read_aton(outputfilename,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mstar,ierr)
+       else
+          call write_mesa(outputfilename,mtab,pres,temp,r,den,en,Xfrac,Yfrac,mu=mu)
+          ! now read the softened profile instead
+          call read_mesa(outputfilename,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mstar,ierr)
+       endif
     else
        if (iprofile == imesa) then
           call read_mesa(input_profile,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mstar,ierr)
+       else if (iprofile == iaton) then
+          call read_aton(input_profile,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mstar,ierr)
        else
           call read_kepler_file(trim(input_profile),ng_max,npts,r,den,pres,mtab,temp,en,&
                 Mstar,composition,comp_label,Xfrac,Yfrac,columns_compo,ierr)
@@ -193,7 +206,7 @@ logical function need_inputprofile(iprofile)
  integer, intent(in) :: iprofile
 
  select case(iprofile)
- case(imesa,ikepler,ifromfile)
+ case(imesa,ikepler,iaton,ifromfile)
     need_inputprofile = .true.
  case default
     need_inputprofile = .false.

--- a/src/setup/set_star_utils.f90
+++ b/src/setup/set_star_utils.f90
@@ -103,6 +103,7 @@ subroutine read_star_profile(iprofile,ieos,input_profile,gamma,polyk,ui_coef,&
  !
  ! set up tabulated density profile
  !
+ character(len=120) :: profile_filename
  calc_polyk = .true.
  allocate(r(ng_max),den(ng_max),pres(ng_max),temp(ng_max),en(ng_max),mtab(ng_max))
  temp = 0.  ! Initialize temperature array for non-file-based profiles
@@ -163,6 +164,7 @@ subroutine read_star_profile(iprofile,ieos,input_profile,gamma,polyk,ui_coef,&
           ! now read the softened profile instead
           call read_mesa(outputfilename,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mstar,ierr)
        endif
+       profile_filename = outputfilename
     else
        if (iprofile == imesa) then
           call read_mesa(input_profile,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mstar,ierr)
@@ -172,11 +174,12 @@ subroutine read_star_profile(iprofile,ieos,input_profile,gamma,polyk,ui_coef,&
           call read_kepler_file(trim(input_profile),ng_max,npts,r,den,pres,mtab,temp,en,&
                 Mstar,composition,comp_label,Xfrac,Yfrac,columns_compo,ierr)
        endif
+       profile_filename = input_profile
     endif
-    if (ierr==1) call fatal('set_star',trim(input_profile)//' does not exist')
+    if (ierr==1) call fatal('set_star',trim(profile_filename)//' does not exist')
     if (ierr==2) call fatal('set_star','insufficient data points read from file')
     if (ierr==3) call fatal('set_star','too many data points; increase ng')
-    if (ierr /= 0) call fatal('set_star','error in reading stellar profile from'//trim(input_profile))
+    if (ierr /= 0) call fatal('set_star','error in reading stellar profile from '//trim(profile_filename))
     npts = size(den)
     rmin  = r(1)
     Rstar = r(npts)


### PR DESCRIPTION
Description:
Added a readwrite_aton module similar to MESA and KEPLER. Updated all the lines in setup that needed to include the new option.

Components modified:
- [ X] Setup (src/setup)
- [ ] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [ ] Test suite (src/tests)
- [ ] Documentation (docs/)
- [ ] Build/CI (build/ or github actions)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [ ] Better testing
- [ ] Code cleanup / refactor
- [X ] Other Added a new module like readwirte_mesa.f90 called readwrite_aton.f90 to read star files from another code.

Testing:
I can read the file which is now option 8, and the behaviour is identical to mesa.

Did you run the bots? no

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? yes

Is there a unit test that could be added for this feature/bug? yes I think anything that is done for MESA would work.

If so, please describe what a unit test might check:
a test should check that running phantomsetup on SETUP=star with ieos=10 and option=8 successfully creates a dump



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing/exporting ATON-format stellar profiles.
  * Introduced ATON as a selectable density-profile/EOS option, including input-profile handling and updated setup/option I/O.

* **Bug Fixes**
  * Improved ATON profile detection and validation by inferring ATON from column labels and expanding nonnegativity checks to cover additional required fields.
  * Refined softened-core workflows to reuse ATON read/write steps consistently.
  * Enhanced multi-star EOS setup so variable-component options are requested only when relevant.

* **Chores**
  * Updated build configuration to include an additional ATON-related compilation unit.
  * Updated editor settings to disable the Fortran language server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->