### PR TITLE
Fix mpi req null for MPICH MPIs

### DIFF
--- a/src/main/dens.F90
+++ b/src/main/dens.F90
@@ -129,7 +129,8 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
  use mpimemory,   only:stack_waiting => dens_stack_2
  use mpimemory,   only:stack_redo    => dens_stack_3
  use mpiderivs,   only:send_cell,recv_cells,check_send_finished,init_cell_exchange,&
-                       finish_cell_exchange,recv_while_wait,reset_cell_counters,cell_counters
+                       finish_cell_exchange,recv_while_wait,reset_cell_counters,cell_counters,&
+                       init_send_requests
  use timestep,    only:rhomaxnow
  use part,        only:ngradh
  use viscosity,   only:irealvisc
@@ -292,8 +293,8 @@ subroutine densityiterate(icall,npart,nactive,xyzh,vxyzu,divcurlv,divcurlB,Bevol
  call get_timings(t1,tcpu1)
  !$omp end single
 
- !--initialise send requests to 0
- irequestsend = 0
+ !--initialise send requests to null
+ call init_send_requests(irequestsend)
 
  !$omp do schedule(runtime)
  over_cells: do icell=1,int(ncells)

--- a/src/main/force.F90
+++ b/src/main/force.F90
@@ -230,7 +230,8 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
  use dust,         only:drag_implicit
  use nicil,        only:nimhd_get_jcbcb
  use mpiderivs,    only:send_cell,recv_cells,check_send_finished,init_cell_exchange,&
-                        finish_cell_exchange,recv_while_wait,reset_cell_counters,cell_counters
+                        finish_cell_exchange,recv_while_wait,reset_cell_counters,cell_counters,&
+                        init_send_requests
  use mpimemory,    only:reserve_stack,reset_stacks,get_cell,write_cell
  use mpimemory,    only:stack_remote  => force_stack_1
  use mpimemory,    only:stack_waiting => force_stack_2
@@ -499,8 +500,8 @@ subroutine force(icall,npart,xyzh,vxyzu,fxyzu,divcurlv,divcurlB,Bevol,dBevol,&
  call get_timings(t1,tcpu1)
  !$omp end single
 
- !--initialise send requests to 0
- irequestsend = 0
+ !--initialise send requests to null
+ call init_send_requests(irequestsend)
 
  !$omp do schedule(runtime)
  over_cells: do icell=1,int(ncells)

--- a/src/main/mpi_derivs.F90
+++ b/src/main/mpi_derivs.F90
@@ -198,6 +198,9 @@ end subroutine init_cellforce_exchange
 subroutine init_send_requests(irequestsend)
  integer, intent(out) :: irequestsend(nprocs)
 
+!--instead of simply assigning 0, assign MPI_REQUEST_NULL
+!  it is infact 0 in open mpi, but 0x2c000000 for MPICH-derived MPI. 
+
 #ifdef MPI
  irequestsend = MPI_REQUEST_NULL
 #else

--- a/src/main/mpi_derivs.F90
+++ b/src/main/mpi_derivs.F90
@@ -52,6 +52,7 @@ module mpiderivs
  public :: deallocate_cell_comms_arrays
 
  public :: init_cell_exchange
+ public :: init_send_requests
  public :: send_cell
  public :: recv_cells
  public :: check_send_finished
@@ -188,6 +189,22 @@ subroutine init_cellforce_exchange(xbufrecv,ireq,thread_complete,ncomplete_mpi,d
  dtype = 0
 #endif
 end subroutine init_cellforce_exchange
+
+!-----------------------------------------------------------------------
+!+
+!  Subroutine to initialize send request handles to null
+!+
+!-----------------------------------------------------------------------
+subroutine init_send_requests(irequestsend)
+ integer, intent(out) :: irequestsend(nprocs)
+
+#ifdef MPI
+ irequestsend = MPI_REQUEST_NULL
+#else
+ irequestsend = 0
+#endif
+
+end subroutine init_send_requests
 
 !-----------------------------------------------------------------------
 !+


### PR DESCRIPTION
Description:
`irequestsend` (array of MPI send-request handles) was initialised to the integer `0` in `densityiterate` (`src/main/dens.F90`) and `force` (`src/main/force.F90`). Apart from OMPI's fortran bindings, `0` is not guaranteed to be `MPI_REQUEST_NULL` for MPICH-derived implementations like MPICH or Intel MPI,

The fix adds `init_send_requests` to `mpiderivs`, which assigns `MPI_REQUEST_NULL` under `#ifdef MPI` and `0` in the serial build where the value is never used, and also calls it from `dens.F90` and `force.F90`.

Components modified:
<!-- Check all that apply, or delete lines that don't -->
- [ ] Setup (src/setup)
- [x] Main code (src/main)
- [ ] Moddump utilities (src/utils/moddump)
- [ ] Analysis utilities (src/utils/analysis)
- [ ] Test suite (src/tests)
- [ ] Documentation (docs/)
- [ ] Build/CI (build/ or github actions)

Type of change:
<!-- Check all that apply, or delete lines that don't -->
- [x] Bug fix
- [ ] Physics improvements
- [ ] Better initial conditions
- [ ] Performance improvements
- [ ] Documentation update
- [ ] Better testing
- [ ] Code cleanup / refactor
- [ ] Other (please describe)

Testing:
<!-- Describe how you have tested the change -->

Did you run the bots? no

Did you update relevant documentation in the docs directory? no (because not user-facing)

Did you add comments such that the purpose of the code is understandable? yes

Is there a unit test that could be added for this feature/bug? yes

If so, please describe what a unit test might check:
A small test would call `init_send_requests` with no sends posted, then call `check_send_finished` and check every element of `idone` comes back `.true.` with no MPI error. That is to be done under an MPICH-family MPI, since the old code passes under Open MPI.
Probably a better change would be in `.github/workflows/mpi.yml`, where installing mpich lib and running on more than one rank (which would have caught it).

<!-- If this PR is related to an issue, please link it here -->
Related issues: #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization of parallel communication requests during density and force calculations.
  * Enhanced compatibility and stability for MPI-enabled and non-MPI runs by using appropriate request states.
  * Reduced the risk of communication-related issues during iterative calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->