### PR TITLE
fix compiler warning about split intrinsic with gfortran v16

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,17 +27,17 @@ Christophe Pinte <christophe.pinte@univ-grenoble-alpes.fr>
 Enrico Ragusa <enr.ragusa@gmail.com>
 Terrence Tricco <tstricco@mun.ca>
 Stephane Michoulier <stephane.michoulier@gmail.com>
+Ali Pourmand <alpourmand@gmail.com>
 Simone Ceppi <simo.ceppi@gmail.com>
 Antoine Alaguero <antoine.alaguero@univ-grenoble-alpes.fr>
 Cristiano Longarini <cl2000@cam.ac.uk>
+Camille Landri <camille.landri@gmail.com>
 Ana Lourdes Juarez <analourdesjg17@gmail.com>
 Spencer Magnall <spencermagnall@gmail.com>
 Caitlyn Hardiman <caitlyn.hardiman1@monash.edu>
 Amber Tilly <amber.abs@gmail.com>
 Steven Rieder <s.rieder@uva.nl>
-Ali Pourmand <alpourmand@gmail.com>
 Sergei Biriukov <svbiriukov@gmail.com>
-Camille Landri <camille.landri@gmail.com>
 Giovanni Dipierro <giovanni.dipierro@leicester.ac.uk>
 Roberto Iaconi <robertoiaconi1@gmail.com>
 Siméon <simeon.deschaux@gmail.com>
@@ -46,6 +46,7 @@ Hauke Worpel <hworpel@aip.de>
 Stephen Nielson <stephen.neilson@students.mq.edu.au>
 Sahl Rowther <sahl.rowther@leicester.ac.uk>
 Martina Toscani <mtoscani94@gmail.com>
+Orsola De Marco <orsola.demarco@mq.edu.au>
 Benedetta Veronesi <benedetta.veronesi@unimi.it>
 Simon Glover <glover@uni-heidelberg.de>
 Thomas Reichardt <thomas.reichardt@students.mq.edu.au>
@@ -55,21 +56,22 @@ Christopher Russell <cmprussell@gmail.com>
 Davide Dionese <davide.dionese@hotmail.it>
 Taj Jankovič <taj.jankovic@gmail.com>
 Timothée David--Cléris <timothee.davidcleris@proton.me>
+camillelandri <mangakam03@gmail.com>
 Madeline Overton <overtm2@unlv.nevada.edu>
 Alessia Franchini <alessia.franchini@unlv.edu>
 Alex Pettitt <alex@astro1.sci.hokudai.ac.jp>
+Arcelia Hermosillo Ruiz <a.hermosillo-ruiz@exeter.ac.uk>
 Jolien Malfait <jolien.malfait@kuleuven.be>
 Phantom benchmark bot <ubuntu@phantom-benchmarks.novalocal>
 Ryosuke Hirai <ryosuke.lufc@gmail.com>
 Bridget McFarlane <bmcf0001@student.monash.edu>
+Camille Landri <camille.landri@kuleuven.be>
 José Barría <jose.barriac@postgrado.uv.cl>
 Kieran Hirsh <kieran.hirsh1@monash.edu>
 Nicole Rodrigues <nicole.rodrigues@monash.edu>
-Arcelia Hermosillo Ruiz <a.hermosillo-ruiz@exeter.ac.uk>
 David Trevascus <dtre10@student.monash.edu>
 Farzana Meru <f.meru@warwick.ac.uk>
 Nicolás Cuello <cuello.nicolas@gmail.com>
-camillelandri <mangakam03@gmail.com>
 Adam Koval <adam_koval@hotmail.com>
 Ariel Chitan <arielchitan@gmail.com>
 Cheryl Lau <lausiching@gmail.com>
@@ -83,7 +85,6 @@ Jianni Grossi <jgro0009@student.monash.edu>
 Joe Fisher <jwfis1@student.monash.edu>
 Kateryna Andrych <kateryna.andrych@mq.edu.au>
 Maxime Lombart <maxime.lombart@ens-lyon.fr>
-Orsola De Marco <orsola.demarco@mq.edu.au>
 Siméon Deschaux <simeon.deschaux@gmail.com>
 Zachary Pellow <zpel1@student.monash.edu>
 Ali Pourmand <61276279+AliPourmand@users.noreply.github.com>

--- a/src/main/cons2primsolver.f90
+++ b/src/main/cons2primsolver.f90
@@ -199,8 +199,8 @@ subroutine conservative2primitive(x,metrici,v,dens,u,P,temp,gamma,rho,pmom,en,ie
        have_eos_cache = .true.
        select case(ieos)
        case (10)
-         ! inputs and outputs are all in code units
-         call get_u_from_rho_s(ieos,en,dens,u)
+          ! inputs and outputs are all in code units
+          call get_u_from_rho_s(ieos,en,dens,u)
 
        case (12)
           cgsdens = dens * unit_density
@@ -266,7 +266,7 @@ subroutine conservative2primitive(x,metrici,v,dens,u,P,temp,gamma,rho,pmom,en,ie
     endif
     select case(ieos)
     case (10)
-      ! inputs and outputs are all in code units
+       ! inputs and outputs are all in code units
        call get_u_from_rho_s(ieos,en,dens,u)
 
     case (12)

--- a/src/main/eos.f90
+++ b/src/main/eos.f90
@@ -530,7 +530,7 @@ subroutine equationofstate(eos_type,ponrhoi,spsoundi,rhoi,xi,yi,zi,tempi,eni,gam
     ponrhoi = presi/rhoi
     gammai = 1.d0 + presi/(eni*rhoi)
     spsoundi = sqrt(gammai*ponrhoi)
-   case (25) ! zero temperature EOS
+ case (25) ! zero temperature EOS
     cgsrhoi = rhoi * unit_density
 
     call get_zerotemp_pressure(cgsrhoi,cgspresi)
@@ -1816,7 +1816,7 @@ subroutine write_options_eos(iunit)
  case(23)
     call write_options_eos_tillotson(iunit)
  case(25)
-   call write_options_eos_zerotemp(iunit)
+    call write_options_eos_zerotemp(iunit)
  end select
 
  if (.not.isothermal .and. eos_allows_shock_and_work(ieos)) then

--- a/src/main/eos_mesa.f90
+++ b/src/main/eos_mesa.f90
@@ -14,7 +14,7 @@ module eos_mesa
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: mesa_microphysics, physcon, dim
+! :Dependencies: dim, mesa_microphysics, physcon
 !
 
  use mesa_microphysics

--- a/src/main/eos_mesa.f90
+++ b/src/main/eos_mesa.f90
@@ -174,8 +174,6 @@ subroutine get_eos_u_from_rhos_mesa_gr(den,s,u)
 
 end subroutine get_eos_u_from_rhos_mesa_gr
 
-
-
 !----------------------------------------------------------------
 !+
 !  subroutine returns internal energy and temperature from

--- a/src/main/eos_mesa.f90
+++ b/src/main/eos_mesa.f90
@@ -66,7 +66,7 @@ subroutine init_eos_mesa(x,z,ierr)
 
     call read_eos_mesa_gr(x,z,ierr)
     if (ierr /= 0) return
- end if
+ endif
 
  call read_eos_mesa(x,z,ierr)
  if (ierr /= 0) return

--- a/src/main/eos_mesa_microphysics.f90
+++ b/src/main/eos_mesa_microphysics.f90
@@ -330,7 +330,6 @@ subroutine get_eos_constants_mesa(ierr)
 
 end subroutine get_eos_constants_mesa
 
-
 ! Get the constants to be used in the MESA EoS for GR
 subroutine get_eos_constants_mesa_gr(ierr)
  integer, intent(out) :: ierr
@@ -382,7 +381,6 @@ subroutine get_eos_constants_mesa_gr(ierr)
  return
 
 end subroutine get_eos_constants_mesa_gr
-
 
 ! Read MESA EoS tables, and then construct a new array for the specific values of X and Z
 subroutine read_eos_mesa(x,z,ierr)
@@ -699,7 +697,6 @@ pure subroutine getvalue_mesa_gr(rho,s,ivout,vout,ierr)
 
 end subroutine getvalue_mesa_gr
 
-
 !only use if between e(2) < e < e(n_e-1) and v(2) < v < v(n_v-1)
 
 pure subroutine  eos_cubic_spline_mesa(e1,v1,e,v,n_var,z,h1,dh)
@@ -860,8 +857,6 @@ subroutine deallocate_arrays_mesa
  if (allocated(mesa_gr_ds_data)) deallocate(mesa_gr_ds_data)
  if (allocated(mesa_gr_ds_data0)) deallocate(mesa_gr_ds_data0)
 
-
 end subroutine deallocate_arrays_mesa
-
 
 end module mesa_microphysics

--- a/src/main/eos_mesa_microphysics.f90
+++ b/src/main/eos_mesa_microphysics.f90
@@ -14,7 +14,7 @@ module mesa_microphysics
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: datafiles
+! :Dependencies: datafiles, physcon
 !
  use datafiles, only:find_phantom_datafile
 

--- a/src/main/eos_mesa_microphysics.f90
+++ b/src/main/eos_mesa_microphysics.f90
@@ -652,7 +652,7 @@ end subroutine getvalue_mesa
 ! Note: ivout=1,2,3,4 returns the unlogged quantity
 ! inputted s should be in cgs units, then it has to be converted to log10(S/(k_B*N_A)) in cgs units (because the MESA tables are in these units)
 pure subroutine getvalue_mesa_gr(rho,s,ivout,vout,ierr)
- use physcon, only: kboltz,avogadro
+ use physcon, only:kboltz,avogadro
  real,    intent(in)  :: rho, s
  real,    intent(out) :: vout
  integer, intent(in)  :: ivout

--- a/src/main/eos_zerotemp.f90
+++ b/src/main/eos_zerotemp.f90
@@ -33,7 +33,7 @@ module eos_zerotemp
 
  private
 
-  ! these set the mixture of species
+ ! these set the mixture of species
  ! following elements can be set by user at runtime
  real :: xh  = 0.0
  real :: xhe = 0.0
@@ -197,12 +197,12 @@ subroutine get_zerotemp_pressure(rhoi,presi)
  ! This is a good approximation for white dwarfs where the electrons are highly degenerate but the ions are not.
  ! Note also that this assumes a fully ionised gas, so mu is the mean molecular weight per free electron
 
-    ne = rhoi / (mu_e * atomic_mass_unit)
+ ne = rhoi / (mu_e * atomic_mass_unit)
 
-    x = ( (3.0 * ne * planckh**3) / &
+ x = ( (3.0 * ne * planckh**3) / &
         (8.0 * pi * mass_electron_cgs**3 * c**3) )**(1.0/3.0)
 
-    presi = (pi * mass_electron_cgs**4 * c**5 / (3.0 * planckh**3)) * f_chandra(x)
+ presi = (pi * mass_electron_cgs**4 * c**5 / (3.0 * planckh**3)) * f_chandra(x)
 
 end subroutine get_zerotemp_pressure
 
@@ -215,14 +215,14 @@ subroutine get_zerotemp_u(rhoi,u)
  real,    intent(out)   :: u
  real :: ne, x, gx
 
-    ne = rhoi / (mu_e * atomic_mass_unit)
+ ne = rhoi / (mu_e * atomic_mass_unit)
 
-    x = ( (3.0 * ne * planckh**3) / &
+ x = ( (3.0 * ne * planckh**3) / &
         (8.0 * pi * mass_electron_cgs**3 * c**3) )**(1.0/3.0)
 
-    gx = (8*x**3)*(sqrt(x**2 + 1)-1)-f_chandra(x)
-    u = (pi * mass_electron_cgs**4 * c**5 / (3.0 * planckh**3)) * gx
-    u = u/rhoi !previous equation is erg/cm^3 so here I convert it
+ gx = (8*x**3)*(sqrt(x**2 + 1)-1)-f_chandra(x)
+ u = (pi * mass_electron_cgs**4 * c**5 / (3.0 * planckh**3)) * gx
+ u = u/rhoi !previous equation is erg/cm^3 so here I convert it
 end subroutine get_zerotemp_u
 
 !----------------------------------------------------------------
@@ -256,52 +256,52 @@ end subroutine get_zerotemp_spsoundi
 !----------------------------------------------------------------
 subroutine get_zerotemp_rhofrompres(presi,densi,ierr)
 
-   real, intent(in)  :: presi
-   real, intent(out) :: densi
-   integer, intent(out) :: ierr
+ real, intent(in)  :: presi
+ real, intent(out) :: densi
+ integer, intent(out) :: ierr
 
-   real :: ne, x, fx
-   real :: xlo, xhi, xmid
-   integer :: iter
+ real :: ne, x, fx
+ real :: xlo, xhi, xmid
+ integer :: iter
 
-   integer, parameter :: iter_max = 1000
-   real,    parameter :: tolerance = 1.e-12
+ integer, parameter :: iter_max = 1000
+ real,    parameter :: tolerance = 1.e-12
 
-   fx = presi * (3.0*planckh**3) / &
+ fx = presi * (3.0*planckh**3) / &
         (pi*mass_electron_cgs**4*c**5)
 
-   ! Initial bracket
-   xlo = 0.0
-   xhi = 1.0
+ ! Initial bracket
+ xlo = 0.0
+ xhi = 1.0
 
-   do while (f_chandra(xhi) < fx)
-      xhi = 2.0*xhi
-   enddo
+ do while (f_chandra(xhi) < fx)
+    xhi = 2.0*xhi
+ enddo
 
-   ierr = 0
+ ierr = 0
 
-   do iter = 1, iter_max
+ do iter = 1, iter_max
 
-      xmid = 0.5*(xlo + xhi)
+    xmid = 0.5*(xlo + xhi)
 
-      if (f_chandra(xmid) > fx) then
-         xhi = xmid
-      else
-         xlo = xmid
-      endif
+    if (f_chandra(xmid) > fx) then
+       xhi = xmid
+    else
+       xlo = xmid
+    endif
 
-      if (abs(xhi-xlo)/(xmid+1.e-300) < tolerance) exit
+    if (abs(xhi-xlo)/(xmid+1.e-300) < tolerance) exit
 
-   enddo
+ enddo
 
-   if (iter == iter_max) ierr = 1
+ if (iter == iter_max) ierr = 1
 
-   x = 0.5*(xlo + xhi)
+ x = 0.5*(xlo + xhi)
 
-   ne = (8.0*pi*mass_electron_cgs**3*c**3 / &
+ ne = (8.0*pi*mass_electron_cgs**3*c**3 / &
         (3.0*planckh**3)) * x**3
 
-   densi = ne * mu_e * atomic_mass_unit
+ densi = ne * mu_e * atomic_mass_unit
 
 end subroutine get_zerotemp_rhofrompres
 

--- a/src/main/extern_gwinspiral.f90
+++ b/src/main/extern_gwinspiral.f90
@@ -15,7 +15,8 @@ module extern_gwinspiral
 ! :Owner: Daniel Price
 !
 ! :Runtime parameters:
-!   - stop_ratio : *ratio of particles crossing CoM to indicate a merger*
+!   - gw_boostfac : *multiplicative factor to boost GW force*
+!   - stop_ratio  : *ratio of particles crossing CoM to indicate a merger*
 !
 ! :Dependencies: centreofmass, dump_utils, infile_utils, units
 !

--- a/src/main/utils_filenames.f90
+++ b/src/main/utils_filenames.f90
@@ -20,7 +20,7 @@ module fileutils
 
  implicit none
  public :: getnextfilename,numfromfile,basename,get_ncolumns,skip_header,number_of_rows
- public :: read_column_labels,get_column_labels,split,find_column
+ public :: read_column_labels,get_column_labels,split_string,find_column
  public :: strip_extension,is_digit,files_are_sequential,load_data_file
  public :: ucase,lcase,make_tags_unique,get_nlines,string_delete,string_replace,nospaces
  integer, parameter :: max_line_length = 10000 ! for finding number of columns
@@ -511,17 +511,20 @@ end subroutine string_replace
 ! Split a string into substrings based on a delimiter
 !
 !---------------------------------------------------------------------------
-pure subroutine split(string,delim,stringarr,nsplit)
+pure subroutine split_string(string,delim,stringarr,nsplit)
  character(len=*), intent(in)  :: string
  character(len=*), intent(in)  :: delim
- character(len=*), intent(out) :: stringarr(:)
+ character(len=*), intent(out), dimension(:), optional :: stringarr
  integer,          intent(out) :: nsplit
- integer :: i,j,imax,iend
+ integer :: i,j,imax,iend,nmax
 
  i = 1
  nsplit = 0
  imax = len(string)
- do while(nsplit < size(stringarr) .and. i <= imax)
+ nmax = imax
+ if (present(stringarr)) nmax = size(stringarr)
+
+ do while(nsplit < nmax .and. i <= imax)
     ! find next non-blank character
     if (string(i:i)==' ') then
        do while (string(i:i)==' ')
@@ -539,13 +542,13 @@ pure subroutine split(string,delim,stringarr,nsplit)
     iend = min(i+j-1,imax)
     ! extract the substring
     nsplit = nsplit + 1
-    if (nsplit <= size(stringarr)) then
+    if (nsplit <= nmax .and. present(stringarr)) then
        stringarr(nsplit) = string(i:iend)
     endif
     i = iend + len(delim) + 1
  enddo
 
-end subroutine split
+end subroutine split_string
 
 !-----------------------------------------------------------------
 !
@@ -642,13 +645,13 @@ subroutine get_column_labels(line,nlabels,labels,method,ndesired,csv)
     linestr = line(i1:)
     call normalize_bracket_delimiters(linestr)
     ! now split on '][' which should work regardless of original spacing
-    call split(linestr,'][',labels,nlabels)
+    call split_string(linestr,'][',labels,nlabels)
  elseif (index(line,',') > 1 .or. is_csv) then
     !
     ! format style 2: mylabel1,mylabel2,mylabel3
     !
     istyle = 2
-    call split(line(i1:),',',labels,nlabelstmp)
+    call split_string(line(i1:),',',labels,nlabelstmp)
     if (is_csv) then
        nlabels = nlabelstmp  ! allow blank/arbitrary labels in csv format
     else
@@ -662,7 +665,7 @@ subroutine get_column_labels(line,nlabels,labels,method,ndesired,csv)
     ! try splitting with 4, then 3, then 2 spaces until the number of labels decreases
     nlabels_prev = 0
     over_spaces: do i=4,2,-1
-       call split(line(i1:),spaces(1:i),labels,nlabelstmp)
+       call split_string(line(i1:),spaces(1:i),labels,nlabelstmp)
 
        ! quit if we already have the target number of labels
        if (nlabelstmp == ntarget) exit over_spaces
@@ -672,7 +675,7 @@ subroutine get_column_labels(line,nlabels,labels,method,ndesired,csv)
        if ((nlabelstmp < nlabels_prev .or. nlabelstmp >= max(nlabels_prev,2)  &
             .and. i < 4 .and. .not. (ntarget > 0 .and. nlabelstmp > ntarget))) then
           ! take the answer with the previous number of spaces
-          call split(line(i1:),spaces(1:i+1),labels,nlabelstmp)
+          call split_string(line(i1:),spaces(1:i+1),labels,nlabelstmp)
           exit over_spaces
        endif
        nlabels_prev = nlabelstmp
@@ -694,7 +697,7 @@ subroutine get_column_labels(line,nlabels,labels,method,ndesired,csv)
        ! (this style is also dangerous)
        !
        istyle = 4
-       call split(line(i1:),' ',labels,nlabelstmp)
+       call split_string(line(i1:),' ',labels,nlabelstmp)
        nlabels = count_sensible_labels(nlabelstmp,labels)
     endif
  endif

--- a/src/setup/readwrite_aton.f90
+++ b/src/setup/readwrite_aton.f90
@@ -89,7 +89,6 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
  m = -1.
  allocate(r,pres,rho,ene,temp,Xfrac,Yfrac,mu,source=m)
 
- 
     ! read file forwards, from centre to surface
     do i = 1,lines
        read(iu,*,iostat=ierr) dat(i,1:ncols)

--- a/src/setup/readwrite_aton.f90
+++ b/src/setup/readwrite_aton.f90
@@ -10,7 +10,7 @@ module readwrite_aton
 !
 ! :References: Ventura et al. (1998)
 !
-! :Owner: Daniel Price
+! :Owner: Orsola De Marco
 !
 ! :Runtime parameters: None
 !

--- a/src/setup/readwrite_aton.f90
+++ b/src/setup/readwrite_aton.f90
@@ -89,79 +89,79 @@ subroutine read_aton(filepath,rho,r,pres,m,ene,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mst
  m = -1.
  allocate(r,pres,rho,ene,temp,Xfrac,Yfrac,mu,source=m)
 
-    ! read file forwards, from centre to surface
-    do i = 1,lines
-       read(iu,*,iostat=ierr) dat(i,1:ncols)
-    enddo
-    if (ierr /= 0) then
-       print "(a,/)",' ERROR reading data from ATON file (new statement)'
+ ! read file forwards, from centre to surface
+ do i = 1,lines
+    read(iu,*,iostat=ierr) dat(i,1:ncols)
+ enddo
+ if (ierr /= 0) then
+    print "(a,/)",' ERROR reading data from ATON file (new statement)'
+    return
+ endif
+
+ ! Set mass fractions to fixed inputs if not in file
+ Xfrac = X_in
+ Yfrac = 1. - X_in - Z_in
+ mu = 0.
+ do i = 1,ncols
+    if (header(i)(1:1) == '#' .and. .not. trim(lcase(header(i)))=='#mass' &
+           .and. .not. trim(lcase(header(i)))=='#m/msun') then
+       print '("Detected wrong header entry : ",a," in file ",a)',trim(lcase(header(i))),trim(fullfilepath)
+       ierr = 2
        return
     endif
-
-    ! Set mass fractions to fixed inputs if not in file
-    Xfrac = X_in
-    Yfrac = 1. - X_in - Z_in
-    mu = 0.
-    do i = 1,ncols
-       if (header(i)(1:1) == '#' .and. .not. trim(lcase(header(i)))=='#mass' &
-           .and. .not. trim(lcase(header(i)))=='#m/msun') then
-          print '("Detected wrong header entry : ",a," in file ",a)',trim(lcase(header(i))),trim(fullfilepath)
-          ierr = 2
-          return
-       endif
-       got_column = .true.
-       select case(trim(lcase(header(i))))
-       case('mass_grams')
-          m = dat(1:lines,i)
-       case('mass','#mass','m','m/msun','#m/msun')
-          m = dat(1:lines,i)
-          if (isatonfile .or. maxval(m) < 1.e-10*solarm) m = m * solarm  ! If reading ATON profile, 'mass' or 'M/Msun' is in units of Msun
-       case('logm','log_mass')
-          m = 10**dat(1:lines,i)
-          if (isatonfile .or. maxval(m) < 1.e-10*solarm) m = m * solarm
-       case('rho','density')
-          rho = dat(1:lines,i)
-       case('logrho')
-          rho = 10**(dat(1:lines,i))
-       case('energy','e_int','e_internal','cell_specific_ie','internal energy','internal_energy')
-          ene = dat(1:lines,i)
-       case('loge')
-          ene = 10**dat(1:lines,i)
-       case('radius_cm')
-          r = dat(1:lines,i)
-       case('radius_km')
-          r = dat(1:lines,i) * 1e5
-       case('radius','r')
-          r = dat(1:lines,i)
-          if (maxval(r) < 1e-5*solarr) r = r * solarr
-       case('logr')
-          r = (10**dat(1:lines,i)) * solarr
-       case('logr_cm')
-          r = 10**dat(1:lines,i)
-       case('pressure','p')
-          pres = dat(1:lines,i)
-       case('logp')
-          pres = 10**dat(1:lines,i)
-       case('temperature','t')
-          temp = dat(1:lines,i)
-       case('logt')
-          temp = 10**dat(1:lines,i)
-       case('x_mass_fraction_h','x','xfrac','h1','hydrogen')
-          Xfrac = dat(1:lines,i)
-       case('log_x')
-          Xfrac = 10**dat(1:lines,i)
-       case('y_mass_fraction_he','y','yfrac','he4','helium')
-          Yfrac = dat(1:lines,i)
-       case('log_y')
-          Yfrac = 10**dat(1:lines,i)
-       case('mu','molecular weight','molecular_weight')
-          mu = dat(1:lines,i)
-       case default
-          got_column = .false.
-       end select
-       if (got_column) print "(1x,i0,': ',a)",i,trim(header(i))
-    enddo
-    print "(a)"
+    got_column = .true.
+    select case(trim(lcase(header(i))))
+    case('mass_grams')
+       m = dat(1:lines,i)
+    case('mass','#mass','m','m/msun','#m/msun')
+       m = dat(1:lines,i)
+       if (isatonfile .or. maxval(m) < 1.e-10*solarm) m = m * solarm  ! If reading ATON profile, 'mass' or 'M/Msun' is in units of Msun
+    case('logm','log_mass')
+       m = 10**dat(1:lines,i)
+       if (isatonfile .or. maxval(m) < 1.e-10*solarm) m = m * solarm
+    case('rho','density')
+       rho = dat(1:lines,i)
+    case('logrho')
+       rho = 10**(dat(1:lines,i))
+    case('energy','e_int','e_internal','cell_specific_ie','internal energy','internal_energy')
+       ene = dat(1:lines,i)
+    case('loge')
+       ene = 10**dat(1:lines,i)
+    case('radius_cm')
+       r = dat(1:lines,i)
+    case('radius_km')
+       r = dat(1:lines,i) * 1e5
+    case('radius','r')
+       r = dat(1:lines,i)
+       if (maxval(r) < 1e-5*solarr) r = r * solarr
+    case('logr')
+       r = (10**dat(1:lines,i)) * solarr
+    case('logr_cm')
+       r = 10**dat(1:lines,i)
+    case('pressure','p')
+       pres = dat(1:lines,i)
+    case('logp')
+       pres = 10**dat(1:lines,i)
+    case('temperature','t')
+       temp = dat(1:lines,i)
+    case('logt')
+       temp = 10**dat(1:lines,i)
+    case('x_mass_fraction_h','x','xfrac','h1','hydrogen')
+       Xfrac = dat(1:lines,i)
+    case('log_x')
+       Xfrac = 10**dat(1:lines,i)
+    case('y_mass_fraction_he','y','yfrac','he4','helium')
+       Yfrac = dat(1:lines,i)
+    case('log_y')
+       Yfrac = 10**dat(1:lines,i)
+    case('mu','molecular weight','molecular_weight')
+       mu = dat(1:lines,i)
+    case default
+       got_column = .false.
+    end select
+    if (got_column) print "(1x,i0,': ',a)",i,trim(header(i))
+ enddo
+ print "(a)"
 
  close(iu)
 
@@ -202,7 +202,7 @@ end subroutine read_aton
 !  used in star setup to write softened stellar profile.
 !+
 !----------------------------------------------------------------
- subroutine write_aton(outputpath,m,pres,temp,r,rho,ene,Xfrac,Yfrac,csound,mu)
+subroutine write_aton(outputpath,m,pres,temp,r,rho,ene,Xfrac,Yfrac,csound,mu)
  use physcon, only:solarm
  real,               intent(in) :: m(:),rho(:),pres(:),r(:),ene(:),temp(:)
  character(len=120), intent(in) :: outputpath

--- a/src/setup/readwrite_mesa.f90
+++ b/src/setup/readwrite_mesa.f90
@@ -10,7 +10,7 @@ module readwrite_mesa
 !
 ! :References: Paxton et al. (2011), ApJS 192, 3
 !
-! :OWner: Daniel Price
+! :Owner: Daniel Price
 !
 ! :Runtime parameters: None
 !

--- a/src/setup/set_dust_options.f90
+++ b/src/setup/set_dust_options.f90
@@ -13,7 +13,6 @@ module set_dust_options
 ! :Owner: Mark Hutchison
 !
 ! :Runtime parameters:
-!   - dust_method       : *dust method (1=one fluid,2=two fluid,3=Hybrid)*
 !   - dust_to_gas       : *dust to gas ratio*
 !   - graindensinp      : *intrinsic grain density (in g/cm^3)*
 !   - graindenslargeinp : *intrinsic grain density (in g/cm^3)*

--- a/src/setup/set_star.f90
+++ b/src/setup/set_star.f90
@@ -1180,7 +1180,7 @@ subroutine read_options_stars_eos(nstars,star,label,ieos,db,nerr)
  if (any(star(:)%iprofile==imesa .or. &
          star(:)%iprofile==iaton)) then
   call read_inopt(use_var_comp,'use_var_comp',db,errcount=nerr)
- endif 
+ endif
 
  select case(ieos)
  case(9)
@@ -1224,7 +1224,7 @@ subroutine set_star_eos_interactive(ieos,star)
  if (any(star(:)%iprofile==imesa .or. &
          star(:)%iprofile==iaton)) then
   call prompt('Use variable composition?',use_var_comp)
- endif 
+ endif
 
  select case(ieos)
  case(9)

--- a/src/setup/set_star.f90
+++ b/src/setup/set_star.f90
@@ -1179,7 +1179,7 @@ subroutine read_options_stars_eos(nstars,star,label,ieos,db,nerr)
  call read_inopt(ieos,'ieos',db,errcount=nerr)
  if (any(star(:)%iprofile==imesa .or. &
          star(:)%iprofile==iaton)) then
-  call read_inopt(use_var_comp,'use_var_comp',db,errcount=nerr)
+    call read_inopt(use_var_comp,'use_var_comp',db,errcount=nerr)
  endif
 
  select case(ieos)
@@ -1223,7 +1223,7 @@ subroutine set_star_eos_interactive(ieos,star)
  call prompt('Enter the desired EoS (1=isothermal,2=idealgas,10=MESA,12=idealplusrad)',ieos)
  if (any(star(:)%iprofile==imesa .or. &
          star(:)%iprofile==iaton)) then
-  call prompt('Use variable composition?',use_var_comp)
+    call prompt('Use variable composition?',use_var_comp)
  endif
 
  select case(ieos)

--- a/src/setup/set_star_utils.f90
+++ b/src/setup/set_star_utils.f90
@@ -134,7 +134,7 @@ subroutine read_star_profile(iprofile,ieos,input_profile,gamma,polyk,ui_coef,&
     if (isoftcore > 0) then
        if (iprofile == imesa) then
           call read_mesa(input_profile,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mstar,ierr,cgsunits=.true.)
-       else if (iprofile == iaton) then
+       elseif (iprofile == iaton) then
           call read_aton(input_profile,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mstar,ierr,cgsunits=.true.)
        else
           call read_kepler_file(trim(input_profile),ng_max,npts,r,den,pres,mtab,temp,en,&
@@ -168,7 +168,7 @@ subroutine read_star_profile(iprofile,ieos,input_profile,gamma,polyk,ui_coef,&
     else
        if (iprofile == imesa) then
           call read_mesa(input_profile,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mstar,ierr)
-       else if (iprofile == iaton) then
+       elseif (iprofile == iaton) then
           call read_aton(input_profile,den,r,pres,mtab,en,temp,X_in,Z_in,Xfrac,Yfrac,mu,Mstar,ierr)
        else
           call read_kepler_file(trim(input_profile),ng_max,npts,r,den,pres,mtab,temp,en,&

--- a/src/setup/setup_binary.f90
+++ b/src/setup/setup_binary.f90
@@ -13,14 +13,15 @@ module setup
 ! :Owner: Daniel Price
 !
 ! :Runtime parameters:
-!   - corotate : *set stars in corotation*
-!   - deltat   : *output interval as fraction of binary period*
-!   - norbits  : *maximum number of binary orbits*
+!   - corotate   : *set stars in corotation*
+!   - deltat     : *output interval as fraction of binary period*
+!   - gwinspiral : *set gravitational wave inspiral*
+!   - norbits    : *maximum number of binary orbits*
 !
-! :Dependencies: centreofmass, dim, eos, externalforces, infile_utils, io,
-!   kernel, mpidomain, options, part, physcon, sethier_utils,
-!   sethierarchical, setorbit, setstar, setunits, setup_params, timestep,
-!   units
+! :Dependencies: centreofmass, dim, eos, extern_gwinspiral, externalforces,
+!   infile_utils, io, kernel, mpidomain, options, part, physcon,
+!   sethier_utils, sethierarchical, setorbit, setstar, setunits,
+!   setup_params, timestep, units
 !
  use setstar,       only:star_t
  use setorbit,      only:orbit_t

--- a/src/utils/analysis_krome.F90
+++ b/src/utils/analysis_krome.F90
@@ -21,9 +21,9 @@ module analysis
  use part,       only: maxp
  use raytracer,  only: get_all_tau
  use hdf5
- #ifdef _OPENMP
-   use omp_lib, only:omp_set_num_threads, omp_get_max_threads, omp_get_wtime
- #endif
+#ifdef _OPENMP
+ use omp_lib, only:omp_set_num_threads, omp_get_max_threads, omp_get_wtime
+#endif
  implicit none
  character(len=20), parameter, public :: analysistype = 'krome'
  public :: do_analysis
@@ -62,23 +62,23 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
 
 #ifdef _OPENMP
 #ifdef __GFORTRAN__
-   print*, "Setting number of threads to 1 (KROME is not thread-safe when compiled with gfortran)"
-   call omp_set_num_threads(1)
+ print*, "Setting number of threads to 1 (KROME is not thread-safe when compiled with gfortran)"
+ call omp_set_num_threads(1)
 #else
-   print*, "running with ", omp_get_max_threads(), " threads"
+ print*, "running with ", omp_get_max_threads(), " threads"
 #endif
 #else
-   print*, "running without OpenMP"
+ print*, "running without OpenMP"
 #endif
 
  if (.not.done_init) then
     done_init = .true.
 
-   ! initialize HDF5
-   call h5open_f(hdferr)
-   if (hdferr /= 0) then
-      call fatal(analysistype, 'Failed to initialize HDF5')
-   endif
+    ! initialize HDF5
+    call h5open_f(hdferr)
+    if (hdferr /= 0) then
+       call fatal(analysistype, 'Failed to initialize HDF5')
+    endif
 
     print*, "initialising KROME"
     call krome_init()
@@ -99,8 +99,8 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
     !check if a file with abundances already exists, if so read it in and use it as initial abundances
     inquire(file=trim(dumpfile)//'.h5', size=isize)
     if (isize > 0) then
-         print*, "Found existing abundance file, reading in abundances"
-         call read_chem(npart, dumpfile)
+       print*, "Found existing abundance file, reading in abundances"
+       call read_chem(npart, dumpfile)
     else
        print*, "setting abundances"
        !$omp parallel do default(none) &
@@ -119,7 +119,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
     call init_eos(ieos, ierr)
     if (ierr /= 0) call fatal(analysistype, "Failed to initialise EOS")
 
-   else
+ else
     dt_cgs = (time - tprev)*utime
     completed_iterations = 0
     print*, "not first step data, timestep = ",dt_cgs, "npart = ",npart, "nprev = ",nprev
@@ -185,7 +185,7 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
              call chem_init(abundance_part)
           endif
           if (iamtype(iphase(i)) /= iboundary .and. i > 2460) then ! 2460 is the amount of boundary particles
-            !Thermodynamic quantities
+             !Thermodynamic quantities
              rho_cgs = rhoh(xyzh(4,i),particlemass)*unit_density
              gammai = gamma
              mui    = gmw
@@ -215,12 +215,12 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
        endif
     enddo outer
 #ifdef _OPENMP
-   print*, "        - Took ", omp_get_wtime() - tstart, " seconds"
-   tstart = omp_get_wtime()
+    print*, "        - Took ", omp_get_wtime() - tstart, " seconds"
+    tstart = omp_get_wtime()
 #endif
-   call write_chem(npart, dumpfile)
+    call write_chem(npart, dumpfile)
 #ifdef _OPENMP
-   print*, "        - Took ", omp_get_wtime() - tstart, " seconds"
+    print*, "        - Took ", omp_get_wtime() - tstart, " seconds"
 #endif
  endif
 
@@ -279,7 +279,7 @@ subroutine write_chem(npart, dumpfile)
     return
  endif
 
-  ! create group for particle data
+ ! create group for particle data
  call h5gcreate_f(file_id, 'chemistry', group_id, hdferr)
  ! create dataspace for particle datasets
  dims(1) = krome_nmols
@@ -329,7 +329,7 @@ subroutine read_chem(npart, dumpfile)
     return
  endif
 
-  ! open group for particle data
+ ! open group for particle data
  call h5gopen_f(file_id, 'chemistry', group_id, hdferr)
 
  call h5dget_space_f(dset_id, filespace_id, hdferr)

--- a/src/utils/analysis_krome.F90
+++ b/src/utils/analysis_krome.F90
@@ -60,7 +60,6 @@ subroutine do_analysis(dumpfile,num,xyzh,vxyzu,particlemass,npart,time,iunit)
  real          :: max_radius, radius, tstart
  integer       :: i, j, k, isize=0, ierr, completed_iterations, npart_copy = 0, hdferr, i_radius = 1
 
-
 #ifdef _OPENMP
 #ifdef __GFORTRAN__
    print*, "Setting number of threads to 1 (KROME is not thread-safe when compiled with gfortran)"

--- a/src/utils/analysis_krome.F90
+++ b/src/utils/analysis_krome.F90
@@ -22,7 +22,7 @@ module analysis
  use raytracer,  only: get_all_tau
  use hdf5
  #ifdef _OPENMP
-   use omp_lib, only: omp_set_num_threads, omp_get_max_threads, omp_get_wtime
+   use omp_lib, only:omp_set_num_threads, omp_get_max_threads, omp_get_wtime
  #endif
  implicit none
  character(len=20), parameter, public :: analysistype = 'krome'

--- a/src/utils/moddump_binary.f90
+++ b/src/utils/moddump_binary.f90
@@ -16,9 +16,10 @@ module moddump
 !
 ! :Runtime parameters: None
 !
-! :Dependencies: centreofmass, dim, eos, extern_corotate, externalforces,
-!   infile_utils, io, options, part, physcon, prompting, readwrite_dumps,
-!   readwrite_mesa, setbinary, table_utils, timestep, units, vectorutils
+! :Dependencies: centreofmass, dim, eos, extern_corotate,
+!   extern_gwinspiral, externalforces, infile_utils, io, options, part,
+!   physcon, prompting, readwrite_dumps, readwrite_mesa, setbinary,
+!   table_utils, timestep, units, vectorutils
 !
  implicit none
  character(len=*), parameter, public :: moddump_flags = ''


### PR DESCRIPTION
Description:
fix compiler warning, also ran bots

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Setup (src/setup)
- [x] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [ ] Test suite (src/tests)
- [ ] Documentation (docs/)
- [ ] Build/CI (build/ or github actions)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [x] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [ ] Better testing
- [ ] Code cleanup / refactor
- [x] Other (please describe)

Testing:
no compiler warnings with gfortran v16

Did you run the bots? yes

Did you update relevant documentation in the docs directory? no

Did you add comments such that the purpose of the code is understandable? n/a

Is there a unit test that could be added for this feature/bug? no, already test against latest gfortran

<!-- If this PR is related to an issue, please link it here -->
Related issues: #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Renamed the public string-splitting utility to `split_string`.
  * Made the utility’s output array optional, enabling callers to request only the number of parsed segments.

* **Documentation**
  * Clarified code-unit conventions and runtime-parameter documentation.
  * Updated module ownership and dependency metadata.

* **Style**
  * Standardized formatting, indentation, whitespace, and conditional syntax across EOS, stellar-profile, data I/O, and chemistry components.
  * No computational behavior or public interfaces changed beyond the string utility update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->